### PR TITLE
chore(deps): update crossbeam-epoch 0.9.18 -> 0.9.20 (RUSTSEC advisory)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary
Lockfile-only bump of the transitive `crossbeam-epoch` (via criterion) past the RUSTSEC advisory that has made the `cargo-deny` check fail on every open Dependabot PR.

## Testing
- [x] `cargo deny check`: passes locally (was: error[vulnerability] on crossbeam-epoch 0.9.18)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` on stable: clean locally — this PR's run will show whether the "cargo doc (docs.rs clone)" failures on the old Dependabot branches were branch-specific

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level transitive dependency upgrade for a known advisory; no code or API surface changes in this repo.
> 
> **Overview**
> **Lockfile-only** update that bumps transitive dependency **`crossbeam-epoch`** from **0.9.18** to **0.9.20** (checksum updated in `Cargo.lock`). No application or manifest source changes—this addresses a **RUSTSEC** advisory that was failing **`cargo-deny`** on CI and Dependabot PRs.
> 
> The dependency is pulled in transitively (e.g. via **criterion** for benchmarks), so the fix is entirely in the resolved lock graph.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b71d5ac75af36762616e71a0cb0dd55ca48445cd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->