### PR TITLE
feat(tables): R2007+ LTYPE / BLOCK_HEADER string-stream decoders, LWPOLYLINE DD vertices, R2013/R2018 boundary pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,30 +8,99 @@ once the public API stabilizes at 0.1.0.
 
 ## [Unreleased]
 
-### Fixed — R2013/R2018 common-entity preamble alignment (2026-04-20, #103)
+### Fixed — R2007+ LTYPE string-stream names (2026-04-29, #103)
 
-- **`src/common_entity.rs`** — Added the three missing preamble fields
-  between `non_fixed_ltype` and `plotstyle_flag` per ODA 5.4.1 §19.4.1
-  + libredwg reference: `CMC color` (BS color_index, minimal BYLAYER
-  path), `BD linetype_scale`, `BB ltype_flags`. Also changed
-  `shadow_flags` from RC (8 bits) to BB (2 bits) — the on-disk
-  encoding uses only 2 bits (cast_shadow + receive_shadow) even
-  though some spec revisions label the field "RC".
-  
-  Measured effect on `sample_AC1032.dwg` (R2018):
-  - `BS invisibility` now decodes as **0** (valid) instead of **-10207**
-  - LINE end-point `BD` deltas now decode to clean **1.0 / 0.0**
-    shortcut values instead of tiny subnormals
-  - 1 of 3 modelspace LINEs now passes the plausibility check (was 0/3)
+- **`src/tables/ltype.rs` / `src/entities/dispatch.rs`** — Added a modern
+  `LTYPE` path for R2007+ table records. It reads entry names/descriptions
+  from the split string stream, parses the non-string fields in ODA v5.4.1
+  §19.5.3 order, and falls back to the legacy inline decoder if the modern
+  parse is not plausible.
+- **`examples/dump_decoded_entities.rs`** — Print decoded `LTYPE` records so
+  recovered linetype names are visible during corpus inspection.
+- **`tests/r2013_entity_values.rs`** — Added a real-DWG regression asserting
+  that `sample_AC1032.dwg` recovers `ByBlock`, `ByLayer`, and `Continuous`,
+  including the `Continuous` description `Solid line`.
+- **Measured effect after the BLOCK_HEADER fix:** aggregate coverage improved
+  from 437 decoded / 1,660 skipped / 184 errored / 19.2% to 458 decoded /
+  1,660 skipped / 163 errored / 20.1%. `sample_AC1032.dwg` improved from
+  326 / 337 / 82 / 43.8% to 329 / 337 / 79 / 44.2%, and `LTYPE` errors
+  dropped from 30 to 9.
 
-  Known residual gaps tracked as follow-ups to #103:
-  - `RD` start-point reads still produce ~6e+14 garbage on some LINEs
-    (the BD delta path aligns but the absolute-value RD before it is
-    still off by a few bits in some encodings)
-  - Complex-color CMC suffix (BL rgb + TV name) disabled — reintroducing
-    it over-consumed ENDBLK preamble bits on line_2013.dwg
-- **`src/handle_allocator.rs`** — Fix pre-existing doctest that had
-  stale assertions (Boy Scout while in the file).
+### Fixed — R2007+ BLOCK_HEADER string-stream names (2026-04-29, #103)
+
+- **`src/tables/block_record.rs` / `src/entities/dispatch.rs`** — Added a
+  modern `BLOCK_HEADER` path that reads R2007+ table-record names from the
+  object's split string stream instead of treating `TV` fields as inline data.
+  This follows the ODA v5.4.1 §19.1 rule that Unicode strings in modern objects
+  live in the string stream even when the object table lists `TV` fields among
+  normal data.
+- **`examples/dump_decoded_entities.rs`** — Print `BLOCK_RECORD` names so the
+  recovered symbol-table records are visible during corpus inspection.
+- **`tests/r2013_entity_values.rs`** — Added a real-DWG regression asserting
+  that `sample_AC1032.dwg` recovers core block-record names including
+  `*Model_Space`, `*Paper_Space`, `_ArchTick`, `MyBlock`, `my_block`,
+  `my_block_v2`, and `my-dynamic-block`.
+- **Measured effect after the LWPOLYLINE fix:** aggregate coverage improved
+  from 408 decoded / 1,660 skipped / 213 errored / 17.9% to 437 decoded /
+  1,660 skipped / 184 errored / 19.2%. `sample_AC1032.dwg` improved from
+  312 / 337 / 96 / 41.9% to 326 / 337 / 82 / 43.8%, and `BLOCK_HEADER`
+  errors dropped from 39 to 10.
+
+### Fixed — LWPOLYLINE DD vertex decoding (2026-04-29, #103)
+
+- **`src/entities/lwpolyline.rs`** — Decode LWPOLYLINE vertices as
+  first point `RD/RD`, then subsequent points as `DD/DD` using the
+  previous point as the default. The old decoder read every vertex as
+  raw doubles, which produced enormous coordinates and exhausted the
+  stream on common AC1032 rectangles.
+- **`tests/r2013_entity_values.rs`** — Added a real-DWG regression
+  asserting that `sample_AC1032.dwg` decodes at least 10 finite,
+  nondegenerate LWPOLYLINE bodies.
+- **Measured effect after the common-entity fix:** aggregate coverage
+  improved from 400 decoded / 1,660 skipped / 221 errored / 17.5% to
+  408 decoded / 1,660 skipped / 213 errored / 17.9%.
+
+### Fixed — R2013/R2018 common-entity/body boundary (2026-04-29, #103)
+
+- **`src/common_entity.rs`** — Corrected the modern common-entity
+  preamble layout against traced R2013/R2018 data: removed the stale modern
+  `is_on_layer` / `non_fixed_ltype` data-stream reads, limited the
+  DS-data bit to R2013+, restored `shadow_flags` to an `RC`, and
+  skipped R2004+ CMC color suffixes (`alpha`, `rgb`, color name, and
+  book name) without consuming color handles from the data stream.
+- **`examples/trace_entity_boundary.rs`** — Added a reusable boundary
+  tracer for LINE/CIRCLE/ARC records. It compares the production
+  common-entity end against plausible body starts and reports duplicate
+  handles / no-candidate records for real DWGs.
+- **`examples/trace_common_entity.rs` /
+  `examples/test_line_bd_vs_rd.rs`** — Brought the forensic examples
+  back in sync with the corrected R2013 preamble so they no longer
+  encode the obsolete 68-bit overread.
+- **`tests/r2013_entity_values.rs`** — Promoted the real-DWG value
+  tests out of `#[ignore]`. `line_2013.dwg` now asserts the authored
+  `(50, 50, 0) -> (100, 100, 0)` LINE, the R2013 CIRCLE/ARC samples
+  must decode typed geometry, and `sample_AC1032.dwg` must retain at
+  least 80 nondegenerate LINE bodies.
+- **Measured effect:** `examples/coverage_report.rs ../../samples`
+  improved from 169 decoded / 1,655 skipped / 457 errored / 7.4%
+  aggregate coverage to 400 decoded / 1,660 skipped / 221 errored /
+  17.5%. `sample_AC1032.dwg` improved from 106 decoded / 332 skipped /
+  307 errored / 14.2% to 304 decoded / 337 skipped / 104 errored /
+  40.8%.
+
+### Fixed — LINE DD coordinate decoding (2026-04-28, #103)
+
+- **`src/bitcursor.rs` / `src/bitwriter.rs`** — Added `DD`
+  (bitdouble-with-default) support. The reader handles the spec's
+  default, 4-byte patch, 6-byte patch, and full-double forms; the writer
+  emits exact-default or full-double forms.
+- **`src/entities/line.rs` / `src/element_encoder.rs`** — Decode and encode
+  `LINE` end coordinates as `DD` fields using each start coordinate as
+  the default, instead of treating them as `BD` deltas.
+- **Measured effect before the common-entity boundary fix:** decoded
+  count moved from 166 to 169 on the local sample corpus and reduced
+  R2018 LINE errors from 83 to 80. The 2026-04-29 common-entity fix
+  above is the change that made the real-DWG value tests pass.
 
 ### Added — Phase 12 write-path + Phase 13 WASM scaffolding (2026-04-20 late)
 
@@ -261,19 +330,19 @@ proceed in parallel.
   a compression-bomb test proves a 6-byte input claiming 1 TiB
   stays bounded (`small_input_with_huge_expected_size_stays_bounded`).
 
-### Known — decoder-correctness regression discovered (task #97)
+### Known at 0.1.0-alpha.1 — decoder-correctness regression discovered (task #97)
 
 Task #97 (validate decoders against real R2013 corpus) surfaced a
 deeper architectural gap than the dispatcher type-code bugs that
 #71-#96 closed:
 
-1. **Handle walk misses modelspace geometry.** The single-entity
+1. **Handle walk missed modelspace geometry.** The single-entity
    R2013 samples (`line_2013.dwg`, `circle_2013.dwg`, `arc_2013.dwg`)
    each decode 6 objects, all of which are empty `BLOCK`/`ENDBLK`
    shells. The user-drawn LINE/CIRCLE/ARC is stored at a handle
    reachable only through `BLOCK_HEADER → owned entities` — a
-   traversal the current reader does not perform.
-2. **Bit-cursor offset inside typed payloads is wrong on R2018.**
+   traversal the 0.1.0-alpha.1 reader did not perform.
+2. **Bit-cursor offset inside typed payloads was wrong on R2018.**
    `sample_AC1032.dwg` is the one corpus file where typed entity
    decoders fire on real data, and the results are garbage: LINE
    endpoints with `z = 1.2e+225`, POINT positions with
@@ -283,11 +352,9 @@ deeper architectural gap than the dispatcher type-code bugs that
    error earlier in the pipeline or a missed preamble field in the
    R2018 layout.
 
-Four integration tests in `tests/r2013_entity_values.rs` pin the
-expected invariants. They are `#[ignore]`'d so `cargo test` stays
-green; `cargo test --release -- --ignored` reproduces the regression
-on demand. The "honest coverage" numbers below measure *dispatch
-success*, not *value correctness*.
+Those invariants are now active default tests in the Unreleased
+changes above. The historical "honest coverage" numbers below measure
+*dispatch success*, not *value correctness*.
 
 ## [0.1.0-alpha.1] — 2026-04-19
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 This is **0.1.0-alpha.1**. Do not use it in production. Do not benchmark it against the ODA SDK. Do not tell your CAD team dwg-rs solves their interop problem today.
 
-Empirical entity-decode coverage as measured on 2026-04-25 by
+Empirical entity-decode coverage as measured on 2026-04-29 by
 [`examples/coverage_report.rs`](./examples/coverage_report.rs) against the
 local `samples/` set:
 
@@ -25,29 +25,34 @@ local `samples/` set:
 |---------|--------------|---------|---------|---------|--------------|
 | R14 / R2000 / R2007 | 9 | n/a | n/a | n/a | not supported (no handle-map for this layout yet) |
 | R2004 (AC1018)      | 3 | 15 | 522 | 60 | **2.5 %** |
-| R2010 (AC1024)      | 3 | 18 | 474 | 51 | **3.3 %** |
-| R2013 (AC1027)      | 3 | 30 | 327 | 39 | **7.6 %** |
-| R2018 (AC1032)      | 1 | 103 | 332 | 310 | **13.8 %** |
-| **Aggregate** | **19** | **166** | **1655** | **460** | **7.3 %** |
+| R2010 (AC1024)      | 3 | 54 | 474 | 15 | **9.9 %** |
+| R2013 (AC1027)      | 3 | 60 | 327 | 9 | **15.2 %** |
+| R2018 (AC1032)      | 1 | 329 | 337 | 79 | **44.2 %** |
+| **Aggregate** | **19** | **458** | **1660** | **163** | **20.1 %** |
 
-Per-entity-type error concentration in the R2018 sample (where most real data is):
+Per-entity-type error concentration in the measured corpus:
 
 | Type code | DXF name | Occurrences as error |
 |-----------|----------|-----------------------|
-| 0x13 (19) | `LINE` | 83 |
-| 0x05 (5) | unknown / table-dependent | 47 |
-| 0x31 (49) | unknown / table-dependent | 39 |
-| 0x2C (44) | `MTEXT` | 33 |
-| 0x39 (57) | unknown / table-dependent | 30 |
-| 0x1B (27) | `POINT` | 29 |
-| ... | (long tail) | 199 |
+| 0x01 (1) | `TEXT` | 25 |
+| 0x35 (53) | `STYLE` | 21 |
+| 0x45 (69) | `DIMSTYLE` | 20 |
+| 0x41 (65) | `VPORT` | 11 |
+| 0x31 (49) | `BLOCK_HEADER` | 10 |
+| 0x04 (4) | `BLOCK` | 9 |
+| 0x05 (5) | `ENDBLK` | 9 |
+| 0x39 (57) | `LTYPE` | 9 |
+| ... | (long tail) | 49 |
 
 **Translation:** the 27 entity decoders in [`src/entities/*.rs`](./src/entities/)
-are verified against hand-crafted synthetic input (193 unit + proptest + sample tests pass)
-but fail on real-world files because the common-entity preamble, extended-data loop, and
-handle-stream layout in production DWG files has version-specific deviations this
-crate doesn't yet fully model. This is the gap between "decoder functions exist" and
-"decoders work end-to-end." Closing it is the 0.2.0 milestone.
+are verified against hand-crafted synthetic input, and the R2013/R2018
+common-entity/body boundary is now pinned by real-DWG tests for LINE,
+CIRCLE, ARC, the `sample_AC1032.dwg` LINE population, common LWPOLYLINE
+vertices, and R2007+ `BLOCK_HEADER` / simple `LTYPE` string-stream names. The remaining gap is
+broader than "does the dispatcher return a variant": several table, text,
+insert, dimension, hatch, and LWPOLYLINE flag variants still misread
+version-specific field layouts or split streams. Closing that real-file decode
+gap is the 0.2.0 milestone.
 
 ## Capability matrix at a glance
 
@@ -65,9 +70,9 @@ crate doesn't yet fully model. This is the gap between "decoder functions exist"
 | HandleMap + ClassMap parsing | ✓ shipped | — |
 | Header variables | ✓ shipped | Strict + lossy variants |
 | Object-stream walker (R2004+) | ✓ shipped | R14 / R2000 / R2007 pending (#104) |
-| Per-entity field decoders | ⚠ alpha | Broad synthetic coverage; real-file aggregate currently ~7.3% (#103) |
+| Per-entity field decoders | ⚠ alpha | Broad synthetic coverage; real-file aggregate currently ~20.1% (#103) |
 | Entity graph (owner / reactors / blocks / layers) | ⚠ partial | Resolver APIs exist; trailing-handle/block traversal gaps remain |
-| Symbol tables (LAYER / LTYPE / STYLE / DIMSTYLE / …) | ✓ dispatch shipped | Content-field decode pending |
+| Symbol tables (LAYER / LTYPE / STYLE / DIMSTYLE / …) | ⚠ partial | R2007+ BLOCK_HEADER and simple LTYPE names decode; broader content fields pending |
 | SVG / PDF export | ⚠ alpha | SVG writer + paged-SVG PDF path; output quality depends on decoded geometry |
 | DXF writer | ⚠ alpha | Writer exists for R12..R2018 targets; DXF parser is not implemented |
 | DWG writer | ⚠ alpha | `DwgFile::to_bytes()` and R2004-family byte assembly exist; external CAD acceptance not automated |
@@ -79,7 +84,7 @@ crate doesn't yet fully model. This is the gap between "decoder functions exist"
 
 ## What *does* work today
 
-The container layer is the most mature part of the crate and is covered by the test suite (run `cargo test` for the current count; 645 unit + ~100 integration + 10 doctests as of 2026-04-20):
+The container layer is the most mature part of the crate and is covered by the test suite (run `cargo test` for the current count; 649 lib tests plus integration suites and 10 doctests as of 2026-04-29):
 
 - Version identification across AC1014 (R14, 1997) → AC1032 (2018, 2024+)
 - R13–R15 simple file header + R2004+ XOR-encrypted header
@@ -104,6 +109,9 @@ The container layer is the most mature part of the crate and is covered by the t
 ### Hard-no list — what dwg-rs does NOT do today
 
 - End-to-end entity decoding on most real R2004-family files (see coverage table above).
+  R2013/R2018 LINE/CIRCLE/ARC alignment is now pinned; many text,
+  insert, dimension, hatch, LWPOLYLINE flag variants, and table-object paths still
+  need real-file field-layout work.
 - R14 / R2000 object-stream walking (different layout from R2004-family; not yet implemented).
 - R2007 section payloads (layer-1 Sec_Mask shipped, layer-2 bit-rotation scaffolded only).
 - Full HATCH boundary path tree, full MLEADER leader-line list, full 75-field DIMSTYLE.
@@ -233,7 +241,7 @@ Quick layer overview:
 
 ```text
 $ cargo test --release
-# 645 unit tests + integration suites (code_table, corpus_roundtrip,
+# 649 lib tests + integration suites (code_table, corpus_roundtrip,
 # dispatch_roundtrip, dxf_roundtrip, entity_regression, fuzz_corpus,
 # gltf, svg_goldens, write_roundtrip, mutation_failure, proptest,
 # samples) + 10 doctests. Exact count grows with each commit; check
@@ -246,8 +254,9 @@ $ cargo deny check                                                # no advisorie
 
 Tests exercise the container layer end-to-end across all 19 corpus files and verify
 bit-level round-trip properties for every primitive. They do **not** verify that every
-entity decoder succeeds on every real-world drawing — that's what the 22 % / 43 % /
-85 % coverage numbers above measure. Both classes of testing are needed.
+entity decoder succeeds on every real-world drawing — that's what the 20.1 %
+aggregate / 44.2 % AC1032 coverage numbers above measure. Both classes of
+testing are needed.
 
 ## Safety
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,21 +34,32 @@ Ship bar for this milestone:
 ## 0.2.0 — entity-decode correctness
 
 **Theme: make the decoders work on real files.** The biggest known
-gap: `coverage_report.rs` shows only ~25% of entities decode on the
-measured corpus, and `tests/r2013_entity_values.rs` pins four
-`#[ignore]`'d tests that fail on real data.
+gap: `coverage_report.rs` shows only 20.1% of entities decode on the
+measured corpus. The first boundary layer is now fixed for
+R2013/R2018 LINE/CIRCLE/ARC records, common LWPOLYLINE vertices, and
+R2007+ BLOCK_HEADER / simple LTYPE string-stream names, but table, text,
+insert, dimension, hatch, and remaining LWPOLYLINE variants still need
+real-file field-layout work.
 
 Ship bar:
 
-- [ ] Handle-driven walk reaches modelspace geometry on R2013
-      (currently the R2013 samples decode only empty `BLOCK` /
-      `ENDBLK` shells; real `LINE` / `CIRCLE` / `ARC` live inside
-      `BLOCK_HEADER → owned entities` and are never visited)
-- [ ] Bit-cursor alignment inside R2018 typed entity payloads
-      produces finite, plausible coordinates (currently `LINE`
-      endpoints can have `z = 1.2e+225`, etc.)
-- [ ] The four `#[ignore]`'d tests in
-      `tests/r2013_entity_values.rs` are un-ignored and pass
+- [x] Handle-driven walk reaches modelspace LINE/CIRCLE/ARC geometry
+      consistently across the R2013 samples and the R2018 AC1032
+      sample's LINE population
+- [x] Bit-cursor alignment inside those typed geometry payloads
+      produces finite, plausible coordinates
+- [x] Real-DWG value tests in `tests/r2013_entity_values.rs` are
+      active in the default test run and pass
+- [x] Common LWPOLYLINE vertices decode first-point `RD/RD` and
+      subsequent `DD/DD`, pinned by AC1032 plausibility coverage
+- [x] Recover R2007+ `BLOCK_HEADER` names from the split string stream
+      and pin them against `sample_AC1032.dwg`
+- [x] Recover simple R2007+ `LTYPE` names/descriptions from the split
+      string stream and pin `ByBlock`, `ByLayer`, and `Continuous`
+      against `sample_AC1032.dwg`
+- [ ] Extend the real-file field-layout fixes to TEXT / MTEXT strings,
+      INSERT rotation, remaining table records, DIMENSION, HATCH,
+      remaining LWPOLYLINE flag variants, and trailing-handle variants
 - [ ] Decode-rate ≥ 75% aggregate on the measured corpus
 - [ ] `tests/fixtures/raw_entities/` holds hand-authored byte-level
       fixtures for `LINE`, `CIRCLE`, `ARC`, `POINT`, `LWPOLYLINE`,

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,4 +1,4 @@
-# Status — 2026-04-25
+# Status — 2026-04-29
 
 A plain-text snapshot of what has shipped in this crate, organized
 by the task-tracker labels, so contributors can orient without
@@ -6,12 +6,15 @@ scrolling the changelog.
 
 ## Summary
 
-- **Lib tests:** 645+ passing in default/debug and release-all-features
+- **Lib tests:** 649 passing in default/debug and release-all-features
   profiles, clippy + fmt clean.
-- **WASM tests:** 39 passing in `wasm/` sub-crate.
+- **WASM tests:** 40 passing in `wasm/` sub-crate.
 - **Integration tests:** DXF round-trip (7), glTF smoke (3), SVG
   goldens (3), fuzz-corpus regression (6), write-path (5),
-  entity-value regression (18).
+  entity-regression (18), real-DWG value regression (8).
+- **Current real-file decode coverage:** 458 decoded / 1,660 skipped /
+  163 errored / 20.1% on the local 19-file `samples/` corpus. The
+  R2018 `sample_AC1032.dwg` sample is 329 / 337 / 79 / 44.2%.
 - **Fuzz targets:** 9 (lz77 / bitcursor / dwg-file-open / section-map /
   object-walker / classmap / handlemap / header-vars / rs-fec).
   Seed corpus: 30 hand-crafted inputs across all targets.
@@ -38,6 +41,8 @@ scrolling the changelog.
 - `ObjectWalker` with typed dispatch + `DispatchSummary`.
 - Handle map + class map parsers (with writer-side inverses).
 - Strict / lossy / count-cap variants.
+- R2013/R2018 common-entity/body boundary pinned for LINE/CIRCLE/ARC
+  with active real-DWG regression tests.
 
 ### Entity decoders (Phase 4, 27 modules)
 - LINE, CIRCLE, ARC, ELLIPSE, POINT, LWPOLYLINE, POLYLINE 2D/3D.
@@ -53,6 +58,12 @@ scrolling the changelog.
 - OLE2FRAME, WIPEOUT, MLINE.
 - PROXY entity / PROXY object (opaque pass-through).
 - RAY, XLINE, VIEWPORT, TRACE, SOLID-2D.
+- `LINE` end coordinates use DD fields with each start coordinate as
+  the default; `line_2013.dwg` now asserts the authored
+  `(50, 50, 0) -> (100, 100, 0)` geometry.
+- `LWPOLYLINE` vertices use first-point `RD/RD`, then subsequent
+  `DD/DD` values with the previous point as default. The AC1032 sample
+  now asserts at least 10 finite, nondegenerate LWPOLYLINE bodies.
 
 ### Symbol tables (Phase 6)
 - LAYER, LTYPE, STYLE, VIEW, UCS, VPORT, APPID, DIMSTYLE.
@@ -172,17 +183,19 @@ scrolling the changelog.
 
 These have genuine open scope requiring focused work, not stubs.
 
-- **Current real-file decode baseline:** the 2026-04-25
-  `examples/coverage_report.rs ../../samples` run reports 166 decoded,
-  1655 skipped, 460 errored, 7.3% aggregate coverage. This is the
+- **Current real-file decode baseline:** the 2026-04-29
+  `examples/coverage_report.rs ../../samples` run reports 458 decoded,
+  1660 skipped, 163 errored, 20.1% aggregate coverage. This is the
   practical product-readiness blocker even though synthetic decoder
   tests are broad.
 
-- **#103 R2018 bit-cursor misalignment** (P0, partially traced to
-  line.rs). Requires a 2nd R2013 corpus sample with known
-  coordinates for hypothesis falsification. This is the biggest
-  single blocker for `decoded_entities()` decode-rate improvements
-  across all recent versions.
+- **#103 remaining real-file decoder alignment** (P0). The
+  R2013/R2018 common-entity/body boundary is fixed for LINE/CIRCLE/ARC,
+  common LWPOLYLINE vertices now use DD correctly, R2007+ BLOCK_HEADER
+  names and simple LTYPE names are recovered from the split string stream,
+  and active value tests pass, but the next blockers are TEXT/MTEXT strings, INSERT
+  rotation, DIMENSION, HATCH, table-object field layouts, and remaining
+  LWPOLYLINE flag variants.
 - **#104 R14 / R2000 / R2007 handle-map walker.** Container layer
   ships for these versions, but the object-stream walker is
   R2004+ only. Unlocks `decoded_entities()` for those release

--- a/docs/announcements/01-hn-show-hn.md
+++ b/docs/announcements/01-hn-show-hn.md
@@ -6,7 +6,7 @@
 
 **Body:**
 
-dwg-rs is an Apache-2.0 Rust reader for Autodesk DWG files. It is **pre-alpha**: the container layer (file identification, section map, LZ77, Sec_Mask layer-1, CRCs, Reed-Solomon, metadata, handle map, class map, object-stream walker) has landed and has unit + corpus coverage; per-entity field decoders are alpha — measured aggregate decode rate is 25 % on the public `nextgis/dwg_samples` corpus + one AC1032 sample, with R2013 around 86 % and R2018 at 22 %. The README publishes the per-version table so you can decide whether the current coverage fits your use case.
+dwg-rs is an Apache-2.0 Rust reader for Autodesk DWG files. It is **pre-alpha**: the container layer (file identification, section map, LZ77, Sec_Mask layer-1, CRCs, Reed-Solomon, metadata, handle map, class map, object-stream walker) has landed and has unit + corpus coverage; per-entity field decoders are alpha — measured aggregate decode rate is 20.1 % on the public `nextgis/dwg_samples` corpus + one AC1032 sample, with R2013 at 15.2 % and R2018 at 44.2 %. The README publishes the per-version table so you can decide whether the current coverage fits your use case.
 
 Why another DWG reader: LibreDWG (GPL-3) is more complete today and ACadSharp (MIT, C#) is a mature .NET option, but nothing Apache-2.0 exists in Rust. dwg-rs fills that niche. Built from the ODA's public Open Design Specification v5.4.1 and first-party byte inspection of public sample files. CLEANROOM.md documents the source-provenance policy (executable code from Autodesk SDK / ODA SDK / GPL-licensed readers was not imported; one scoped exception is documented for algorithm-description comments in the MIT-licensed ACadSharp).
 

--- a/docs/announcements/02-r-rust-post.md
+++ b/docs/announcements/02-r-rust-post.md
@@ -6,7 +6,7 @@
 
 **Body:**
 
-Just published dwg-rs, an Apache-2.0 Rust reader for Autodesk DWG files. Honest upfront: 0.1.0-alpha.1. Container layer has landed; per-entity decoders are alpha. Aggregate decode rate across the public `nextgis/dwg_samples` corpus + one AC1032 sample is 25 %, ranging from 22 % on R2018 to 86 % on R2013; the full per-version breakdown is in the README.
+Just published dwg-rs, an Apache-2.0 Rust reader for Autodesk DWG files. Honest upfront: 0.1.0-alpha.1. Container layer has landed; per-entity decoders are alpha. Aggregate decode rate across the public `nextgis/dwg_samples` corpus + one AC1032 sample is 20.1 %, with R2018 at 44.2 % and R2013 at 15.2 %; the full per-version breakdown is in the README.
 
 Why this exists: mature open-source DWG readers do exist — LibreDWG (GPL-3) and ACadSharp (MIT, C#) — but nothing Apache-2.0 in Rust. dwg-rs fills that niche. It is built from the ODA's freely-redistributable Open Design Specification v5.4.1 and first-party byte inspection of public sample files. `CLEANROOM.md` documents the source-provenance policy; every PR ships with a declaration.
 

--- a/docs/announcements/03-linkedin-aec.md
+++ b/docs/announcements/03-linkedin-aec.md
@@ -14,7 +14,7 @@ It is built from the ODA's freely-redistributable Open Design Specification v5.4
 
 What this means for downstream tools: a DWG container-layer reader you can evaluate for a closed-source product, a SaaS backend, or a permissively-licensed OSS pipeline — provided the current partial coverage fits your use case.
 
-Honest status: 0.1.0-alpha.1, pre-alpha. The container layer (file identification, section map, LZ77 decompression, CRC + Reed-Solomon, metadata, handle map, class map, object-stream walker) has landed and carries unit + corpus coverage. Per-entity field decoders are alpha — the README publishes measured decode rates per DWG version (22 % on R2018, 86 % on R2013, 25 % aggregate across the `nextgis/dwg_samples` corpus + one AC1032 sample). Entity-decoder correctness is the 0.2.0 milestone.
+Honest status: 0.1.0-alpha.1, pre-alpha. The container layer (file identification, section map, LZ77 decompression, CRC + Reed-Solomon, metadata, handle map, class map, object-stream walker) has landed and carries unit + corpus coverage. Per-entity field decoders are alpha — the README publishes measured decode rates per DWG version (44.2 % on R2018, 15.2 % on R2013, 20.1 % aggregate across the `nextgis/dwg_samples` corpus + one AC1032 sample). Entity-decoder correctness is the 0.2.0 milestone.
 
 Sibling project: rvt-rs — same source-provenance policy, same license, for Autodesk Revit (.rvt / .rfa).
 

--- a/docs/announcements/04-r-autocad.md
+++ b/docs/announcements/04-r-autocad.md
@@ -10,7 +10,7 @@ I have been building dwg-rs, an open-source, Apache-2 reader for AutoCAD DWG fil
 
 Where things stand, without marketing gloss: pre-alpha. The container layer — recognizing DWG version, decompressing sections, reading metadata, listing every object — has landed and is exercised by the repository's unit + corpus tests against sample files from R14 through R2018.
 
-Where it falls short: the per-entity decoders (the code that turns "object #42" into "a LINE from A to B") are alpha. The README publishes measured per-version numbers — about 86 % of entities decode on R2013, about 22 % on R2018, 25 % aggregate — so you can see the actual state instead of trusting a pitch. Raising that number is the next milestone.
+Where it falls short: the per-entity decoders (the code that turns "object #42" into "a LINE from A to B") are alpha. The README publishes measured per-version numbers — 15.2 % of entities decode on R2013, 44.2 % on R2018, 20.1 % aggregate — so you can see the actual state instead of trusting a pitch. Raising that number is the next milestone.
 
 You can already pull a DWG's embedded thumbnail, list the AutoCAD version that wrote the file, extract the metadata block, and walk the raw object table. The in-browser viewer needs the entity decoders to land first.
 

--- a/docs/blog/01-reading-dwg-without-autocad.md
+++ b/docs/blog/01-reading-dwg-without-autocad.md
@@ -178,7 +178,7 @@ treating the payload as a single bit-stream will read garbage
 handle-references. We know — that's roughly what our current
 per-entity decoders do, and it's exactly why the
 [README's measured decode rate](../../README.md#pre-alpha-status--read-this-first)
-is in the 20–80 % range depending on version: the container layer
+is in the 2.5–44.2 % range depending on version: the container layer
 is solid, but the entity payload layer still reads the tail of the
 payload as if it were one stream.
 

--- a/docs/blog/02-open-dwg-pipeline.md
+++ b/docs/blog/02-open-dwg-pipeline.md
@@ -123,11 +123,11 @@ if let Some(Ok((entities, summary))) = file.decoded_entities() {
 That last call is where the 0.1.0-alpha.1 limits bite. The
 container gives you every object with its correct handle, type
 code, and raw payload bytes — but the *typed* decoders underneath
-`decoded_entities()` currently succeed on 20–80 % of entities
+`decoded_entities()` currently succeed on 2.5–44.2 % of entities
 depending on version (see the
 [capability matrix](../../README.md#capability-matrix-at-a-glance)
-for the measured numbers). On R2013 it's ~86 %. On R2018 it's
-~22 %. On R2004 it's 0 %. The gap is the per-version handle/data
+for the measured numbers). On R2013 it's 15.2 %. On R2018 it's
+44.2 %. On R2004 it's 2.5 %. The gap is the per-version handle/data
 stream split covered in the
 [previous post](./01-reading-dwg-without-autocad.md#the-split-stream-architecture),
 not a missing renderer.
@@ -291,7 +291,7 @@ Against the README capability matrix:
   parsing, raw object enumeration on R2004+, the `Curve`/`Path`
   types, the SVG writer, the DXF writer + section emitters,
   `examples/dwg_to_svg.rs`.
-- **Alpha**: per-entity decoders (20–80 % real-file decode rate
+- **Alpha**: per-entity decoders (2.5–44.2 % real-file decode rate
   depending on version; see [README's measured numbers](../../README.md#pre-alpha-status--read-this-first)).
 - **Pending**: R14/R2000/R2007 object walk, entity graph (owners,
   reactors, blocks), full symbol-table content decoders, glTF

--- a/docs/blog/03-sibling-projects-rvt-rs.md
+++ b/docs/blog/03-sibling-projects-rvt-rs.md
@@ -121,8 +121,8 @@ files, and land the write path.
 
 For `dwg-rs`:
 
-- Per-version entity preamble fixes (R2004 and R2018 are the
-  current big gaps; R2013 is ~86 %). See the
+- Per-version entity preamble fixes (R2004, R2010, R2013, and
+  R2018 all still have measured real-file decoder gaps). See the
   [capability matrix](../../README.md#capability-matrix-at-a-glance)
   and
   [the bit-stream walk-through](./01-reading-dwg-without-autocad.md#the-split-stream-architecture).

--- a/docs/landing/compatibility.md
+++ b/docs/landing/compatibility.md
@@ -23,11 +23,11 @@ Legend:
 |----------|-------------------------|--------|------------------|----------------|---------------|--------------------|-----------------|---------|
 | `AC1014` | R14                     | 1997   | ok               | ok             | pending       | pending            | pending         | pending |
 | `AC1015` | R2000 / 2000i / 2002    | 1999   | ok               | ok             | pending       | pending            | pending         | pending |
-| `AC1018` | R2004 / 2005 / 2006     | 2003   | ok               | ok             | ok            | partial (0% real)  | pending         | pending |
+| `AC1018` | R2004 / 2005 / 2006     | 2003   | ok               | ok             | ok            | partial (2.5% real) | pending         | pending |
 | `AC1021` | R2007 / 2008 / 2009     | 2006   | partial          | pending        | pending       | pending            | pending         | pending |
-| `AC1024` | R2010 / 2011 / 2012     | 2009   | ok               | ok             | ok            | partial (43% real) | pending         | pending |
-| `AC1027` | R2013 / 2014-2017       | 2012   | ok               | ok             | ok            | partial (86% real) | pending         | pending |
-| `AC1032` | R2018 / 2019-2025+      | 2017   | ok               | ok             | ok            | partial (22% real) | pending         | pending |
+| `AC1024` | R2010 / 2011 / 2012     | 2009   | ok               | ok             | ok            | partial (9.9% real) | pending         | pending |
+| `AC1027` | R2013 / 2014-2017       | 2012   | ok               | ok             | ok            | partial (15.2% real) | pending         | pending |
+| `AC1032` | R2018 / 2019-2025+      | 2017   | ok               | ok             | ok            | partial (44.2% real) | pending         | pending |
 | `AC10??` | R32 / future            | future | n/a              | n/a            | n/a           | n/a                | n/a             | n/a     |
 
 Notes, column by column:
@@ -35,13 +35,13 @@ Notes, column by column:
 - **Container parse.** Identifier detection, file-open header, section page map, section info, LZ77 decompression, Sec_Mask layer-1. The only `partial` is R2007 because its Sec_Mask layer-2 bit-rotation is scaffolded but not finished; section payloads for R2007 currently error rather than decode.
 - **Metadata parse.** `SummaryInfo`, `AppInfo`, `Preview`, `FileDepList`. Works across every version the container layer parses. Auto-detects UTF-16 for R21+ and carves a PNG thumbnail from R24+ preview streams.
 - **Object walker.** `all_objects()` returns every `RawObject` with type code, handle, and raw payload bytes. Works on R2004 and newer (handle-map-driven walk). R14 / R2000 use a different object-stream layout that is not yet implemented (issue #104). R2007 is blocked by the Sec_Mask layer-2 gap above.
-- **Per-entity decoder.** The 27 typed decoders in [`src/entities/`](../../src/entities/) are verified against hand-crafted synthetic bit streams (193 unit + proptest tests pass). Real-file decode rates are what the `(… % real)` numbers in the table report, measured by `examples/coverage_report.rs`. The aggregate real-file decode rate across all corpora is currently 25 %. Closing this gap is the 0.2.0 ship bar — see [`ROADMAP.md`](../../ROADMAP.md).
+- **Per-entity decoder.** The 27 typed decoders in [`src/entities/`](../../src/entities/) are verified against hand-crafted synthetic bit streams. Real-file decode rates are what the `(… % real)` numbers in the table report, measured by `examples/coverage_report.rs`. The aggregate real-file decode rate across all corpora is currently 20.1 %. Closing this gap is the 0.2.0 ship bar — see [`ROADMAP.md`](../../ROADMAP.md).
 - **Geometry export.** SVG / PNG / PDF / glTF output. The `svg` module exists in [`src/svg.rs`](../../src/svg.rs) but the full export path is pending until per-entity decoders stabilize — rendering broken geometry would publish confidently-wrong pictures.
 - **Write.** `file_writer.rs` is stage 1 of 5. LZ77 literal-only encoder works; Reed-Solomon encoder is tracked by issue #109; stages 2-5 (section encoding, buffer assembly, CRC splicing, file-level write) are the 0.4.0 milestone.
 
 ## What "partial" looks like in practice
 
-Consider the R2013 row. Container parse is `ok`, metadata parse is `ok`, object walker is `ok` — that means you can open any R2013 file, read metadata, and enumerate every object by handle. Per-entity decoder is `partial (86% real)` — meaning of the seven "hot" entity types `coverage_report.rs` probes per file, six decode cleanly and one errors. The error is typically a common-entity preamble misalignment that the synthetic unit tests don't exercise because they feed the decoder a hand-aligned bit stream.
+Consider the R2013 row. Container parse is `ok`, metadata parse is `ok`, object walker is `ok` — that means you can open any R2013 file, read metadata, and enumerate every object by handle. Per-entity decoder is `partial (15.2% real)` on the measured corpus. The remaining errors are typically version-specific table, text, insert, dimension, hatch, or flag-layout mismatches that synthetic unit tests don't exercise because they feed decoders hand-aligned bit streams.
 
 The honest consequence: today on R2013 you can trust `DwgFile::version()`, `file.summary_info()`, `file.all_objects()`, and most `entities::*` decoders when you dispatch by hand. You cannot yet trust the fully automated `file.decoded_entities()` pipeline to cover 100 % of entities on arbitrary drawings — even though on R2013 specifically it gets most of the way there.
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -89,7 +89,7 @@ f = dwg.DwgFile.open(path, limits="paranoid")
 ## Why is this a placeholder?
 
 The container layer is pre-alpha and the per-entity decoders hover in
-the 22–86 % real-file coverage band (see the
+the 2.5–44.2 % real-file coverage band (see the
 [capability matrix](../README.md#capability-matrix-at-a-glance) for
 the measured numbers). Shipping Python bindings before the Rust
 surface stabilizes would mean the bindings churn every time a decoder

--- a/examples/dump_decoded_entities.rs
+++ b/examples/dump_decoded_entities.rs
@@ -207,6 +207,22 @@ fn print_entity(i: usize, e: &DecodedEntity) {
         DecodedEntity::Block(b) => {
             println!("[{i}] BLOCK  name={:?}", truncate(&b.name, 64));
         }
+        DecodedEntity::BlockRecord(b) => {
+            println!(
+                "[{i}] BLOCK_RECORD  name={:?} owned={:?}",
+                truncate(&b.header.name, 64),
+                b.num_owned_objects
+            );
+        }
+        DecodedEntity::Ltype(l) => {
+            println!(
+                "[{i}] LTYPE  name={:?} desc={:?} pattern_length={:.6} dashes={}",
+                truncate(&l.header.name, 64),
+                truncate(&l.description, 80),
+                l.pattern_length,
+                l.dashes.len()
+            );
+        }
         DecodedEntity::EndBlk(_) => {
             println!("[{i}] ENDBLK");
         }

--- a/examples/test_h3_invisibility.rs
+++ b/examples/test_h3_invisibility.rs
@@ -1,23 +1,15 @@
-//! Empirical test of H3 (revised): the BS invisibility read in the
-//! common-entity preamble is consuming 18 bits (tag 00 → 16-bit
-//! literal) when it should consume far fewer. Re-decode the LINE
-//! preamble inline with EXPERIMENTAL changes:
+//! Verify the R2013 common-entity invisibility read on `line_2013.dwg`.
 //!
-//! Variant A — invisibility as a single B (1 bit) instead of BS.
-//! Variant B — skip invisibility entirely (assume it lives in the
-//!             handle stream for R2010+).
-//! Variant C — read invisibility as RS (raw 16-bit short, 16 bits)
-//!             instead of BS tag-prefix encoded.
-//!
-//! For each variant: walk the preamble inline (no reliance on the
-//! crate's read_common_entity_data), then run line::decode against
-//! the resulting cursor and report success/failure with bit
-//! position. The variant that yields a clean LINE decode is the
-//! right one.
+//! This started as an experiment for alternate invisibility encodings.
+//! The boundary fix proved the invisibility field was not the root cause:
+//! stale compatibility bits before CMC color and the shadow-field width
+//! had shifted the cursor. The example now uses the production reader and
+//! prints the decoded common preamble plus typed LINE geometry.
 
-use dwg::DwgFile;
 use dwg::bitcursor::BitCursor;
+use dwg::common_entity::read_common_entity_data;
 use dwg::entities::line;
+use dwg::{DwgFile, Version};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let file = DwgFile::open("../../samples/line_2013.dwg")?;
@@ -26,141 +18,45 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let payload = &line_obj.raw;
     let payload_bits = payload.len() * 8;
 
-    // Compute data-stream end.
-    let mut probe = BitCursor::new(payload);
-    let handle_stream_bits = read_mc_unsigned(&mut probe)?;
-    let data_stream_end = payload_bits - handle_stream_bits as usize;
-    println!(
-        "payload {} bits, handle_stream {} bits, data_stream ends at bit {}",
-        payload_bits, handle_stream_bits, data_stream_end
-    );
-
-    for label in [
-        "baseline (BS, current)",
-        "A: B (1 bit)",
-        "B: skip invis",
-        "C: RS (16 bits)",
-    ] {
-        println!("\n=== {label} ===");
-        match try_variant(payload, label) {
-            Ok((before, after, line)) => println!(
-                "  DECODED  preamble→bit {before}  line→bit {after} (consumed {} bits)\n  line = {:?}",
-                after - before,
-                line
-            ),
-            Err((stage, pos, e)) => println!("  FAILED at {stage}, bit {pos}: {e}"),
-        }
-    }
-
-    Ok(())
-}
-
-fn try_variant(
-    payload: &[u8],
-    label: &str,
-) -> Result<(usize, usize, line::Line), (&'static str, usize, dwg::Error)> {
     let mut c = BitCursor::new(payload);
-    // Object header: MC handle_stream_size, BB+RC type_code, Handle.
-    read_mc_unsigned(&mut c).map_err(|e| ("header MC", c.position_bits(), e))?;
-    let tag = c
-        .read_bb()
-        .map_err(|e| ("header BB", c.position_bits(), e))?;
-    match tag {
-        0 => {
-            c.read_rc()
-                .map_err(|e| ("type_code", c.position_bits(), e))?;
-        }
-        1 => {
-            c.read_rc()
-                .map_err(|e| ("type_code", c.position_bits(), e))?;
+    let handle_stream_bits = read_mc_unsigned(&mut c)?;
+    let data_stream_end = payload_bits - handle_stream_bits as usize;
+
+    let type_tag = c.read_bb()?;
+    match type_tag {
+        0 | 1 => {
+            let _ = c.read_rc()?;
         }
         _ => {
-            c.read_rc()
-                .map_err(|e| ("type_code lsb", c.position_bits(), e))?;
-            c.read_rc()
-                .map_err(|e| ("type_code msb", c.position_bits(), e))?;
+            let _ = c.read_rc()?;
+            let _ = c.read_rc()?;
         }
     }
-    c.read_handle()
-        .map_err(|e| ("handle", c.position_bits(), e))?;
+    let _handle = c.read_handle()?;
 
-    // Preamble — inline copy of read_common_entity_data with the
-    // variant-under-test substitution.
-    // XDATA loop: BS_u terminator.
-    loop {
-        let size = c
-            .read_bs_u()
-            .map_err(|e| ("xdata size", c.position_bits(), e))?;
-        if size == 0 {
-            break;
-        }
-        c.read_handle()
-            .map_err(|e| ("xdata appid", c.position_bits(), e))?;
-        for _ in 0..size {
-            c.read_rc()
-                .map_err(|e| ("xdata payload", c.position_bits(), e))?;
-        }
-    }
-    // Graphics flag.
-    if c.read_b()
-        .map_err(|e| ("graphics flag", c.position_bits(), e))?
-    {
-        let n = c
-            .read_rl()
-            .map_err(|e| ("graphics size", c.position_bits(), e))?;
-        for _ in 0..n {
-            c.read_rc()
-                .map_err(|e| ("graphics payload", c.position_bits(), e))?;
-        }
-    }
-    // Mode + reactors + dict markers.
-    c.read_bb().map_err(|e| ("entmode", c.position_bits(), e))?;
-    c.read_bl()
-        .map_err(|e| ("num_reactors", c.position_bits(), e))?;
-    c.read_b().map_err(|e| ("no_xdict", c.position_bits(), e))?;
-    c.read_b()
-        .map_err(|e| ("binary_chain", c.position_bits(), e))?;
-    c.read_b()
-        .map_err(|e| ("is_on_layer", c.position_bits(), e))?;
-    c.read_b()
-        .map_err(|e| ("non_fixed_ltype", c.position_bits(), e))?;
-    c.read_bb()
-        .map_err(|e| ("plotstyle", c.position_bits(), e))?;
-    // R2007+: material + shadow
-    c.read_bb()
-        .map_err(|e| ("material", c.position_bits(), e))?;
-    c.read_rc().map_err(|e| ("shadow", c.position_bits(), e))?;
-    // R2010+: visualstyle 3B
-    c.read_b().map_err(|e| ("vs_full", c.position_bits(), e))?;
-    c.read_b().map_err(|e| ("vs_face", c.position_bits(), e))?;
-    c.read_b().map_err(|e| ("vs_edge", c.position_bits(), e))?;
+    let common = read_common_entity_data(&mut c, Version::R2013)?;
+    let body_start = c.position_bits();
+    let decoded_line = line::decode(&mut c)?;
 
-    // Variant-under-test: invisibility encoding.
-    match label {
-        "baseline (BS, current)" => {
-            c.read_bs()
-                .map_err(|e| ("invis BS", c.position_bits(), e))?;
-        }
-        "A: B (1 bit)" => {
-            c.read_b().map_err(|e| ("invis B", c.position_bits(), e))?;
-        }
-        "B: skip invis" => {
-            // no read
-        }
-        "C: RS (16 bits)" => {
-            c.read_rs()
-                .map_err(|e| ("invis RS", c.position_bits(), e))?;
-        }
-        _ => unreachable!(),
-    }
-    // Lineweight (R2000+): RC = 8 bits.
-    c.read_rc()
-        .map_err(|e| ("lineweight", c.position_bits(), e))?;
+    println!(
+        "payload_bits={payload_bits} handle_stream_bits={handle_stream_bits} data_stream_end={data_stream_end}"
+    );
+    println!(
+        "common_end={body_start} invisibility={} lineweight=0x{:02X}",
+        common.invisibility, common.lineweight
+    );
+    println!(
+        "line=({:.6},{:.6},{:.6}) -> ({:.6},{:.6},{:.6}) 2d={}",
+        decoded_line.start.x,
+        decoded_line.start.y,
+        decoded_line.start.z,
+        decoded_line.end.x,
+        decoded_line.end.y,
+        decoded_line.end.z,
+        decoded_line.is_2d
+    );
 
-    let preamble_end = c.position_bits();
-    let line = line::decode(&mut c).map_err(|e| ("line::decode", c.position_bits(), e))?;
-    let line_end = c.position_bits();
-    Ok((preamble_end, line_end, line))
+    Ok(())
 }
 
 fn read_mc_unsigned(c: &mut BitCursor<'_>) -> Result<u64, dwg::Error> {

--- a/examples/test_line_bd_vs_rd.rs
+++ b/examples/test_line_bd_vs_rd.rs
@@ -1,12 +1,16 @@
 //! Test whether the LINE decoder should use BD (bit-double, tag-encoded,
 //! 2-66 bits) vs RD (raw double, byte-aligned, 64 bits) for start coords.
+//! The current spec path is RD start coordinates plus DD end coordinates;
+//! the BD variants below are retained as forensic alternatives.
 //!
 //! If the file's start coordinates are at-origin (0,0,0), BD encoding
 //! takes 2 bits per coord (tag 10 = 0.0); RD encoding takes 64 bits.
 //! That accounts for ~190 bits of decoder slop on a single LINE.
 
 use dwg::DwgFile;
+use dwg::Version;
 use dwg::bitcursor::BitCursor;
+use dwg::common_entity::read_common_entity_data;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let file = DwgFile::open("../../samples/line_2013.dwg")?;
@@ -15,16 +19,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let payload = &line_obj.raw;
     println!("payload: {} bits", payload.len() * 8);
 
-    // Match preamble end at bit 86 (from the prior tracer).
-    // Skip header (34 bits) + preamble (52 bits) = 86 bits inline,
-    // then decode the LINE body two ways and compare.
+    // Use the production common-entity reader so this forensic comparison
+    // stays aligned with the real R2013 boundary (bit 74 for this sample).
     let mut c = BitCursor::new(payload);
     skip_to_preamble_end(&mut c)?;
     let body_start = c.position_bits();
     println!("entity body starts at bit {}\n", body_start);
 
-    // Variant 1: original line.rs encoding (RD for start coords).
-    println!("--- Variant 1: RD start coords (current line.rs) ---");
+    // Variant 1: current line.rs encoding (RD starts, DD ends).
+    println!("--- Variant 1: RD start coords + DD end coords (current line.rs) ---");
     {
         let mut cc = BitCursor::new(payload);
         skip_to_preamble_end(&mut cc)?;
@@ -47,7 +50,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Variant 2: BD for start coords (alternative spec interpretation).
-    println!("\n--- Variant 2: BD start coords (alternative spec) ---");
+    println!("\n--- Variant 2: BD start coords + DD end coords (alternative spec) ---");
     {
         let mut cc = BitCursor::new(payload);
         skip_to_preamble_end(&mut cc)?;
@@ -92,10 +95,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    // Variant 4: BD start + delta end + INVERTED zflag interpretation.
+    // Variant 4: BD start + DD end + INVERTED zflag interpretation.
     // If zflag=1 means 2D in spec but my decoder treats zflag=0 as 2D,
     // inverting saves 130+ bits on a flat 2D line.
-    println!("\n--- Variant 4: BD + INVERTED zflag (zflag=0 → 2D) ---");
+    println!("\n--- Variant 4: BD start + DD end + INVERTED zflag (zflag=0 → 2D) ---");
     {
         let mut cc = BitCursor::new(payload);
         skip_to_preamble_end(&mut cc)?;
@@ -140,9 +143,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    // Variant 6: BD + inverted zflag, NO BE (extrusion always default).
+    // Variant 6: BD start + DD end + inverted zflag, NO BE (extrusion always default).
     // Spec might say BE is omitted on R2007+ entities (ext is in handle stream).
-    println!("\n--- Variant 6: BD + inverted zflag + skip BE (default extrusion) ---");
+    println!("\n--- Variant 6: BD start + DD end + inverted zflag + skip BE ---");
     {
         let mut cc = BitCursor::new(payload);
         skip_to_preamble_end(&mut cc)?;
@@ -165,7 +168,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Variant 7: same as 6 but also drop BT thickness (always 0).
-    println!("\n--- Variant 7: BD + inverted zflag + skip BT + skip BE ---");
+    println!("\n--- Variant 7: BD start + DD end + inverted zflag + skip BT + skip BE ---");
     {
         let mut cc = BitCursor::new(payload);
         skip_to_preamble_end(&mut cc)?;
@@ -198,25 +201,25 @@ fn decode_line_bd_inv_zflag_no_be(
     let sx = c
         .read_bd()
         .map_err(|e| ("BD start.x", c.position_bits(), e))?;
-    let ex_delta = c
-        .read_bd()
-        .map_err(|e| ("BD end.x", c.position_bits(), e))?;
+    let ex = c
+        .read_dd(sx)
+        .map_err(|e| ("DD end.x", c.position_bits(), e))?;
     let sy = c
         .read_bd()
         .map_err(|e| ("BD start.y", c.position_bits(), e))?;
-    let ey_delta = c
-        .read_bd()
-        .map_err(|e| ("BD end.y", c.position_bits(), e))?;
+    let ey = c
+        .read_dd(sy)
+        .map_err(|e| ("DD end.y", c.position_bits(), e))?;
     let (sz, ez) = if is_2d {
         (0.0, 0.0)
     } else {
         let sz = c
             .read_bd()
             .map_err(|e| ("BD start.z", c.position_bits(), e))?;
-        let ez_delta = c
-            .read_bd()
-            .map_err(|e| ("BD end.z", c.position_bits(), e))?;
-        (sz, sz + ez_delta)
+        let ez = c
+            .read_dd(sz)
+            .map_err(|e| ("DD end.z", c.position_bits(), e))?;
+        (sz, ez)
     };
     let thick = read_bt(c).map_err(|e| ("BT thickness", c.position_bits(), e))?;
     Ok((
@@ -224,8 +227,8 @@ fn decode_line_bd_inv_zflag_no_be(
             sx,
             sy,
             sz,
-            ex: sx + ex_delta,
-            ey: sy + ey_delta,
+            ex,
+            ey,
             ez,
             thick,
             is_2d,
@@ -242,33 +245,33 @@ fn decode_line_bd_inv_zflag_no_bt_be(
     let sx = c
         .read_bd()
         .map_err(|e| ("BD start.x", c.position_bits(), e))?;
-    let ex_delta = c
-        .read_bd()
-        .map_err(|e| ("BD end.x", c.position_bits(), e))?;
+    let ex = c
+        .read_dd(sx)
+        .map_err(|e| ("DD end.x", c.position_bits(), e))?;
     let sy = c
         .read_bd()
         .map_err(|e| ("BD start.y", c.position_bits(), e))?;
-    let ey_delta = c
-        .read_bd()
-        .map_err(|e| ("BD end.y", c.position_bits(), e))?;
+    let ey = c
+        .read_dd(sy)
+        .map_err(|e| ("DD end.y", c.position_bits(), e))?;
     let (sz, ez) = if is_2d {
         (0.0, 0.0)
     } else {
         let sz = c
             .read_bd()
             .map_err(|e| ("BD start.z", c.position_bits(), e))?;
-        let ez_delta = c
-            .read_bd()
-            .map_err(|e| ("BD end.z", c.position_bits(), e))?;
-        (sz, sz + ez_delta)
+        let ez = c
+            .read_dd(sz)
+            .map_err(|e| ("DD end.z", c.position_bits(), e))?;
+        (sz, ez)
     };
     Ok((
         LineFields {
             sx,
             sy,
             sz,
-            ex: sx + ex_delta,
-            ey: sy + ey_delta,
+            ex,
+            ey,
             ez,
             thick: 0.0,
             is_2d,
@@ -285,25 +288,25 @@ fn decode_line_bd_inverted_zflag(
     let sx = c
         .read_bd()
         .map_err(|e| ("BD start.x", c.position_bits(), e))?;
-    let ex_delta = c
-        .read_bd()
-        .map_err(|e| ("BD end.x", c.position_bits(), e))?;
+    let ex = c
+        .read_dd(sx)
+        .map_err(|e| ("DD end.x", c.position_bits(), e))?;
     let sy = c
         .read_bd()
         .map_err(|e| ("BD start.y", c.position_bits(), e))?;
-    let ey_delta = c
-        .read_bd()
-        .map_err(|e| ("BD end.y", c.position_bits(), e))?;
+    let ey = c
+        .read_dd(sy)
+        .map_err(|e| ("DD end.y", c.position_bits(), e))?;
     let (sz, ez) = if is_2d {
         (0.0, 0.0)
     } else {
         let sz = c
             .read_bd()
             .map_err(|e| ("BD start.z", c.position_bits(), e))?;
-        let ez_delta = c
-            .read_bd()
-            .map_err(|e| ("BD end.z", c.position_bits(), e))?;
-        (sz, sz + ez_delta)
+        let ez = c
+            .read_dd(sz)
+            .map_err(|e| ("DD end.z", c.position_bits(), e))?;
+        (sz, ez)
     };
     let thick = read_bt(c).map_err(|e| ("BT thickness", c.position_bits(), e))?;
     let _ext = read_be(c).map_err(|e| ("BE extrusion", c.position_bits(), e))?;
@@ -312,8 +315,8 @@ fn decode_line_bd_inverted_zflag(
             sx,
             sy,
             sz,
-            ex: sx + ex_delta,
-            ey: sy + ey_delta,
+            ex,
+            ey,
             ez,
             thick,
             is_2d,
@@ -386,25 +389,25 @@ fn decode_line_rd(
     let sx = c
         .read_rd()
         .map_err(|e| ("RD start.x", c.position_bits(), e))?;
-    let ex_delta = c
-        .read_bd()
-        .map_err(|e| ("BD end.x", c.position_bits(), e))?;
+    let ex = c
+        .read_dd(sx)
+        .map_err(|e| ("DD end.x", c.position_bits(), e))?;
     let sy = c
         .read_rd()
         .map_err(|e| ("RD start.y", c.position_bits(), e))?;
-    let ey_delta = c
-        .read_bd()
-        .map_err(|e| ("BD end.y", c.position_bits(), e))?;
+    let ey = c
+        .read_dd(sy)
+        .map_err(|e| ("DD end.y", c.position_bits(), e))?;
     let (sz, ez) = if zflag {
         (0.0, 0.0)
     } else {
         let sz = c
             .read_rd()
             .map_err(|e| ("RD start.z", c.position_bits(), e))?;
-        let ez_delta = c
-            .read_bd()
-            .map_err(|e| ("BD end.z", c.position_bits(), e))?;
-        (sz, sz + ez_delta)
+        let ez = c
+            .read_dd(sz)
+            .map_err(|e| ("DD end.z", c.position_bits(), e))?;
+        (sz, ez)
     };
     let thick = read_bt(c).map_err(|e| ("BT thickness", c.position_bits(), e))?;
     let _ext = read_be(c).map_err(|e| ("BE extrusion", c.position_bits(), e))?;
@@ -413,8 +416,8 @@ fn decode_line_rd(
             sx,
             sy,
             sz,
-            ex: sx + ex_delta,
-            ey: sy + ey_delta,
+            ex,
+            ey,
             ez,
             thick,
             is_2d: zflag,
@@ -430,25 +433,25 @@ fn decode_line_bd(
     let sx = c
         .read_bd()
         .map_err(|e| ("BD start.x", c.position_bits(), e))?;
-    let ex_delta = c
-        .read_bd()
-        .map_err(|e| ("BD end.x", c.position_bits(), e))?;
+    let ex = c
+        .read_dd(sx)
+        .map_err(|e| ("DD end.x", c.position_bits(), e))?;
     let sy = c
         .read_bd()
         .map_err(|e| ("BD start.y", c.position_bits(), e))?;
-    let ey_delta = c
-        .read_bd()
-        .map_err(|e| ("BD end.y", c.position_bits(), e))?;
+    let ey = c
+        .read_dd(sy)
+        .map_err(|e| ("DD end.y", c.position_bits(), e))?;
     let (sz, ez) = if zflag {
         (0.0, 0.0)
     } else {
         let sz = c
             .read_bd()
             .map_err(|e| ("BD start.z", c.position_bits(), e))?;
-        let ez_delta = c
-            .read_bd()
-            .map_err(|e| ("BD end.z", c.position_bits(), e))?;
-        (sz, sz + ez_delta)
+        let ez = c
+            .read_dd(sz)
+            .map_err(|e| ("DD end.z", c.position_bits(), e))?;
+        (sz, ez)
     };
     let thick = read_bt(c).map_err(|e| ("BT thickness", c.position_bits(), e))?;
     let _ext = read_be(c).map_err(|e| ("BE extrusion", c.position_bits(), e))?;
@@ -457,8 +460,8 @@ fn decode_line_bd(
             sx,
             sy,
             sz,
-            ex: sx + ex_delta,
-            ey: sy + ey_delta,
+            ex,
+            ey,
             ez,
             thick,
             is_2d: zflag,
@@ -537,23 +540,7 @@ fn skip_to_preamble_end(c: &mut BitCursor<'_>) -> Result<(), Box<dyn std::error:
         let _ = c.read_rc()?;
     }
     let _ = c.read_handle()?;
-    // preamble (52 bits matching prior tracer):
-    let _ = c.read_bs_u()?; // XDATA terminator
-    let _ = c.read_b()?; // graphics
-    let _ = c.read_bb()?; // entmode
-    let _ = c.read_bl()?; // num_reactors
-    let _ = c.read_b()?; // no_xdict
-    let _ = c.read_b()?; // binary_chain
-    let _ = c.read_b()?; // is_on_layer
-    let _ = c.read_b()?; // non_fixed_ltype
-    let _ = c.read_bb()?; // plotstyle
-    let _ = c.read_bb()?; // material (R2007+)
-    let _ = c.read_rc()?; // shadow (R2007+)
-    let _ = c.read_b()?; // visualstyle full (R2010+)
-    let _ = c.read_b()?; // visualstyle face
-    let _ = c.read_b()?; // visualstyle edge
-    let _ = c.read_bs()?; // invisibility
-    let _ = c.read_rc()?; // lineweight
+    let _ = read_common_entity_data(c, Version::R2013)?;
     Ok(())
 }
 

--- a/examples/trace_common_entity.rs
+++ b/examples/trace_common_entity.rs
@@ -6,23 +6,14 @@
 //! meant to be compared against a clean-room reading of ODA OpenDS
 //! §19.4.1 to localize field-order drift.
 //!
-//! This exists because:
-//!   - The full decode fails with "wanted 8 bits, 5 remain" 3 bits
-//!     past the data-stream boundary.
-//!   - `invisibility` reads as -10207 (0xD821 LE u16), which is
-//!     impossible for a real LINE.
-//!   - The preamble consumes 52 bits (bit 34 → bit 86). Expected
-//!     minimum is 36 for R2013+ per the current module's field list,
-//!     so invisibility is taking the BS tag=00 literal path (18 bits).
-//!
-//! If an expected-but-missing field is inserted between plotstyle
-//! and invisibility (CMC color, BD linetype_scale, etc.), that same
-//! bit window gets eaten by the new field, invisibility lands on the
-//! real 16-bit invisibility value (0 or 1), and the LINE decoder
-//! starts at a cursor position ~20-25 bits further, eliminating the
-//! overshoot.
+//! This exists because the R2013/R2018 boundary is easy to regress:
+//! two stale compatibility bits before CMC color and a 2-bit shadow
+//! read pushed the LINE body off by 68 bits. The corrected R2013 path
+//! stops at bit 74 for `line_2013.dwg`, exactly where the typed LINE
+//! body decodes as `(50,50,0) -> (100,100,0)`.
 
 use dwg::DwgFile;
+use dwg::Version;
 use dwg::bitcursor::BitCursor;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -101,30 +92,36 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let no_xdict = c.read_b()?;
     report(&mut c, "B no_xdictionary", format!("{no_xdict}"));
 
-    let binary_chain = c.read_b()?; // R2004+
-    report(&mut c, "B binary_chain (R2004+)", format!("{binary_chain}"));
-
-    let is_on_layer = c.read_b()?;
-    report(&mut c, "B is_on_layer", format!("{is_on_layer}"));
-
-    let non_fixed_ltype = c.read_b()?;
-    report(&mut c, "B non_fixed_ltype", format!("{non_fixed_ltype}"));
-
-    // CMC color (R2004+: BS index + optional complex suffix).
-    let color_index = c.read_bs_u()?;
+    let has_ds_data = c.read_b()?; // R2013+
     report(
         &mut c,
-        "BS CMC color_index",
-        format!("{color_index} (0x{color_index:04X})"),
+        "B has_ds_binary_data (R2013+)",
+        format!("{has_ds_data}"),
     );
-    if (color_index & 0xC000) != 0 {
+
+    // CMC color (R2004+: BS index + optional complex suffix).
+    let color_raw = c.read_bs_u()?;
+    report(
+        &mut c,
+        "BS CMC raw color",
+        format!("{color_raw} (0x{color_raw:04X})"),
+    );
+    let color_flags = color_raw >> 8;
+    if color_flags & 0x20 != 0 {
+        let alpha = c.read_bl()?;
+        report(&mut c, "BL CMC alpha suffix", format!("0x{alpha:08X}"));
+    }
+    if color_flags & 0x40 == 0 && color_flags & 0x80 != 0 {
         let rgb = c.read_bl()?;
-        let has_name = c.read_b()?;
-        report(
-            &mut c,
-            "BL rgb + B name_flag (complex color)",
-            format!("rgb=0x{rgb:08X} has_name={has_name}"),
-        );
+        report(&mut c, "BL CMC rgb suffix", format!("0x{rgb:08X}"));
+    }
+    if color_flags & 0x41 == 0x41 {
+        let name = read_tv(&mut c, file.version())?;
+        report(&mut c, "TV CMC color name suffix", format!("{name:?}"));
+    }
+    if color_flags & 0x42 == 0x42 {
+        let book_name = read_tv(&mut c, file.version())?;
+        report(&mut c, "TV CMC book name suffix", format!("{book_name:?}"));
     }
 
     // BD linetype_scale.
@@ -141,12 +138,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let material = c.read_bb()?; // R2007+
     report(&mut c, "BB material (R2007+)", format!("{material}"));
 
-    let shadow = c.read_bb()?; // R2007+ — try BB (2 bits) per some ODA revisions
-    report(
-        &mut c,
-        "BB shadow_flags (R2007+) — trying 2-bit variant",
-        format!("{shadow}"),
-    );
+    let shadow = c.read_rc()?; // R2007+
+    report(&mut c, "RC shadow_flags (R2007+)", format!("{shadow}"));
 
     let vs_full = c.read_b()?; // R2010+
     let vs_face = c.read_b()?;
@@ -157,18 +150,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         format!("full={vs_full} face={vs_face} edge={vs_edge}"),
     );
 
-    // ---- THIS IS WHERE H3 SAYS MORE FIELDS BELONG ---- //
-    // Expected per spec §19.4.1 R2004+ before invisibility:
-    //   - CMC entity_color (BS + flags, ~2-18 bits)
-    //   - BD linetype_scale (2-66 bits)
-    //   - H handles (deferred to handle stream, no data-stream bits)
-    // Current decoder reads BS invisibility here — likely consuming
-    // bits that should belong to CMC / BD above.
-
     let inv = c.read_bs()?;
     report(
         &mut c,
-        "BS invisibility (SUSPECT — likely misaligned)",
+        "BS invisibility",
         format!("{inv} (0x{:04X} as i16; valid values: 0 or 1)", inv as u16),
     );
 
@@ -193,15 +178,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     println!();
     println!("Expected next: LINE body (§19.4.20)");
-    println!("  B zflag → RD start.x → BD end.x delta → RD start.y → BD end.y delta");
-    println!("  → (if !zflag: RD start.z → BD end.z delta) → BT thickness → BE extrusion");
+    println!("  B zflag → RD start.x → DD end.x → RD start.y → DD end.y");
+    println!("  → (if !zflag: RD start.z → DD end.z) → BT thickness → BE extrusion");
     println!();
     println!("Minimum 2D LINE body = 1 + 64 + 2 + 64 + 2 + 1 + 1 = 135 bits");
     println!("Minimum 3D LINE body = 135 + 64 + 2 = 201 bits");
     println!();
-    println!("If H3 holds, the preamble is missing fields that consume ~20-25 bits");
-    println!("before invisibility, so the real cursor position after preamble should");
-    println!("be ~bit 106-111, not bit 86 as currently decoded.");
+    println!("Boundary check:");
+    println!(
+        "  Run `cargo run --example trace_entity_boundary -- ../../samples/line_2013.dwg 0x13 1`."
+    );
+    println!("  For this sample, the corrected common-entity reader stops at bit 74.");
 
     Ok(())
 }
@@ -223,5 +210,33 @@ fn read_mc_unsigned(c: &mut BitCursor<'_>) -> Result<u64, dwg::Error> {
         if !cont || shift >= 64 {
             return Ok(value);
         }
+    }
+}
+
+fn read_tv(c: &mut BitCursor<'_>, version: Version) -> Result<String, Box<dyn std::error::Error>> {
+    let len = c.read_bs_u()? as usize;
+    if len == 0 {
+        return Ok(String::new());
+    }
+    if version.is_r2007_plus() {
+        let mut units = Vec::with_capacity(len);
+        for _ in 0..len {
+            let lo = c.read_rc()? as u16;
+            let hi = c.read_rc()? as u16;
+            units.push((hi << 8) | lo);
+        }
+        if units.last() == Some(&0) {
+            units.pop();
+        }
+        Ok(String::from_utf16(&units)?)
+    } else {
+        let mut bytes = Vec::with_capacity(len);
+        for _ in 0..len {
+            bytes.push(c.read_rc()?);
+        }
+        if bytes.last() == Some(&0) {
+            bytes.pop();
+        }
+        Ok(String::from_utf8_lossy(&bytes).into_owned())
     }
 }

--- a/examples/trace_entity_boundary.rs
+++ b/examples/trace_entity_boundary.rs
@@ -1,0 +1,541 @@
+//! Trace common-entity/body boundary candidates for fixed geometry entities.
+//!
+//! Usage:
+//!
+//! ```text
+//! cargo run --example trace_entity_boundary -- ../../samples/line_2013.dwg 0x13
+//! cargo run --example trace_entity_boundary -- ../../samples/sample_AC1032.dwg 0x13 20
+//! ```
+//!
+//! The tracer replays the dispatcher's current object-header + common-entity
+//! positioning, then brute-force decodes candidate body starts between the
+//! header end and data-stream end. It is diagnostic only: candidates are
+//! scored by geometric plausibility, not treated as proof.
+
+use dwg::bitcursor::BitCursor;
+use dwg::common_entity::{self, CommonEntityData};
+use dwg::entities::{arc, circle, line};
+use dwg::{DwgFile, Error, Version};
+use std::collections::BTreeMap;
+use std::env;
+use std::process::ExitCode;
+
+const TYPE_ARC: u16 = 0x11;
+const TYPE_CIRCLE: u16 = 0x12;
+const TYPE_LINE: u16 = 0x13;
+
+fn main() -> ExitCode {
+    let mut args = env::args().skip(1);
+    let Some(path) = args.next() else {
+        eprintln!("usage: trace_entity_boundary <file.dwg> [type-code=0x13] [detail-limit]");
+        return ExitCode::FAILURE;
+    };
+    let type_code = match args.next() {
+        Some(s) => match parse_type_code(&s) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("{e}");
+                return ExitCode::FAILURE;
+            }
+        },
+        None => TYPE_LINE,
+    };
+    let detail_limit = args
+        .next()
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(usize::MAX);
+
+    let file = match DwgFile::open(&path) {
+        Ok(file) => file,
+        Err(e) => {
+            eprintln!("open failed ({path}): {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let Some(objects_result) = file.all_objects() else {
+        eprintln!("{} has no handle-driven object walk", file.version());
+        return ExitCode::FAILURE;
+    };
+    let objects = match objects_result {
+        Ok(objects) => objects,
+        Err(e) => {
+            eprintln!("object walk failed: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    println!("=== {path} ===");
+    println!("version: {}", file.version());
+    println!("filter: type_code=0x{type_code:04X}");
+
+    let mut matching = 0usize;
+    let mut current_ok = 0usize;
+    let mut current_plausible = 0usize;
+    let mut with_plausible_candidate = 0usize;
+    let mut delta_hist: Vec<isize> = Vec::new();
+    let mut start_delta_hist: BTreeMap<isize, usize> = BTreeMap::new();
+    let mut end_delta_hist: BTreeMap<isize, usize> = BTreeMap::new();
+    let mut current_common_bits_hist: BTreeMap<usize, usize> = BTreeMap::new();
+    let mut candidate_common_bits_hist: BTreeMap<usize, usize> = BTreeMap::new();
+    let mut candidate_start_hist: BTreeMap<usize, usize> = BTreeMap::new();
+    let mut no_candidate_examples = Vec::new();
+    let mut matching_handle_offsets: BTreeMap<u64, Vec<(usize, usize)>> = BTreeMap::new();
+    let mut detail_count = 0usize;
+
+    for (object_index, raw) in objects.iter().enumerate() {
+        if raw.type_code != type_code {
+            continue;
+        }
+        matching += 1;
+        matching_handle_offsets
+            .entry(raw.handle.value)
+            .or_default()
+            .push((object_index, raw.stream_offset));
+        let trace = trace_raw_object(raw, file.version(), type_code);
+        if trace.current_decode_ok {
+            current_ok += 1;
+        }
+        if trace.current_plausible {
+            current_plausible += 1;
+        }
+        if let Some(best) = trace.best_candidate.as_ref() {
+            with_plausible_candidate += 1;
+            if let Some(current) = trace.current_body_start {
+                let delta = best.start_bit as isize - current as isize;
+                delta_hist.push(delta);
+                *start_delta_hist.entry(delta).or_insert(0) += 1;
+            }
+            if let Some(data_end) = trace.data_end {
+                *end_delta_hist
+                    .entry(best.end_bit as isize - data_end as isize)
+                    .or_insert(0) += 1;
+            }
+            if let Some(header_end) = trace.header_end {
+                *candidate_common_bits_hist
+                    .entry(best.start_bit.saturating_sub(header_end))
+                    .or_insert(0) += 1;
+            }
+            *candidate_start_hist.entry(best.start_bit).or_insert(0) += 1;
+        } else if no_candidate_examples.len() < 5 {
+            no_candidate_examples.push(format!(
+                "#{} handle=0x{:X} current_common_end={:?}",
+                object_index, raw.handle.value, trace.current_body_start
+            ));
+        }
+
+        if let (Some(header_end), Some(current)) = (trace.header_end, trace.current_body_start) {
+            *current_common_bits_hist
+                .entry(current.saturating_sub(header_end))
+                .or_insert(0) += 1;
+        }
+
+        if detail_count < detail_limit {
+            detail_count += 1;
+            print_trace(object_index, raw, &trace);
+        }
+    }
+
+    println!();
+    println!("=== summary ===");
+    println!("matching objects: {matching}");
+    println!("current decoder ok: {current_ok}");
+    println!("current decoder plausible: {current_plausible}");
+    println!("objects with plausible scanned candidate: {with_plausible_candidate}");
+    if !delta_hist.is_empty() {
+        let min = delta_hist.iter().min().unwrap();
+        let max = delta_hist.iter().max().unwrap();
+        let sum: isize = delta_hist.iter().sum();
+        let avg = sum as f64 / delta_hist.len() as f64;
+        println!(
+            "best_candidate_start - current_common_end: min={min} max={max} avg={avg:.1} bits"
+        );
+    }
+    print_hist("current common bits", &current_common_bits_hist);
+    print_hist("candidate common bits", &candidate_common_bits_hist);
+    print_hist("candidate start bit", &candidate_start_hist);
+    print_hist(
+        "best_candidate_start - current_common_end",
+        &start_delta_hist,
+    );
+    print_hist("best_candidate_end - data_end", &end_delta_hist);
+    if !no_candidate_examples.is_empty() {
+        println!(
+            "objects without plausible scanned candidate: {}",
+            no_candidate_examples.join(", ")
+        );
+    }
+    let duplicate_handles = matching_handle_offsets
+        .iter()
+        .filter(|(_, offsets)| offsets.len() > 1)
+        .map(|(handle, offsets)| {
+            let rendered_offsets = offsets
+                .iter()
+                .map(|(index, offset)| format!("#{index}@{offset}"))
+                .collect::<Vec<_>>()
+                .join("/");
+            format!("0x{handle:X}={rendered_offsets}")
+        })
+        .collect::<Vec<_>>();
+    if !duplicate_handles.is_empty() {
+        println!(
+            "duplicate matching handles: {}",
+            duplicate_handles.join(", ")
+        );
+    }
+
+    ExitCode::SUCCESS
+}
+
+struct BoundaryTrace {
+    header_end: Option<usize>,
+    handle_stream_bits: Option<u64>,
+    data_end: Option<usize>,
+    current_body_start: Option<usize>,
+    common: Option<CommonEntityData>,
+    common_error: Option<String>,
+    current_decode: String,
+    current_decode_ok: bool,
+    current_plausible: bool,
+    best_candidate: Option<Candidate>,
+    candidates: Vec<Candidate>,
+}
+
+struct Candidate {
+    start_bit: usize,
+    end_bit: usize,
+    over_data_end: isize,
+    plausible: bool,
+    summary: String,
+    score: i32,
+}
+
+fn print_hist<K>(label: &str, hist: &BTreeMap<K, usize>)
+where
+    K: std::fmt::Display + Ord,
+{
+    if hist.is_empty() {
+        return;
+    }
+    let rendered = hist
+        .iter()
+        .map(|(value, count)| format!("{value}:{count}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    println!("{label}: {rendered}");
+}
+
+fn trace_raw_object(
+    raw: &dwg::object::RawObject,
+    version: Version,
+    type_code: u16,
+) -> BoundaryTrace {
+    let header = replay_header(&raw.raw, version);
+    let (header_end, handle_stream_bits, data_end) = match header {
+        Ok(header) => (
+            Some(header.header_end),
+            header.handle_stream_bits,
+            header.data_end,
+        ),
+        Err(e) => {
+            return BoundaryTrace {
+                header_end: None,
+                handle_stream_bits: None,
+                data_end: None,
+                current_body_start: None,
+                common: None,
+                common_error: Some(format!("header replay: {e}")),
+                current_decode: "header replay failed".to_string(),
+                current_decode_ok: false,
+                current_plausible: false,
+                best_candidate: None,
+                candidates: Vec::new(),
+            };
+        }
+    };
+
+    let mut cursor = BitCursor::new(&raw.raw);
+    skip_to(&mut cursor, header_end.unwrap()).ok();
+    let (current_body_start, common, common_error) =
+        match common_entity::read_common_entity_data(&mut cursor, version) {
+            Ok(common) => (Some(cursor.position_bits()), Some(common), None),
+            Err(e) => (Some(cursor.position_bits()), None, Some(e.to_string())),
+        };
+
+    let (current_decode, current_decode_ok, current_plausible) = if common_error.is_none() {
+        decode_candidate(&raw.raw, type_code, cursor.position_bits(), data_end)
+            .map(|hit| (hit.summary, true, hit.plausible))
+            .unwrap_or_else(|e| (format!("ERR {e}"), false, false))
+    } else {
+        ("common preamble failed".to_string(), false, false)
+    };
+
+    let mut candidates = Vec::new();
+    if let (Some(header_end), Some(data_end)) = (header_end, data_end) {
+        for start_bit in header_end..=data_end.min(raw.raw.len() * 8) {
+            if let Ok(mut hit) = decode_candidate(&raw.raw, type_code, start_bit, Some(data_end)) {
+                if hit.plausible {
+                    let distance_to_data_end = (hit.end_bit as isize - data_end as isize).abs();
+                    hit.score += 1000 - distance_to_data_end.min(1000) as i32;
+                    if Some(start_bit) == current_body_start {
+                        hit.score += 5000;
+                    }
+                    candidates.push(hit);
+                }
+            }
+        }
+    }
+    candidates.sort_by(|a, b| b.score.cmp(&a.score).then(a.start_bit.cmp(&b.start_bit)));
+    candidates.truncate(5);
+    let best_candidate = candidates.first().map(|c| Candidate {
+        start_bit: c.start_bit,
+        end_bit: c.end_bit,
+        over_data_end: c.over_data_end,
+        plausible: c.plausible,
+        summary: c.summary.clone(),
+        score: c.score,
+    });
+
+    BoundaryTrace {
+        header_end,
+        handle_stream_bits,
+        data_end,
+        current_body_start,
+        common,
+        common_error,
+        current_decode,
+        current_decode_ok,
+        current_plausible,
+        best_candidate,
+        candidates,
+    }
+}
+
+struct HeaderReplay {
+    header_end: usize,
+    handle_stream_bits: Option<u64>,
+    data_end: Option<usize>,
+}
+
+fn replay_header(payload: &[u8], version: Version) -> Result<HeaderReplay, Error> {
+    let mut c = BitCursor::new(payload);
+    let handle_stream_bits = if version.is_r2010_plus() {
+        Some(read_mc_unsigned(&mut c)?)
+    } else {
+        None
+    };
+    let _type_code = read_object_type(&mut c, version)?;
+    if matches!(version, Version::R2000) {
+        let _object_size_bits = c.read_rl()?;
+    }
+    let _handle = c.read_handle()?;
+    let data_end =
+        handle_stream_bits.and_then(|bits| (payload.len() * 8).checked_sub(bits as usize));
+    Ok(HeaderReplay {
+        header_end: c.position_bits(),
+        handle_stream_bits,
+        data_end,
+    })
+}
+
+fn decode_candidate(
+    payload: &[u8],
+    type_code: u16,
+    start_bit: usize,
+    data_end: Option<usize>,
+) -> Result<Candidate, String> {
+    let mut c = BitCursor::new(payload);
+    skip_to(&mut c, start_bit).map_err(|e| e.to_string())?;
+    let (summary, plausible) = match type_code {
+        TYPE_LINE => {
+            let l = line::decode(&mut c).map_err(|e| e.to_string())?;
+            let dx = l.end.x - l.start.x;
+            let dy = l.end.y - l.start.y;
+            let dz = l.end.z - l.start.z;
+            let len = (dx * dx + dy * dy + dz * dz).sqrt();
+            let plausible = finite_abs(l.start.x)
+                && finite_abs(l.start.y)
+                && finite_abs(l.start.z)
+                && finite_abs(l.end.x)
+                && finite_abs(l.end.y)
+                && finite_abs(l.end.z)
+                && finite_abs(l.thickness)
+                && len.is_finite()
+                && len > 1e-9
+                && len < 1e9;
+            (
+                format!(
+                    "LINE 2d={} start=({:.6},{:.6},{:.6}) end=({:.6},{:.6},{:.6}) len={:.6} th={:.3e}",
+                    l.is_2d,
+                    l.start.x,
+                    l.start.y,
+                    l.start.z,
+                    l.end.x,
+                    l.end.y,
+                    l.end.z,
+                    len,
+                    l.thickness
+                ),
+                plausible,
+            )
+        }
+        TYPE_CIRCLE => {
+            let circ = circle::decode(&mut c).map_err(|e| e.to_string())?;
+            let plausible = finite_abs(circ.center.x)
+                && finite_abs(circ.center.y)
+                && finite_abs(circ.center.z)
+                && circ.radius.is_finite()
+                && circ.radius > 1e-9
+                && circ.radius < 1e9
+                && finite_abs(circ.thickness);
+            (
+                format!(
+                    "CIRCLE center=({:.6},{:.6},{:.6}) radius={:.6} th={:.3e}",
+                    circ.center.x, circ.center.y, circ.center.z, circ.radius, circ.thickness
+                ),
+                plausible,
+            )
+        }
+        TYPE_ARC => {
+            let a = arc::decode(&mut c).map_err(|e| e.to_string())?;
+            let plausible = finite_abs(a.center.x)
+                && finite_abs(a.center.y)
+                && finite_abs(a.center.z)
+                && a.radius.is_finite()
+                && a.radius > 1e-9
+                && a.radius < 1e9
+                && finite_abs(a.thickness)
+                && a.start_angle.is_finite()
+                && a.end_angle.is_finite();
+            (
+                format!(
+                    "ARC center=({:.6},{:.6},{:.6}) radius={:.6} start={:.6} end={:.6}",
+                    a.center.x, a.center.y, a.center.z, a.radius, a.start_angle, a.end_angle
+                ),
+                plausible,
+            )
+        }
+        _ => return Err(format!("unsupported scan type 0x{type_code:04X}")),
+    };
+    let end_bit = c.position_bits();
+    let over_data_end = data_end
+        .map(|end| end_bit as isize - end as isize)
+        .unwrap_or(0);
+    Ok(Candidate {
+        start_bit,
+        end_bit,
+        over_data_end,
+        plausible,
+        summary,
+        score: if plausible { 100 } else { 0 },
+    })
+}
+
+fn finite_abs(v: f64) -> bool {
+    v.is_finite() && v.abs() < 1e9
+}
+
+fn print_trace(object_index: usize, raw: &dwg::object::RawObject, trace: &BoundaryTrace) {
+    println!();
+    println!(
+        "#{} handle=0x{:X} offset={} size={} type=0x{:04X} {:?}",
+        object_index, raw.handle.value, raw.stream_offset, raw.size_bytes, raw.type_code, raw.kind
+    );
+    println!(
+        "  header_end={:?} handle_stream_bits={:?} data_end={:?} current_common_end={:?}",
+        trace.header_end, trace.handle_stream_bits, trace.data_end, trace.current_body_start
+    );
+    if let Some(common) = trace.common.as_ref() {
+        println!(
+            "  common mode={:?} reactors={} no_xdict={} has_ds_data={} legacy_layer={} legacy_non_fixed_ltype={} plot={} material={} shadow={} invis={} lineweight=0x{:02X}",
+            common.mode,
+            common.num_reactors,
+            common.no_xdictionary,
+            common.binary_chain,
+            common.is_on_layer,
+            common.non_fixed_ltype,
+            common.plotstyle_flag,
+            common.material_flag,
+            common.shadow_flags,
+            common.invisibility,
+            common.lineweight,
+        );
+    }
+    if let Some(e) = trace.common_error.as_ref() {
+        println!("  common error: {e}");
+    }
+    println!(
+        "  current decode: {}{}",
+        if trace.current_plausible {
+            "PLAUSIBLE "
+        } else if trace.current_decode_ok {
+            "decoded-but-implausible "
+        } else {
+            ""
+        },
+        trace.current_decode
+    );
+    if trace.candidates.is_empty() {
+        println!("  plausible scan candidates: none");
+    } else {
+        println!("  plausible scan candidates:");
+        for c in &trace.candidates {
+            println!(
+                "    bit {:>3} -> {:>3} ({:+} vs data_end): {}",
+                c.start_bit, c.end_bit, c.over_data_end, c.summary
+            );
+        }
+    }
+}
+
+fn skip_to(c: &mut BitCursor<'_>, bit: usize) -> Result<(), Error> {
+    while c.position_bits() < bit {
+        let _ = c.read_b()?;
+    }
+    Ok(())
+}
+
+fn read_mc_unsigned(c: &mut BitCursor<'_>) -> Result<u64, Error> {
+    let mut value: u64 = 0;
+    let mut shift: u32 = 0;
+    loop {
+        let b = c.read_rc()? as u64;
+        let cont = (b & 0x80) != 0;
+        let data = b & 0x7F;
+        value |= data << shift;
+        shift += 7;
+        if !cont || shift >= 64 {
+            return Ok(value);
+        }
+    }
+}
+
+fn read_object_type(c: &mut BitCursor<'_>, version: Version) -> Result<u16, Error> {
+    if version.is_r2010_plus() {
+        let tag = c.read_bb()?;
+        match tag {
+            0 => Ok(c.read_rc()? as u16),
+            1 => Ok((c.read_rc()? as u16) + 0x1F0),
+            _ => {
+                let lsb = c.read_rc()? as u16;
+                let msb = c.read_rc()? as u16;
+                Ok((msb << 8) | lsb)
+            }
+        }
+    } else {
+        Ok(c.read_bs_u()?)
+    }
+}
+
+fn parse_type_code(s: &str) -> Result<u16, String> {
+    let trimmed = s.trim();
+    if let Some(hex) = trimmed
+        .strip_prefix("0x")
+        .or_else(|| trimmed.strip_prefix("0X"))
+    {
+        u16::from_str_radix(hex, 16).map_err(|e| format!("invalid hex type code {s}: {e}"))
+    } else {
+        trimmed
+            .parse::<u16>()
+            .map_err(|e| format!("invalid type code {s}: {e}"))
+    }
+}

--- a/examples/trace_table_entry.rs
+++ b/examples/trace_table_entry.rs
@@ -1,0 +1,647 @@
+//! Trace table-entry decoder boundary/order candidates.
+//!
+//! Usage:
+//!
+//! ```text
+//! cargo run --example trace_table_entry -- ../../samples/sample_AC1032.dwg 0x31 8
+//! ```
+
+use dwg::bitcursor::BitCursor;
+use dwg::{DwgFile, Error, Version};
+use std::env;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let mut args = env::args().skip(1);
+    let Some(path) = args.next() else {
+        eprintln!("usage: trace_table_entry <file.dwg> [type-code=0x31] [detail-limit]");
+        return ExitCode::FAILURE;
+    };
+    let type_code = match args.next() {
+        Some(s) => match parse_type_code(&s) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("{e}");
+                return ExitCode::FAILURE;
+            }
+        },
+        None => 0x31,
+    };
+    let detail_limit = args
+        .next()
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(usize::MAX);
+
+    let file = match DwgFile::open(&path) {
+        Ok(file) => file,
+        Err(e) => {
+            eprintln!("open failed ({path}): {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let Some(objects_result) = file.all_objects() else {
+        eprintln!("{} has no handle-driven object walk", file.version());
+        return ExitCode::FAILURE;
+    };
+    let objects = match objects_result {
+        Ok(objects) => objects,
+        Err(e) => {
+            eprintln!("object walk failed: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let mut matching = 0usize;
+    let mut current_ok = 0usize;
+    let mut current_with_preamble_ok = 0usize;
+    let mut spec_block_ok = 0usize;
+    let mut spec_block_no_preamble_ok = 0usize;
+    let mut detail_count = 0usize;
+
+    println!("=== {path} ===");
+    println!("version: {}", file.version());
+    println!("filter: type_code=0x{type_code:04X}");
+
+    for (object_index, raw) in objects.iter().enumerate() {
+        if raw.type_code != type_code {
+            continue;
+        }
+        matching += 1;
+        let header = match replay_header(&raw.raw, file.version()) {
+            Ok(header) => header,
+            Err(e) => {
+                if detail_count < detail_limit {
+                    detail_count += 1;
+                    println!();
+                    println!(
+                        "#{object_index} handle=0x{:X} offset={} size={} header replay failed: {e}",
+                        raw.handle.value, raw.stream_offset, raw.size_bytes
+                    );
+                }
+                continue;
+            }
+        };
+
+        let current = decode_current(&raw.raw, file.version(), header.header_end);
+        let current_with_preamble =
+            decode_current_after_preamble(&raw.raw, file.version(), header.header_end);
+        let spec_block = decode_spec_block(&raw.raw, file.version(), header.header_end, true);
+        let spec_block_no_preamble =
+            decode_spec_block(&raw.raw, file.version(), header.header_end, false);
+
+        if current.ok {
+            current_ok += 1;
+        }
+        if current_with_preamble.ok {
+            current_with_preamble_ok += 1;
+        }
+        if spec_block.ok {
+            spec_block_ok += 1;
+        }
+        if spec_block_no_preamble.ok {
+            spec_block_no_preamble_ok += 1;
+        }
+
+        if detail_count < detail_limit {
+            detail_count += 1;
+            println!();
+            println!(
+                "#{object_index} handle=0x{:X} offset={} size={} raw_bits={} kind={:?}",
+                raw.handle.value,
+                raw.stream_offset,
+                raw.size_bytes,
+                raw.raw.len() * 8,
+                raw.kind
+            );
+            println!(
+                "  header_end={} handle_stream_bits={:?} data_end={:?}",
+                header.header_end, header.handle_stream_bits, header.data_end
+            );
+            if let Some(data_end) = header.data_end {
+                println!(
+                    "  data window: {}",
+                    hex_window(&raw.raw, header.header_end, data_end)
+                );
+                println!(
+                    "  first data bits: {}",
+                    bits_window(&raw.raw, header.header_end, header.header_end + 48)
+                );
+                let hits = scan_printable_tu(&raw.raw, header.header_end, data_end);
+                if !hits.is_empty() {
+                    println!("  printable TU scan: {}", hits.join("; "));
+                }
+                println!(
+                    "  tail size probes: {}",
+                    tail_size_probes(&raw.raw, data_end)
+                );
+            }
+            if let Some(split) = trace_string_split(&raw.raw, header.data_end) {
+                println!(
+                    "  string split guess: present={} size={} start={} end={} bytes={}",
+                    split.present,
+                    split.size_bits,
+                    split.start_bit,
+                    split.end_bit,
+                    hex_window(&raw.raw, split.start_bit, split.end_bit)
+                );
+            }
+            print_attempt("current", &current, header.data_end);
+            print_attempt(
+                "current+object-preamble",
+                &current_with_preamble,
+                header.data_end,
+            );
+            print_attempt("spec-block", &spec_block, header.data_end);
+            print_attempt(
+                "spec-block-no-preamble",
+                &spec_block_no_preamble,
+                header.data_end,
+            );
+            if type_code == 0x39 {
+                let ltype_modern =
+                    decode_modern_ltype_probe(&raw.raw, file.version(), header.header_end);
+                print_attempt("ltype-modern-probe", &ltype_modern, header.data_end);
+            }
+        }
+    }
+
+    println!();
+    println!("=== summary ===");
+    println!("matching objects: {matching}");
+    println!("current decoder ok: {current_ok}");
+    println!("current+object-preamble ok: {current_with_preamble_ok}");
+    println!("spec-block ok: {spec_block_ok}");
+    println!("spec-block-no-preamble ok: {spec_block_no_preamble_ok}");
+
+    ExitCode::SUCCESS
+}
+
+#[derive(Debug)]
+struct HeaderReplay {
+    header_end: usize,
+    handle_stream_bits: Option<u64>,
+    data_end: Option<usize>,
+}
+
+#[derive(Debug)]
+struct Attempt {
+    ok: bool,
+    end_bit: Option<usize>,
+    summary: String,
+}
+
+struct StringSplitTrace {
+    present: bool,
+    size_bits: usize,
+    start_bit: usize,
+    end_bit: usize,
+}
+
+fn replay_header(payload: &[u8], version: Version) -> Result<HeaderReplay, Error> {
+    let mut c = BitCursor::new(payload);
+    let handle_stream_bits = if version.is_r2010_plus() {
+        Some(read_mc_unsigned(&mut c)?)
+    } else {
+        None
+    };
+    let _type_code = read_object_type(&mut c, version)?;
+    if matches!(version, Version::R2000) {
+        let _object_size_bits = c.read_rl()?;
+    }
+    let _handle = c.read_handle()?;
+    let data_end =
+        handle_stream_bits.and_then(|bits| (payload.len() * 8).checked_sub(bits as usize));
+    Ok(HeaderReplay {
+        header_end: c.position_bits(),
+        handle_stream_bits,
+        data_end,
+    })
+}
+
+fn decode_current(payload: &[u8], version: Version, start_bit: usize) -> Attempt {
+    let mut c = BitCursor::new(payload);
+    if let Err(e) = skip_to(&mut c, start_bit) {
+        return fail(e.to_string(), c.position_bits());
+    }
+    match dwg::tables::block_record::decode(&mut c, version) {
+        Ok(block) => Attempt {
+            ok: true,
+            end_bit: Some(c.position_bits()),
+            summary: format!(
+                "name={:?} owned={:?} base=({:.3},{:.3},{:.3}) xref={:?}",
+                block.header.name,
+                block.num_owned_objects,
+                block.base_point.x,
+                block.base_point.y,
+                block.base_point.z,
+                block.xref_path
+            ),
+        },
+        Err(e) => fail(e.to_string(), c.position_bits()),
+    }
+}
+
+fn decode_current_after_preamble(payload: &[u8], version: Version, start_bit: usize) -> Attempt {
+    let mut c = BitCursor::new(payload);
+    if let Err(e) = skip_to(&mut c, start_bit).and_then(|_| read_object_preamble(&mut c, version)) {
+        return fail(e.to_string(), c.position_bits());
+    }
+    match dwg::tables::block_record::decode(&mut c, version) {
+        Ok(block) => Attempt {
+            ok: true,
+            end_bit: Some(c.position_bits()),
+            summary: format!(
+                "name={:?} owned={:?} base=({:.3},{:.3},{:.3}) xref={:?}",
+                block.header.name,
+                block.num_owned_objects,
+                block.base_point.x,
+                block.base_point.y,
+                block.base_point.z,
+                block.xref_path
+            ),
+        },
+        Err(e) => fail(e.to_string(), c.position_bits()),
+    }
+}
+
+fn decode_spec_block(
+    payload: &[u8],
+    version: Version,
+    start_bit: usize,
+    with_preamble: bool,
+) -> Attempt {
+    let mut c = BitCursor::new(payload);
+    let setup = skip_to(&mut c, start_bit).and_then(|_| {
+        if with_preamble {
+            read_object_preamble(&mut c, version)
+        } else {
+            Ok(())
+        }
+    });
+    if let Err(e) = setup {
+        return fail(e.to_string(), c.position_bits());
+    }
+
+    let result = (|| -> Result<String, Error> {
+        let name = read_tv(&mut c, version)?;
+        let flag64 = c.read_b()?;
+        let xref_index_plus_1 = c.read_bs()?;
+        let xdep = c.read_b()?;
+        let anonymous = c.read_b()?;
+        let has_atts = c.read_b()?;
+        let is_xref = c.read_b()?;
+        let xref_overlay = c.read_b()?;
+        let loaded = if is_r2000_plus(version) {
+            Some(c.read_b()?)
+        } else {
+            None
+        };
+        let owned = if version.is_r2004_plus() {
+            Some(c.read_bl()?)
+        } else {
+            None
+        };
+        let base_x = c.read_bd()?;
+        let base_y = c.read_bd()?;
+        let base_z = c.read_bd()?;
+        let xref_path = read_tv(&mut c, version)?;
+        let mut insert_count_bytes = 0usize;
+        if is_r2000_plus(version) {
+            loop {
+                let b = c.read_rc()?;
+                if b == 0 {
+                    break;
+                }
+                insert_count_bytes += 1;
+                if insert_count_bytes > 100_000 {
+                    return Err(Error::SectionMap(
+                        "BLOCK_HEADER insert count exceeds cap".into(),
+                    ));
+                }
+            }
+            let _description = read_tv(&mut c, version)?;
+            let preview_bytes = c.read_bl_u()? as usize;
+            for _ in 0..preview_bytes {
+                let _ = c.read_rc()?;
+            }
+        }
+        let insert_units = if version.is_r2007_plus() {
+            Some(c.read_bs()?)
+        } else {
+            None
+        };
+        let explodable = if version.is_r2007_plus() {
+            Some(c.read_b()?)
+        } else {
+            None
+        };
+        let scaling = if version.is_r2007_plus() {
+            Some(c.read_rc()?)
+        } else {
+            None
+        };
+        Ok(format!(
+            "name={name:?} flag64={flag64} xref_index_plus_1={xref_index_plus_1} xdep={xdep} anon={anonymous} has_atts={has_atts} is_xref={is_xref} overlay={xref_overlay} loaded={loaded:?} owned={owned:?} base=({base_x:.3},{base_y:.3},{base_z:.3}) xref={xref_path:?} insert_refs={insert_count_bytes} units={insert_units:?} explodable={explodable:?} scaling={scaling:?}"
+        ))
+    })();
+
+    match result {
+        Ok(summary) => Attempt {
+            ok: true,
+            end_bit: Some(c.position_bits()),
+            summary,
+        },
+        Err(e) => fail(e.to_string(), c.position_bits()),
+    }
+}
+
+fn read_object_preamble(c: &mut BitCursor<'_>, version: Version) -> Result<(), Error> {
+    loop {
+        let size = c.read_bs_u()?;
+        if size == 0 {
+            break;
+        }
+        let _appid = c.read_handle()?;
+        for _ in 0..size {
+            let _ = c.read_rc()?;
+        }
+    }
+    let _num_reactors = c.read_bl()?;
+    if version.is_r2004_plus() {
+        let _no_xdictionary = c.read_b()?;
+    }
+    Ok(())
+}
+
+fn decode_modern_ltype_probe(payload: &[u8], version: Version, start_bit: usize) -> Attempt {
+    let mut c = BitCursor::new(payload);
+    if let Err(e) =
+        skip_to(&mut c, start_bit).and_then(|_| read_table_object_prefix_probe(&mut c, version))
+    {
+        return fail(e.to_string(), c.position_bits());
+    }
+    let prefix_end = c.position_bits();
+    let result = (|| -> Result<String, Error> {
+        let flag64 = c.read_b()?;
+        let xref_index_plus_1 = c.read_bs()?;
+        let xdep = c.read_b()?;
+        let pattern_len = c.read_bd()?;
+        let alignment = c.read_rc()?;
+        let num_dashes = c.read_rc()? as usize;
+        for _ in 0..num_dashes.min(256) {
+            let _length = c.read_bd()?;
+            let _shape_number = c.read_bs()?;
+            let _x_offset = c.read_rd()?;
+            let _y_offset = c.read_rd()?;
+            let _scale = c.read_bd()?;
+            let _rotation = c.read_bd()?;
+            let _shape_flag = c.read_bs()?;
+        }
+        let string_start = c.position_bits();
+        let name = read_tv(&mut c, version)?;
+        let desc = read_tv(&mut c, version).unwrap_or_default();
+        Ok(format!(
+            "prefix_end={prefix_end} flag64={flag64} xref_index_plus_1={xref_index_plus_1} xdep={xdep} pattern_len={pattern_len:.3} alignment=0x{alignment:02X} num_dashes={num_dashes} string_start={string_start} name={name:?} desc={desc:?}"
+        ))
+    })();
+    match result {
+        Ok(summary) => Attempt {
+            ok: true,
+            end_bit: Some(c.position_bits()),
+            summary,
+        },
+        Err(e) => fail(e.to_string(), c.position_bits()),
+    }
+}
+
+fn read_table_object_prefix_probe(c: &mut BitCursor<'_>, version: Version) -> Result<(), Error> {
+    for _ in 0..256 {
+        let size = c.read_bs_u()? as usize;
+        if size == 0 {
+            break;
+        }
+        let _appid = c.read_handle()?;
+        for _ in 0..size {
+            let _ = c.read_rc()?;
+        }
+    }
+    if version.is_r2004_plus() {
+        let _no_xdictionary = c.read_b()?;
+    }
+    if matches!(version, Version::R2013 | Version::R2018) {
+        let _has_binary_data = c.read_b()?;
+    }
+    Ok(())
+}
+
+fn read_tv(c: &mut BitCursor<'_>, version: Version) -> Result<String, Error> {
+    let len = c.read_bs_u()? as usize;
+    if len == 0 {
+        return Ok(String::new());
+    }
+    if version.is_r2007_plus() {
+        let mut units = Vec::with_capacity(len);
+        for _ in 0..len {
+            let lo = c.read_rc()? as u16;
+            let hi = c.read_rc()? as u16;
+            units.push((hi << 8) | lo);
+        }
+        if units.last() == Some(&0) {
+            units.pop();
+        }
+        String::from_utf16(&units)
+            .map_err(|_| Error::SectionMap("table entry name is not valid UTF-16".into()))
+    } else {
+        let mut bytes = Vec::with_capacity(len);
+        for _ in 0..len {
+            bytes.push(c.read_rc()?);
+        }
+        if bytes.last() == Some(&0) {
+            bytes.pop();
+        }
+        Ok(String::from_utf8_lossy(&bytes).into_owned())
+    }
+}
+
+fn print_attempt(label: &str, attempt: &Attempt, data_end: Option<usize>) {
+    let delta = match (attempt.end_bit, data_end) {
+        (Some(end), Some(data_end)) => {
+            format!(" ({:+} vs data_end)", end as isize - data_end as isize)
+        }
+        _ => String::new(),
+    };
+    println!(
+        "  {label}: {} end={:?}{delta} {}",
+        if attempt.ok { "ok" } else { "ERR" },
+        attempt.end_bit,
+        attempt.summary
+    );
+}
+
+fn trace_string_split(payload: &[u8], data_end: Option<usize>) -> Option<StringSplitTrace> {
+    let data_end = data_end?;
+    if data_end < 17 {
+        return None;
+    }
+    let present = read_bit_at(payload, data_end - 1)?;
+    if !present {
+        return Some(StringSplitTrace {
+            present,
+            size_bits: 0,
+            start_bit: data_end,
+            end_bit: data_end,
+        });
+    }
+    let size_start = data_end.checked_sub(17)?;
+    let size_bits = read_raw_u16_at(payload, size_start)? as usize;
+    let end_bit = size_start;
+    let start_bit = end_bit.checked_sub(size_bits)?;
+    Some(StringSplitTrace {
+        present,
+        size_bits,
+        start_bit,
+        end_bit,
+    })
+}
+
+fn read_bit_at(bytes: &[u8], bit: usize) -> Option<bool> {
+    let byte = *bytes.get(bit / 8)?;
+    let shift = 7 - (bit % 8);
+    Some(((byte >> shift) & 1) != 0)
+}
+
+fn read_raw_u16_at(bytes: &[u8], bit: usize) -> Option<u16> {
+    let mut c = BitCursor::new(bytes);
+    skip_to(&mut c, bit).ok()?;
+    c.read_rs().ok().map(|value| value as u16)
+}
+
+fn hex_window(bytes: &[u8], start_bit: usize, end_bit: usize) -> String {
+    let start = start_bit / 8;
+    let end = end_bit.div_ceil(8).min(bytes.len());
+    bytes
+        .get(start..end)
+        .unwrap_or_default()
+        .iter()
+        .map(|b| format!("{b:02X}"))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn bits_window(bytes: &[u8], start_bit: usize, end_bit: usize) -> String {
+    (start_bit..end_bit)
+        .filter_map(|bit| read_bit_at(bytes, bit).map(|value| if value { '1' } else { '0' }))
+        .collect()
+}
+
+fn scan_printable_tu(bytes: &[u8], start_bit: usize, end_bit: usize) -> Vec<String> {
+    let mut hits = Vec::new();
+    for bit in start_bit..end_bit {
+        let mut c = BitCursor::new(bytes);
+        if skip_to(&mut c, bit).is_err() {
+            continue;
+        }
+        let Ok(s) = read_tv(&mut c, Version::R2018) else {
+            continue;
+        };
+        let end = c.position_bits();
+        if s.len() >= 2
+            && s.len() <= 80
+            && s.chars()
+                .all(|ch| ch == '\0' || ch == '\n' || ch == '\r' || !ch.is_control())
+        {
+            hits.push(format!("bit {bit}->{end}: {s:?}"));
+            if hits.len() >= 8 {
+                break;
+            }
+        }
+    }
+    hits
+}
+
+fn tail_size_probes(bytes: &[u8], data_end: usize) -> String {
+    let start = data_end.saturating_sub(32);
+    (start..data_end)
+        .filter_map(|bit| {
+            let raw = read_raw_u16_at(bytes, bit)?;
+            let bs = read_bs_u_at(bytes, bit)?;
+            if raw <= 512 || bs <= 512 {
+                Some(format!("{bit}:raw={raw},bs={bs}"))
+            } else {
+                None
+            }
+        })
+        .take(12)
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+fn read_bs_u_at(bytes: &[u8], bit: usize) -> Option<u16> {
+    let mut c = BitCursor::new(bytes);
+    skip_to(&mut c, bit).ok()?;
+    c.read_bs_u().ok()
+}
+
+fn fail(message: String, bit: usize) -> Attempt {
+    Attempt {
+        ok: false,
+        end_bit: Some(bit),
+        summary: message,
+    }
+}
+
+fn skip_to(c: &mut BitCursor<'_>, bit: usize) -> Result<(), Error> {
+    while c.position_bits() < bit {
+        let _ = c.read_b()?;
+    }
+    Ok(())
+}
+
+fn read_mc_unsigned(c: &mut BitCursor<'_>) -> Result<u64, Error> {
+    let mut value: u64 = 0;
+    let mut shift: u32 = 0;
+    loop {
+        let b = c.read_rc()? as u64;
+        let cont = (b & 0x80) != 0;
+        value |= (b & 0x7F) << shift;
+        shift += 7;
+        if !cont || shift >= 64 {
+            return Ok(value);
+        }
+    }
+}
+
+fn read_object_type(c: &mut BitCursor<'_>, version: Version) -> Result<u16, Error> {
+    if version.is_r2010_plus() {
+        let tag = c.read_bb()?;
+        match tag {
+            0 => Ok(c.read_rc()? as u16),
+            1 => Ok((c.read_rc()? as u16) + 0x1F0),
+            _ => {
+                let lsb = c.read_rc()? as u16;
+                let msb = c.read_rc()? as u16;
+                Ok((msb << 8) | lsb)
+            }
+        }
+    } else {
+        Ok(c.read_bs_u()?)
+    }
+}
+
+fn is_r2000_plus(version: Version) -> bool {
+    !matches!(version, Version::R14)
+}
+
+fn parse_type_code(s: &str) -> Result<u16, String> {
+    let trimmed = s.trim();
+    if let Some(hex) = trimmed
+        .strip_prefix("0x")
+        .or_else(|| trimmed.strip_prefix("0X"))
+    {
+        u16::from_str_radix(hex, 16).map_err(|e| format!("invalid hex type code {s}: {e}"))
+    } else {
+        trimmed
+            .parse::<u16>()
+            .map_err(|e| format!("invalid type code {s}: {e}"))
+    }
+}

--- a/src/bitcursor.rs
+++ b/src/bitcursor.rs
@@ -59,6 +59,7 @@ pub struct BitCursor<'a> {
 }
 
 impl<'a> BitCursor<'a> {
+    /// Creates a cursor positioned at the first bit of `bytes`.
     pub fn new(bytes: &'a [u8]) -> Self {
         Self {
             bytes,
@@ -140,6 +141,7 @@ impl<'a> BitCursor<'a> {
     // §2.0 — B (1 bit)
     // ================================================================
 
+    /// Reads a `B` (single bit).
     pub fn read_b(&mut self) -> Result<bool> {
         Ok(self.read_bits(1)? != 0)
     }
@@ -148,6 +150,7 @@ impl<'a> BitCursor<'a> {
     // §2.0 — BB (2 bits, used heavily as dispatch tag)
     // ================================================================
 
+    /// Reads a `BB` (2-bit code).
     pub fn read_bb(&mut self) -> Result<u8> {
         Ok(self.read_bits(2)? as u8)
     }
@@ -160,6 +163,7 @@ impl<'a> BitCursor<'a> {
     //  the previously read bits to the left. Result is 0-7."
     // ================================================================
 
+    /// Reads a `3B` (1- to 3-bit length prefix, R24+).
     pub fn read_3b(&mut self) -> Result<u8> {
         let mut result: u8 = 0;
         for _ in 0..3 {
@@ -180,6 +184,7 @@ impl<'a> BitCursor<'a> {
     //   11 → 256
     // ================================================================
 
+    /// Reads a `BS` (bitshort): a 2-bit prefix selects a 16-bit value, an 8-bit value, 0, or 256.
     pub fn read_bs(&mut self) -> Result<i16> {
         match self.read_bb()? {
             0b00 => {
@@ -210,6 +215,7 @@ impl<'a> BitCursor<'a> {
     //   11 → not used (reserved)
     // ================================================================
 
+    /// Reads a `BL` (bitlong): a 2-bit prefix selects a 32-bit value, an 8-bit value, or 0.
     pub fn read_bl(&mut self) -> Result<i32> {
         match self.read_bb()? {
             0b00 => {
@@ -229,6 +235,7 @@ impl<'a> BitCursor<'a> {
         }
     }
 
+    /// Reads a `BL` and reinterprets the bits as unsigned.
     pub fn read_bl_u(&mut self) -> Result<u32> {
         Ok(self.read_bl()? as u32)
     }
@@ -241,6 +248,7 @@ impl<'a> BitCursor<'a> {
     //  first)."
     // ================================================================
 
+    /// Reads a `BLL` (bitlonglong, R24+): a `3B` byte count followed by that many little-endian bytes.
     pub fn read_bll(&mut self) -> Result<u64> {
         let len = self.read_3b()? as usize;
         let mut out: u64 = 0;
@@ -259,6 +267,7 @@ impl<'a> BitCursor<'a> {
     //   11 → reserved
     // ================================================================
 
+    /// Reads a `BD` (bitdouble): a 2-bit prefix selects a raw double, 1.0, or 0.0.
     pub fn read_bd(&mut self) -> Result<f64> {
         match self.read_bb()? {
             0b00 => {
@@ -286,6 +295,7 @@ impl<'a> BitCursor<'a> {
     //   11 -> full 8-byte IEEE double follows
     // ================================================================
 
+    /// Reads a `DD` (bitdouble with default): the 2-bit prefix keeps `default` or patches 4, 6, or all 8 of its bytes.
     pub fn read_dd(&mut self, default: f64) -> Result<f64> {
         match self.read_bb()? {
             0b00 => Ok(default),
@@ -315,16 +325,19 @@ impl<'a> BitCursor<'a> {
     // "compressed" — they always consume the stated number of bytes.
     // ================================================================
 
+    /// Reads an `RC` (raw 8-bit char).
     pub fn read_rc(&mut self) -> Result<u8> {
         Ok(self.read_bits(8)? as u8)
     }
 
+    /// Reads an `RS` (raw little-endian 16-bit short).
     pub fn read_rs(&mut self) -> Result<i16> {
         let lsb = self.read_bits(8)? as u16;
         let msb = self.read_bits(8)? as u16;
         Ok(((msb << 8) | lsb) as i16)
     }
 
+    /// Reads an `RL` (raw little-endian 32-bit long).
     pub fn read_rl(&mut self) -> Result<u32> {
         let b0 = self.read_bits(8)? as u32;
         let b1 = self.read_bits(8)? as u32;
@@ -333,6 +346,7 @@ impl<'a> BitCursor<'a> {
         Ok((b3 << 24) | (b2 << 16) | (b1 << 8) | b0)
     }
 
+    /// Reads an `RD` (raw little-endian IEEE-754 double).
     pub fn read_rd(&mut self) -> Result<f64> {
         let mut bs = [0u8; 8];
         for b in &mut bs {
@@ -348,6 +362,7 @@ impl<'a> BitCursor<'a> {
     // LSB-first order. The terminating byte's 0x40 bit indicates negation.
     // ================================================================
 
+    /// Reads an `MC` (modular char): 7-bit groups with a continuation high bit and the sign in the final group.
     pub fn read_mc(&mut self) -> Result<i64> {
         let mut value: u64 = 0;
         let mut shift: u32 = 0;
@@ -377,6 +392,7 @@ impl<'a> BitCursor<'a> {
     // Same as MC but 2-byte base module. Used for section sizes.
     // ================================================================
 
+    /// Reads an `MS` (modular short): 15-bit groups with a continuation high bit.
     pub fn read_ms(&mut self) -> Result<u64> {
         let mut value: u64 = 0;
         let mut shift: u32 = 0;
@@ -402,6 +418,7 @@ impl<'a> BitCursor<'a> {
     // |CODE(4 bits)|COUNTER(4 bits)|HANDLE_BYTES * COUNTER|
     // ================================================================
 
+    /// Reads an `H` (handle reference): a code/counter byte followed by `counter` big-endian value bytes.
     pub fn read_handle(&mut self) -> Result<Handle> {
         let code = self.read_bits(4)? as u8;
         let counter = self.read_bits(4)? as u8;

--- a/src/bitcursor.rs
+++ b/src/bitcursor.rs
@@ -17,6 +17,7 @@
 //! | §2.3 | [`BitCursor::read_bl`]     | bitlong: 00=32-bit / 01=8-bit / 10=0 / 11=reserved |
 //! | §2.4 | [`BitCursor::read_bll`]    | bitlonglong: 3-bit length + that many LE bytes |
 //! | §2.5 | [`BitCursor::read_bd`]     | bitdouble: 00=f64 / 01=1.0 / 10=0.0 / 11=reserved |
+//! | §2.5 | [`BitCursor::read_dd`]     | bitdouble with default |
 //! | §2   | [`BitCursor::read_rc`]     | raw u8 (byte-aligned) |
 //! | §2   | [`BitCursor::read_rs`]     | raw u16 LE |
 //! | §2   | [`BitCursor::read_rl`]     | raw u32 LE |
@@ -278,6 +279,38 @@ impl<'a> BitCursor<'a> {
     }
 
     // ================================================================
+    // §2.5 — DD (bitdouble with default)
+    //   00 -> use default
+    //   01 -> patch low 4 bytes of the default double
+    //   10 -> patch bytes 4,5 and low 4 bytes of the default double
+    //   11 -> full 8-byte IEEE double follows
+    // ================================================================
+
+    pub fn read_dd(&mut self, default: f64) -> Result<f64> {
+        match self.read_bb()? {
+            0b00 => Ok(default),
+            0b01 => {
+                let mut bs = default.to_le_bytes();
+                for b in &mut bs[..4] {
+                    *b = self.read_bits(8)? as u8;
+                }
+                Ok(f64::from_le_bytes(bs))
+            }
+            0b10 => {
+                let mut bs = default.to_le_bytes();
+                bs[4] = self.read_bits(8)? as u8;
+                bs[5] = self.read_bits(8)? as u8;
+                for b in &mut bs[..4] {
+                    *b = self.read_bits(8)? as u8;
+                }
+                Ok(f64::from_le_bytes(bs))
+            }
+            0b11 => self.read_rd(),
+            _ => unreachable!(),
+        }
+    }
+
+    // ================================================================
     // Raw (byte-aligned) types. These still honor bit_pos, but are not
     // "compressed" — they always consume the stated number of bytes.
     // ================================================================
@@ -509,6 +542,45 @@ mod tests {
         assert_eq!(c.read_bd().unwrap(), 1.0);
         assert_eq!(c.read_bd().unwrap(), 0.0);
         assert_eq!(c.read_bd().unwrap(), 2.0);
+    }
+
+    // Spec §2.5 — DD (bitdouble with default) examples.
+    #[test]
+    fn spec_2_5_bitdouble_with_default_variants() {
+        let default = 12.5f64;
+        let patch4 = f64::from_le_bytes([1, 2, 3, 4, 0, 0, 0x29, 0x40]);
+        let patch6 = f64::from_le_bytes([9, 8, 7, 6, 5, 4, 0x29, 0x40]);
+        let full = -42.25f64;
+
+        let fields: Vec<(u64, u32)> = vec![
+            (0b00, 2),
+            (0b01, 2),
+            (1, 8),
+            (2, 8),
+            (3, 8),
+            (4, 8),
+            (0b10, 2),
+            (5, 8),
+            (4, 8),
+            (9, 8),
+            (8, 8),
+            (7, 8),
+            (6, 8),
+        ];
+
+        let stream = pack_bits(&fields);
+        let mut c = BitCursor::new(&stream);
+        assert_eq!(c.read_dd(default).unwrap(), default);
+        assert_eq!(c.read_dd(default).unwrap(), patch4);
+        assert_eq!(c.read_dd(default).unwrap(), patch6);
+
+        let mut full_fields: Vec<(u64, u32)> = vec![(0b11, 2)];
+        for b in full.to_le_bytes() {
+            full_fields.push((b as u64, 8));
+        }
+        let stream = pack_bits(&full_fields);
+        let mut c = BitCursor::new(&stream);
+        assert_eq!(c.read_dd(default).unwrap(), full);
     }
 
     // §2.0 — single bits and 2-bit codes

--- a/src/bitwriter.rs
+++ b/src/bitwriter.rs
@@ -29,6 +29,7 @@ pub struct BitWriter {
 }
 
 impl BitWriter {
+    /// Creates an empty writer positioned at bit 0.
     pub fn new() -> Self {
         Self::default()
     }
@@ -84,10 +85,12 @@ impl BitWriter {
         }
     }
 
+    /// Writes a `B` (single bit).
     pub fn write_b(&mut self, v: bool) {
         self.write_bits(if v { 1 } else { 0 }, 1);
     }
 
+    /// Writes a `BB` (2-bit code) from the low two bits of `v`.
     pub fn write_bb(&mut self, v: u8) {
         debug_assert!(v <= 3);
         self.write_bits(v as u64, 2);
@@ -152,6 +155,7 @@ impl BitWriter {
         }
     }
 
+    /// Writes a `BS` from an unsigned value; bit-identical to writing it reinterpreted as `i16`.
     pub fn write_bs_u(&mut self, v: u16) {
         self.write_bs(v as i16);
     }
@@ -174,6 +178,7 @@ impl BitWriter {
         }
     }
 
+    /// Writes a `BL` from an unsigned value; bit-identical to writing it reinterpreted as `i32`.
     pub fn write_bl_u(&mut self, v: u32) {
         self.write_bl(v as i32);
     }
@@ -241,22 +246,26 @@ impl BitWriter {
         }
     }
 
+    /// Writes an `RC` (raw 8-bit char).
     pub fn write_rc(&mut self, v: u8) {
         self.write_bits(v as u64, 8);
     }
 
+    /// Writes an `RS` (raw little-endian 16-bit short).
     pub fn write_rs(&mut self, v: i16) {
         let w = v as u16;
         self.write_bits((w & 0xFF) as u64, 8);
         self.write_bits((w >> 8) as u64, 8);
     }
 
+    /// Writes an `RL` (raw little-endian 32-bit long).
     pub fn write_rl(&mut self, v: u32) {
         for i in 0..4 {
             self.write_bits(((v >> (i * 8)) & 0xFF) as u64, 8);
         }
     }
 
+    /// Writes an `RD` (raw little-endian IEEE-754 double).
     pub fn write_rd(&mut self, v: f64) {
         for b in v.to_le_bytes() {
             self.write_bits(b as u64, 8);

--- a/src/bitwriter.rs
+++ b/src/bitwriter.rs
@@ -10,7 +10,7 @@
 //!
 //! # Coverage
 //!
-//! Primitives: B, BB, 3B, BS, BL, BLL, BD, RC, RS, RL, RD, MC, MS, H,
+//! Primitives: B, BB, 3B, BS, BL, BLL, BD, DD, RC, RS, RL, RD, MC, MS, H,
 //! TV (8-bit variant). All emit bit-for-bit-reversible streams against
 //! the corresponding `BitCursor::read_*` — the bit-cursor + bit-writer
 //! pair is the foundational round-trip invariant for Phase H write
@@ -230,6 +230,17 @@ impl BitWriter {
         }
     }
 
+    /// DD — bitdouble with default. Emits the exact-default form when possible,
+    /// otherwise falls back to the full raw double form.
+    pub fn write_dd(&mut self, default: f64, v: f64) {
+        if v.to_bits() == default.to_bits() {
+            self.write_bb(0b00);
+        } else {
+            self.write_bb(0b11);
+            self.write_rd(v);
+        }
+    }
+
     pub fn write_rc(&mut self, v: u8) {
         self.write_bits(v as u64, 8);
     }
@@ -406,6 +417,22 @@ mod tests {
             } else {
                 assert!((got - v).abs() < 1e-10, "v={v} got={got}");
             }
+        }
+    }
+
+    #[test]
+    fn roundtrip_dd_default_and_full() {
+        for (default, v) in [
+            (0.0f64, 0.0f64),
+            (1.0, 1.0),
+            (12.5, -42.125),
+            (-1e-100, 1e100),
+        ] {
+            let mut w = BitWriter::new();
+            w.write_dd(default, v);
+            let bytes = w.into_bytes();
+            let mut c = BitCursor::new(&bytes);
+            assert_eq!(c.read_dd(default).unwrap(), v);
         }
     }
 

--- a/src/common_entity.rs
+++ b/src/common_entity.rs
@@ -19,9 +19,7 @@
 //! BB  entmode              -- entity mode (see [`EntityMode`])
 //! BL  num_reactors
 //! B   no_xdictionary_handle (R2004+)
-//! B   has_ds_binary_data   (R2013+ — was misnamed "binary_chain_present")
-//! B   is_on_layer
-//! B   non_fixed_ltype
+//! B   has_ds_binary_data   (R2013+)
 //! CMC color                -- BS index + optional BL rgb + B name_flag + TV name
 //! BD  linetype_scale
 //! BB  ltype_flags
@@ -101,12 +99,16 @@ pub struct CommonEntityData {
     pub num_reactors: u32,
     /// Whether an xdictionary handle is absent.
     pub no_xdictionary: bool,
-    /// R2004+: whether a binary chain follows.
+    /// R2013+: whether DS binary data follows.
+    ///
+    /// Kept as `binary_chain` for API compatibility with the earlier
+    /// experimental reader.
     pub binary_chain: bool,
-    /// Whether the "is on a layer?" flag is set. In practice always
-    /// true for valid drawings; kept for diagnostic dumps.
+    /// Legacy pre-R2004 linetype marker compatibility field. Modern R2004+
+    /// entity streams do not carry a separate "is on layer" data bit here.
     pub is_on_layer: bool,
-    /// Whether the entity has a non-"BYLAYER" linetype.
+    /// Legacy pre-R2004 linetype marker compatibility field. Modern R2004+
+    /// streams use `ltype_flags` after linetype scale instead.
     pub non_fixed_ltype: bool,
     /// Raw 2-bit plot-style flag.
     pub plotstyle_flag: u8,
@@ -192,26 +194,54 @@ pub fn read_common_entity_data(
 
     // -- Reactors + object-dict markers -------------------------------------
     let num_reactors = c.read_bl()? as u32;
-    let no_xdictionary = c.read_b()?;
-    let binary_chain = if version.is_r2004_plus() {
+    let no_xdictionary = if version.is_r2004_plus() {
+        c.read_b()?
+    } else {
+        true
+    };
+    let binary_chain = if matches!(version, Version::R2013 | Version::R2018) {
         c.read_b()?
     } else {
         false
     };
 
-    // -- Layer + linetype markers -------------------------------------------
-    let is_on_layer = c.read_b()?;
-    let non_fixed_ltype = c.read_b()?;
+    // R13/R14 carry a separate by-layer linetype marker before the modern
+    // ltype_flags field existed. R2004+ does not; those releases encode this
+    // in ltype_flags below, after linetype_scale.
+    let (is_on_layer, non_fixed_ltype) = if matches!(version, Version::R14) {
+        let is_by_layer_linetype = c.read_b()?;
+        (true, !is_by_layer_linetype)
+    } else {
+        (true, false)
+    };
 
-    // -- CMC entity color (§2.14) -------------------------------------------
-    // Minimal BYLAYER-only CMC: just the BS color_index. The complex
-    // suffix (BL rgb + name) in R2004+ is only present when (index &
-    // 0xC000) != 0, and the exact semantics vary by AutoCAD minor
-    // version — over-consuming it broke ENDBLK preamble reads on
-    // line_2013.dwg. If complex colors appear in real corpora we will
-    // extend this, but the vast majority of real entities use BYLAYER
-    // which fits in 2 bits (BS tag 10).
-    let _color_index = c.read_bs_u()?;
+    // R13-R2000 carry a "nolinks" bit before color. The current public struct
+    // has no stable place for it, but it must still be consumed on legacy
+    // streams so color starts at the right bit.
+    if matches!(version, Version::R14 | Version::R2000) {
+        let _nolinks = c.read_b()?;
+    }
+
+    // -- CMC entity color (§2.11) -------------------------------------------
+    // R2004+ stores a raw BS whose high bits flag optional alpha/RGB/name
+    // suffixes. Color handles live in the handle stream, so they are noted by
+    // the flags but do not consume data-stream bits here.
+    let color_raw = c.read_bs_u()?;
+    if version.is_r2004_plus() {
+        let color_flags = color_raw >> 8;
+        if color_flags & 0x20 != 0 {
+            let _alpha_raw = c.read_bl()?;
+        }
+        if color_flags & 0x40 == 0 && color_flags & 0x80 != 0 {
+            let _rgb = c.read_bl()?;
+        }
+        if color_flags & 0x41 == 0x41 {
+            let _name = crate::tables::read_tv(c, version)?;
+        }
+        if color_flags & 0x42 == 0x42 {
+            let _book_name = crate::tables::read_tv(c, version)?;
+        }
+    }
 
     // -- BD linetype_scale (default 1.0 → BB tag 01, 2 bits) ----------------
     let _linetype_scale = c.read_bd()?;
@@ -222,15 +252,11 @@ pub fn read_common_entity_data(
     let plotstyle_flag = c.read_bb()?;
 
     // -- Material + shadow (R2007+) -----------------------------------------
-    // `shadow_flags` is 2 bits (BB) — the spec labels the field "RC" in
-    // §19.4.1 Table 54 but the actual on-disk encoding only uses 2 bits
-    // (cast_shadow, receive_shadow). Reading RC (8 bits) misaligns the
-    // entire post-preamble stream — we measured a 6-bit overshoot that
-    // caused every subsequent field to read garbage (see task #103).
-    // The `u8` width of `shadow_flags` on the struct is kept for ABI
-    // stability.
+    // shadow_flags is an RC in modern DWG streams. Earlier local experiments
+    // tried BB, but that masked a separate two-bit overread before CMC color
+    // and left R2013/R2018 entity bodies misaligned.
     let (material_flag, shadow_flags) = if version.is_r2007_plus() {
-        (c.read_bb()?, c.read_bb()?)
+        (c.read_bb()?, c.read_rc()?)
     } else {
         (0u8, 0u8)
     };
@@ -295,10 +321,7 @@ mod tests {
         w.write_bb(0b00);
         // num_reactors = 0.
         w.write_bl(0);
-        // no_xdictionary = true, binary_chain = false (R2004+).
-        w.write_b(true);
-        w.write_b(false);
-        // is_on_layer, non_fixed_ltype
+        // no_xdictionary = true; has_ds_data is R2013+.
         w.write_b(true);
         w.write_b(false);
         // CMC color — BS index, BYLAYER (tag 10 → 2 bits, value 0)
@@ -311,7 +334,7 @@ mod tests {
         w.write_bb(0b00);
         // material_flag, shadow_flags (R2007+)
         w.write_bb(0b00);
-        w.write_bb(0b00);
+        w.write_rc(0b00);
         // visualstyle full/face/edge (R2010+)
         w.write_b(false);
         w.write_b(false);
@@ -352,9 +375,7 @@ mod tests {
         w.write_bb(0b10);
         w.write_bl(2); // 2 reactors
         w.write_b(false); // has xdict
-        w.write_b(true); // binary_chain
-        w.write_b(true);
-        w.write_b(true);
+        w.write_b(true); // has_ds_data
         // CMC color — BYLAYER
         w.write_bs(0);
         // BD linetype_scale — 1.0
@@ -363,7 +384,7 @@ mod tests {
         w.write_bb(0b00);
         w.write_bb(0b01);
         w.write_bb(0b10);
-        w.write_bb(0b11);
+        w.write_rc(0b11);
         w.write_b(false);
         w.write_b(false);
         w.write_b(false);
@@ -380,7 +401,7 @@ mod tests {
         assert!(!ce.no_xdictionary);
         assert!(ce.binary_chain);
         assert!(ce.is_on_layer);
-        assert!(ce.non_fixed_ltype);
+        assert!(!ce.non_fixed_ltype);
         assert_eq!(ce.plotstyle_flag, 0b01);
         assert_eq!(ce.material_flag, 0b10);
         assert_eq!(ce.shadow_flags, 0b11);

--- a/src/dxf_sections.rs
+++ b/src/dxf_sections.rs
@@ -62,24 +62,28 @@ pub struct HeaderEntry {
 }
 
 impl HeaderEntry {
+    /// Builds a header variable holding a string value (group code 1/2/3 family).
     pub fn string(name: impl Into<String>, value: impl Into<String>) -> Self {
         HeaderEntry {
             name: name.into(),
             value: HeaderValue::String(value.into()),
         }
     }
+    /// Builds a header variable holding an integer value.
     pub fn int(name: impl Into<String>, value: i64) -> Self {
         HeaderEntry {
             name: name.into(),
             value: HeaderValue::Int(value),
         }
     }
+    /// Builds a header variable holding a double value.
     pub fn double(name: impl Into<String>, value: f64) -> Self {
         HeaderEntry {
             name: name.into(),
             value: HeaderValue::Double(value),
         }
     }
+    /// Builds a header variable holding a 3D point (emitted as the 10/20/30 triple).
     pub fn point(name: impl Into<String>, value: Point3D) -> Self {
         HeaderEntry {
             name: name.into(),

--- a/src/element_encoder.rs
+++ b/src/element_encoder.rs
@@ -81,19 +81,19 @@ fn write_bt(w: &mut BitWriter, v: f64) {
 ///
 /// Writes the z-flag 2D shortcut: when [`Line::is_2d`] is true, both Z
 /// coordinates are omitted (decoder defaults them to 0.0). End coordinates
-/// are delta-encoded relative to start coordinates (BD over the delta).
+/// use DD with the corresponding start coordinate as the default.
 ///
 /// Inverse of [`crate::entities::line::decode`].
 impl ElementEncoder for Line {
     fn encode(&self, w: &mut BitWriter, _version: Version) -> Result<()> {
         w.write_b(self.is_2d);
         w.write_rd(self.start.x);
-        w.write_bd(self.end.x - self.start.x);
+        w.write_dd(self.start.x, self.end.x);
         w.write_rd(self.start.y);
-        w.write_bd(self.end.y - self.start.y);
+        w.write_dd(self.start.y, self.end.y);
         if !self.is_2d {
             w.write_rd(self.start.z);
-            w.write_bd(self.end.z - self.start.z);
+            w.write_dd(self.start.z, self.end.z);
         }
         write_bt(w, self.thickness);
         write_be(w, self.extrusion);

--- a/src/entities/arc.rs
+++ b/src/entities/arc.rs
@@ -27,6 +27,7 @@ pub struct Arc {
     pub end_angle: f64,
 }
 
+/// Decodes the `Arc` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>) -> Result<Arc> {
     let cx = c.read_bd()?;
     let cy = c.read_bd()?;

--- a/src/entities/attdef.rs
+++ b/src/entities/attdef.rs
@@ -32,6 +32,7 @@ pub struct AttDef {
     pub lock_position: bool,
 }
 
+/// Decodes the `AttDef` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<AttDef> {
     let text = text::decode(c, version)?;
     let prompt = read_tv(c, version)?;

--- a/src/entities/attrib.rs
+++ b/src/entities/attrib.rs
@@ -37,20 +37,25 @@ pub struct Attrib {
 }
 
 impl Attrib {
+    /// Bit 0x01 of `flags`: the attribute is invisible.
     pub fn is_invisible(&self) -> bool {
         self.flags & 0x01 != 0
     }
+    /// Bit 0x02 of `flags`: the attribute is constant.
     pub fn is_constant(&self) -> bool {
         self.flags & 0x02 != 0
     }
+    /// Bit 0x04 of `flags`: verification is required on insertion.
     pub fn is_verifiable(&self) -> bool {
         self.flags & 0x04 != 0
     }
+    /// Bit 0x08 of `flags`: the attribute is preset (no prompt on insertion).
     pub fn is_preset(&self) -> bool {
         self.flags & 0x08 != 0
     }
 }
 
+/// Decodes the `Attrib` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<Attrib> {
     let text = text::decode(c, version)?;
     let tag = read_tv(c, version)?;

--- a/src/entities/block.rs
+++ b/src/entities/block.rs
@@ -20,6 +20,7 @@ pub struct Block {
     pub name: String,
 }
 
+/// Decodes the `Block` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<Block> {
     let len = c.read_bs_u()? as usize;
     if len == 0 {

--- a/src/entities/circle.rs
+++ b/src/entities/circle.rs
@@ -23,6 +23,7 @@ pub struct Circle {
     pub extrusion: Vec3D,
 }
 
+/// Decodes the `Circle` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>) -> Result<Circle> {
     let cx = c.read_bd()?;
     let cy = c.read_bd()?;

--- a/src/entities/dimension.rs
+++ b/src/entities/dimension.rs
@@ -70,6 +70,7 @@ pub struct DimensionCommon {
     pub flip_arrow_2: bool,
 }
 
+/// Reads the fields shared by every DIMENSION subtype that precede the subtype-specific data.
 pub fn read_common(c: &mut BitCursor<'_>, version: Version) -> Result<DimensionCommon> {
     let version_flag = if version.is_r2010_plus() {
         c.read_rc()?

--- a/src/entities/dispatch.rs
+++ b/src/entities/dispatch.rs
@@ -693,6 +693,7 @@ pub struct DispatchSummary {
 }
 
 impl DispatchSummary {
+    /// Tallies one dispatch outcome, retaining up to `MAX_RETAINED_ERRORS` error messages.
     pub fn record(&mut self, decoded: &DecodedEntity) {
         match decoded {
             DecodedEntity::Unhandled { .. } => self.unhandled += 1,
@@ -710,10 +711,12 @@ impl DispatchSummary {
         }
     }
 
+    /// Total entities seen: decoded + unhandled + errored.
     pub fn total(&self) -> usize {
         self.decoded + self.unhandled + self.errored
     }
 
+    /// Fraction of seen entities that decoded, or 0.0 when nothing was seen.
     pub fn decoded_ratio(&self) -> f64 {
         let total = self.total();
         if total == 0 {

--- a/src/entities/dispatch.rs
+++ b/src/entities/dispatch.rs
@@ -391,7 +391,7 @@ pub fn decode_from_raw(raw: &RawObject, version: Version) -> DecodedEntity {
     match position_cursor_at_entity_body(raw, version) {
         Ok(mut cursor) => {
             if kind.is_table_entry() {
-                dispatch_table_entry(&mut cursor, type_code, kind, version)
+                dispatch_table_entry(raw, &mut cursor, type_code, kind, version)
             } else {
                 dispatch(&mut cursor, type_code, kind, version)
             }
@@ -411,6 +411,7 @@ pub fn decode_from_raw(raw: &RawObject, version: Version) -> DecodedEntity {
 /// table-entry preamble, so the cursor positioning here is the same
 /// as for drawing entities.
 fn dispatch_table_entry(
+    raw: &RawObject,
     c: &mut BitCursor<'_>,
     type_code: u16,
     kind: ObjectType,
@@ -420,6 +421,18 @@ fn dispatch_table_entry(
         ObjectType::Layer => crate::tables::layer::decode(c, version)
             .map(DecodedEntity::Layer)
             .map_err(|e| e.to_string()),
+        ObjectType::Ltype if version.is_r2007_plus() => {
+            match crate::tables::ltype::decode_modern_split_stream(
+                &raw.raw,
+                c.position_bits(),
+                version,
+            ) {
+                Ok(ltype) => Ok(DecodedEntity::Ltype(ltype)),
+                Err(_) => crate::tables::ltype::decode(c, version)
+                    .map(DecodedEntity::Ltype)
+                    .map_err(|e| e.to_string()),
+            }
+        }
         ObjectType::Ltype => crate::tables::ltype::decode(c, version)
             .map(DecodedEntity::Ltype)
             .map_err(|e| e.to_string()),
@@ -441,6 +454,15 @@ fn dispatch_table_entry(
         ObjectType::DimStyle => crate::tables::dimstyle::decode_partial(c, version)
             .map(DecodedEntity::DimStyle)
             .map_err(|e| e.to_string()),
+        ObjectType::BlockHeader if version.is_r2007_plus() => {
+            crate::tables::block_record::decode_modern_split_stream(
+                &raw.raw,
+                c.position_bits(),
+                version,
+            )
+            .map(DecodedEntity::BlockRecord)
+            .map_err(|e| e.to_string())
+        }
         ObjectType::BlockHeader => crate::tables::block_record::decode(c, version)
             .map(DecodedEntity::BlockRecord)
             .map_err(|e| e.to_string()),

--- a/src/entities/ellipse.rs
+++ b/src/entities/ellipse.rs
@@ -30,6 +30,7 @@ pub struct Ellipse {
     pub end_param: f64,
 }
 
+/// Decodes the `Ellipse` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>) -> Result<Ellipse> {
     let center = read_bd3(c)?;
     let major_axis = read_bd3(c)?;

--- a/src/entities/endblk.rs
+++ b/src/entities/endblk.rs
@@ -11,6 +11,7 @@ use crate::error::Result;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct EndBlk;
 
+/// Decodes an `EndBlk`; the entity carries no payload beyond the common header.
 pub fn decode(_c: &mut BitCursor<'_>) -> Result<EndBlk> {
     Ok(EndBlk)
 }

--- a/src/entities/extruded_surface.rs
+++ b/src/entities/extruded_surface.rs
@@ -44,6 +44,7 @@ pub struct ExtrudedSurface {
     pub draft_angle: f64,
 }
 
+/// Decodes the `ExtrudedSurface` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>) -> Result<ExtrudedSurface> {
     let sat = decode_sat_blob(c)?;
     let sweep_vector = read_bd3(c)?;

--- a/src/entities/helix.rs
+++ b/src/entities/helix.rs
@@ -47,6 +47,7 @@ pub enum ConstrainType {
 }
 
 impl ConstrainType {
+    /// Parses the HELIX constrain type from its `BS` code (0 turn height, 1 turns, 2 height).
     pub fn from_bs(v: i16) -> Result<Self> {
         match v {
             0 => Ok(Self::TurnHeight),
@@ -58,6 +59,7 @@ impl ConstrainType {
         }
     }
 
+    /// Encodes the constrain type back to its `BS` code.
     pub fn to_bs(self) -> i16 {
         match self {
             Self::TurnHeight => 0,
@@ -80,6 +82,7 @@ pub struct Helix {
     pub constrain_type: ConstrainType,
 }
 
+/// Decodes the `Helix` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>) -> Result<Helix> {
     let axis_base_point = read_bd3(c)?;
     let start_point = read_bd3(c)?;

--- a/src/entities/image.rs
+++ b/src/entities/image.rs
@@ -59,6 +59,7 @@ pub enum ClipBoundary {
     Polygon(Vec<Point2D>),
 }
 
+/// Decodes the `Image` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<Image> {
     let _class_version = c.read_bl()?;
     let insertion_point = read_bd3(c)?;

--- a/src/entities/imagedef.rs
+++ b/src/entities/imagedef.rs
@@ -49,6 +49,7 @@ pub struct ImageDef {
 /// pipeline. 64 KiB is already adversarial territory.
 const IMAGEDEF_MAX_PATH_UNITS: usize = 65_536;
 
+/// Decodes the `ImageDef` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<ImageDef> {
     let class_version = c.read_bl()? as u32;
     let image_width = c.read_bd()?;

--- a/src/entities/insert.rs
+++ b/src/entities/insert.rs
@@ -39,6 +39,7 @@ pub struct Insert {
     pub has_attribs: bool,
 }
 
+/// Decodes the `Insert` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>) -> Result<Insert> {
     let insertion_point = read_bd3(c)?;
     let scale_flag = c.read_bb()?;

--- a/src/entities/leader.rs
+++ b/src/entities/leader.rs
@@ -46,6 +46,7 @@ pub struct Leader {
     pub offset_to_block_insertion: Vec3D,
 }
 
+/// Decodes the `Leader` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>) -> Result<Leader> {
     let _unknown = c.read_b()?;
     let annot_type = c.read_bs()?;

--- a/src/entities/light.rs
+++ b/src/entities/light.rs
@@ -50,6 +50,7 @@ pub enum LightType {
 }
 
 impl LightType {
+    /// Maps the light-type code (1 distant, 2 point, 3 spot, 4 web); unknown codes are preserved as `Unknown`.
     pub fn from_code(code: u32) -> Self {
         match code {
             1 => Self::Distant,
@@ -60,10 +61,12 @@ impl LightType {
         }
     }
 
+    /// Point, spot, and web lights carry a position.
     pub fn has_position(self) -> bool {
         matches!(self, Self::Point | Self::Spot | Self::Web)
     }
 
+    /// Spot and web lights carry a target point.
     pub fn has_target(self) -> bool {
         matches!(self, Self::Spot | Self::Web)
     }

--- a/src/entities/line.rs
+++ b/src/entities/line.rs
@@ -5,19 +5,18 @@
 //! ```text
 //! B   zflag             -- true ⇒ entity is 2D (z coords defaulted to 0.0)
 //! RD  start.x
-//! BD  end.x             -- delta-encoded relative to start.x
+//! DD  end.x             -- defaults to start.x
 //! RD  start.y
-//! BD  end.y             -- delta-encoded relative to start.y
+//! DD  end.y             -- defaults to start.y
 //! (if !zflag)
 //!   RD  start.z
-//!   BD  end.z           -- delta-encoded relative to start.z
+//!   DD  end.z           -- defaults to start.z
 //! BT  thickness         -- default 0.0
 //! BE  extrusion         -- default (0,0,1)
 //! ```
 //!
-//! The delta encoding of end coordinates is the spec's "z-flag 2D
-//! shortcut" (§19.4.20). A short line has end-x ≈ start-x, so the
-//! delta typically packs into one BD-bit-2 (1.0) or zero byte.
+//! The end coordinates use the spec's DD (bitdouble with default)
+//! primitive, where each start coordinate is the corresponding default.
 
 use crate::bitcursor::BitCursor;
 use crate::entities::{Point3D, Vec3D, read_be, read_bt};
@@ -41,14 +40,14 @@ pub struct Line {
 pub fn decode(c: &mut BitCursor<'_>) -> Result<Line> {
     let zflag = c.read_b()?;
     let sx = c.read_rd()?;
-    let ex = sx + c.read_bd()?;
+    let ex = c.read_dd(sx)?;
     let sy = c.read_rd()?;
-    let ey = sy + c.read_bd()?;
+    let ey = c.read_dd(sy)?;
     let (sz, ez) = if zflag {
         (0.0, 0.0)
     } else {
         let sz = c.read_rd()?;
-        let ez = sz + c.read_bd()?;
+        let ez = c.read_dd(sz)?;
         (sz, ez)
     };
     let thickness = read_bt(c)?;
@@ -80,9 +79,9 @@ mod tests {
         let mut w = BitWriter::new();
         w.write_b(true); // 2D
         w.write_rd(1.0); // start.x
-        w.write_bd(5.0); // end.x delta: 5.0, so end.x = 6.0
+        w.write_dd(1.0, 6.0); // end.x
         w.write_rd(2.0); // start.y
-        w.write_bd(3.0); // end.y delta: 3.0, end.y = 5.0
+        w.write_dd(2.0, 5.0); // end.y
         w.write_b(true); // thickness default 0.0
         w.write_b(true); // extrusion default
         let bytes = w.into_bytes();
@@ -121,11 +120,11 @@ mod tests {
         let mut w = BitWriter::new();
         w.write_b(false); // 3D
         w.write_rd(1.0);
-        w.write_bd(2.0);
+        w.write_dd(1.0, 3.0);
         w.write_rd(3.0);
-        w.write_bd(4.0);
+        w.write_dd(3.0, 7.0);
         w.write_rd(5.0);
-        w.write_bd(6.0);
+        w.write_dd(5.0, 11.0);
         w.write_b(false); // explicit thickness
         w.write_bd(2.5);
         w.write_b(false); // explicit extrusion

--- a/src/entities/lofted_surface.rs
+++ b/src/entities/lofted_surface.rs
@@ -47,6 +47,7 @@ pub struct LoftedSurface {
     pub end_tangent_mag: f64,
 }
 
+/// Decodes the `LoftedSurface` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>) -> Result<LoftedSurface> {
     let sat = decode_sat_blob(c)?;
     let num_cross_sections = c.read_bl()?;

--- a/src/entities/lwpolyline.rs
+++ b/src/entities/lwpolyline.rs
@@ -62,6 +62,7 @@ pub mod flag_bits {
     pub const HAS_VERTEX_ID: u16 = 0x8000;
 }
 
+/// Decodes the `LwPolyline` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>) -> Result<LwPolyline> {
     use flag_bits::*;
     let flag = c.read_bs_u()?;

--- a/src/entities/lwpolyline.rs
+++ b/src/entities/lwpolyline.rs
@@ -169,10 +169,19 @@ pub fn decode(c: &mut BitCursor<'_>) -> Result<LwPolyline> {
     }
 
     let mut vertices = Vec::with_capacity(num_points);
-    for _ in 0..num_points {
-        let x = c.read_rd()?;
-        let y = c.read_rd()?;
-        vertices.push(Point2D { x, y });
+    if num_points > 0 {
+        let mut previous = Point2D {
+            x: c.read_rd()?,
+            y: c.read_rd()?,
+        };
+        vertices.push(previous);
+        for _ in 1..num_points {
+            previous = Point2D {
+                x: c.read_dd(previous.x)?,
+                y: c.read_dd(previous.y)?,
+            };
+            vertices.push(previous);
+        }
     }
     let mut bulges = Vec::with_capacity(num_bulges);
     for _ in 0..num_bulges {
@@ -212,10 +221,12 @@ mod tests {
         // No optional fields, 3 vertices.
         w.write_bs_u(0);
         w.write_bl(3);
-        for (x, y) in [(0.0f64, 0.0f64), (10.0, 0.0), (10.0, 10.0)] {
-            w.write_rd(x);
-            w.write_rd(y);
-        }
+        w.write_rd(0.0);
+        w.write_rd(0.0);
+        w.write_dd(0.0, 10.0);
+        w.write_dd(0.0, 0.0);
+        w.write_dd(10.0, 10.0);
+        w.write_dd(0.0, 10.0);
         let bytes = w.into_bytes();
         let mut c = BitCursor::new(&bytes);
         let p = decode(&mut c).unwrap();
@@ -233,10 +244,14 @@ mod tests {
         w.write_bs_u(CLOSED | HAS_BULGES);
         w.write_bl(4); // 4 points
         w.write_bl(4); // 4 bulges (one per segment)
-        for (x, y) in [(0.0f64, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)] {
-            w.write_rd(x);
-            w.write_rd(y);
-        }
+        w.write_rd(0.0);
+        w.write_rd(0.0);
+        w.write_dd(0.0, 10.0);
+        w.write_dd(0.0, 0.0);
+        w.write_dd(10.0, 10.0);
+        w.write_dd(0.0, 10.0);
+        w.write_dd(10.0, 0.0);
+        w.write_dd(10.0, 10.0);
         for b in [0.0, 0.5, 0.0, 0.5] {
             w.write_bd(b);
         }

--- a/src/entities/mline.rs
+++ b/src/entities/mline.rs
@@ -74,6 +74,7 @@ pub enum Justification {
 }
 
 impl Justification {
+    /// Maps the MLINE justification code (0 top, 1 zero, 2 bottom); unknown codes are preserved as `Unknown`.
     pub fn from_code(code: u8) -> Self {
         match code {
             0 => Self::Top,
@@ -117,6 +118,7 @@ pub struct MLine {
     pub vertices: Vec<MlineVertex>,
 }
 
+/// Decodes the `MLine` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>) -> Result<MLine> {
     let scale_factor = c.read_bd()?;
     let justification = Justification::from_code(c.read_rc()?);

--- a/src/entities/mtext.rs
+++ b/src/entities/mtext.rs
@@ -58,6 +58,7 @@ pub struct MText {
     pub linespace_factor: f64,
 }
 
+/// Decodes the `MText` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<MText> {
     let insertion_point = read_bd3(c)?;
     let extrusion = read_bd3(c)?;

--- a/src/entities/point.rs
+++ b/src/entities/point.rs
@@ -23,6 +23,7 @@ pub struct Point {
     pub x_axis_angle: f64,
 }
 
+/// Decodes the `Point` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>) -> Result<Point> {
     let x = c.read_bd()?;
     let y = c.read_bd()?;

--- a/src/entities/polyline.rs
+++ b/src/entities/polyline.rs
@@ -39,17 +39,21 @@ pub struct Polyline {
 }
 
 impl Polyline {
+    /// Bit 0x01 of `flag`: the polyline is closed.
     pub fn is_closed(&self) -> bool {
         self.flag & 0x01 != 0
     }
+    /// Bit 0x08 of `flag`: the polyline is a 3D polyline.
     pub fn is_3d(&self) -> bool {
         self.flag & 0x08 != 0
     }
+    /// Bit 0x40 of `flag`: the polyline is a polyface mesh.
     pub fn is_polyface(&self) -> bool {
         self.flag & 0x40 != 0
     }
 }
 
+/// Decodes the `Polyline` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>) -> Result<Polyline> {
     let flag = c.read_bs_u()?;
     let curve_type = c.read_bs()?;

--- a/src/entities/proxy_entity_passthrough.rs
+++ b/src/entities/proxy_entity_passthrough.rs
@@ -52,6 +52,7 @@ pub struct ProxyEntityPassthrough {
     pub original_object_handle: Option<Handle>,
 }
 
+/// Decodes the `ProxyEntityPassthrough` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<ProxyEntityPassthrough> {
     let proxy_class_id = c.read_bl()? as u32;
     let application_version = c.read_bl()? as u32;

--- a/src/entities/ray.rs
+++ b/src/entities/ray.rs
@@ -18,6 +18,7 @@ pub struct Ray {
     pub direction: Vec3D,
 }
 
+/// Decodes the `Ray` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>) -> Result<Ray> {
     let start = read_bd3(c)?;
     let direction = read_bd3(c)?;

--- a/src/entities/revolved_surface.rs
+++ b/src/entities/revolved_surface.rs
@@ -34,6 +34,7 @@ pub struct RevolvedSurface {
     pub sweep_angle: f64,
 }
 
+/// Decodes the `RevolvedSurface` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>) -> Result<RevolvedSurface> {
     let sat = decode_sat_blob(c)?;
     let axis_origin = read_bd3(c)?;

--- a/src/entities/solid.rs
+++ b/src/entities/solid.rs
@@ -33,6 +33,7 @@ pub struct Solid {
     pub extrusion: Vec3D,
 }
 
+/// Decodes the `Solid` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>) -> Result<Solid> {
     let thickness = read_bt(c)?;
     let elevation = c.read_bd()?;

--- a/src/entities/spline.rs
+++ b/src/entities/spline.rs
@@ -67,6 +67,7 @@ pub struct ControlForm {
     pub weights: Vec<f64>,
 }
 
+/// Decodes the `Spline` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<Spline> {
     let scenario = c.read_bl()? as u32;
     let (flag1, knot_param) = if matches!(version, Version::R2013 | Version::R2018) {

--- a/src/entities/swept_surface.rs
+++ b/src/entities/swept_surface.rs
@@ -45,6 +45,7 @@ pub enum AlignOption {
 }
 
 impl AlignOption {
+    /// Parses the sweep alignment option from its `BB` code (0 none, 1 normal, 2 translate, 3 forced).
     pub fn from_bb(v: u8) -> Result<Self> {
         match v {
             0 => Ok(Self::NoAlignment),
@@ -57,6 +58,7 @@ impl AlignOption {
         }
     }
 
+    /// Encodes the alignment option back to its `BB` code.
     pub fn to_bb(self) -> u8 {
         match self {
             Self::NoAlignment => 0,
@@ -78,6 +80,7 @@ pub struct SweptSurface {
     pub align_option: AlignOption,
 }
 
+/// Decodes the `SweptSurface` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>) -> Result<SweptSurface> {
     let sat = decode_sat_blob(c)?;
     let path_handle = c.read_handle()?;

--- a/src/entities/text.rs
+++ b/src/entities/text.rs
@@ -58,6 +58,7 @@ pub struct Text {
     pub v_align: i16,
 }
 
+/// Decodes the `Text` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<Text> {
     let flag = c.read_rc()?;
 

--- a/src/entities/three_d_face.rs
+++ b/src/entities/three_d_face.rs
@@ -27,6 +27,7 @@ pub struct ThreeDFace {
     pub is_triangle: bool,
 }
 
+/// Decodes the `ThreeDFace` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>) -> Result<ThreeDFace> {
     let has_no_flag = c.read_b()?;
     let z_is_zero = c.read_b()?;

--- a/src/entities/trace.rs
+++ b/src/entities/trace.rs
@@ -15,6 +15,7 @@ pub use crate::entities::solid::decode as decode_as_solid;
 #[derive(Debug, Clone, PartialEq)]
 pub struct Trace(pub Solid);
 
+/// Decodes the `Trace` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>) -> Result<Trace> {
     Ok(Trace(decode_as_solid(c)?))
 }

--- a/src/entities/underlay.rs
+++ b/src/entities/underlay.rs
@@ -69,15 +69,19 @@ pub struct Underlay {
 }
 
 impl Underlay {
+    /// Bit 0x01 of `flags`: clipping is enabled.
     pub fn is_clip_on(&self) -> bool {
         self.flags & 0x01 != 0
     }
+    /// Bit 0x02 of `flags`: the underlay is displayed.
     pub fn is_underlay_on(&self) -> bool {
         self.flags & 0x02 != 0
     }
+    /// Bit 0x04 of `flags`: the underlay is drawn monochrome.
     pub fn is_monochrome(&self) -> bool {
         self.flags & 0x04 != 0
     }
+    /// Bit 0x08 of `flags`: colors are adjusted for the background.
     pub fn is_adjust_for_background(&self) -> bool {
         self.flags & 0x08 != 0
     }

--- a/src/entities/vertex.rs
+++ b/src/entities/vertex.rs
@@ -42,6 +42,7 @@ pub struct Vertex {
     pub tangent_direction: Option<f64>,
 }
 
+/// Decodes the `Vertex` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<Vertex> {
     let flag = c.read_rc()?;
     let location = read_bd3(c)?;

--- a/src/entities/viewport.rs
+++ b/src/entities/viewport.rs
@@ -41,6 +41,7 @@ pub struct Viewport {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ViewportSkipped;
 
+/// Decodes the `Viewport` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>) -> Result<Viewport> {
     let center = read_bd3(c)?;
     let width = c.read_bd()?;

--- a/src/entities/xline.rs
+++ b/src/entities/xline.rs
@@ -14,6 +14,7 @@ pub struct XLine {
     pub direction: Vec3D,
 }
 
+/// Decodes the `XLine` payload that follows the common entity header.
 pub fn decode(c: &mut BitCursor<'_>) -> Result<XLine> {
     let point = read_bd3(c)?;
     let direction = read_bd3(c)?;

--- a/src/file_writer.rs
+++ b/src/file_writer.rs
@@ -83,6 +83,7 @@ pub struct WriterScaffold {
 }
 
 impl WriterScaffold {
+    /// Creates an empty scaffold targeting `version`.
     pub fn new(version: Version) -> Self {
         Self {
             sections: BTreeMap::new(),

--- a/src/header.rs
+++ b/src/header.rs
@@ -65,6 +65,7 @@ pub struct LocatorRecord {
 impl LocatorRecord {
     pub const SIZE: usize = 9;
 
+    /// Parses one 9-byte section locator record.
     pub fn parse(bytes: &[u8]) -> Result<Self> {
         if bytes.len() < Self::SIZE {
             return Err(Error::SectionLocator(format!(

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -338,6 +338,7 @@ pub struct FileDepList {
 }
 
 impl FileDepList {
+    /// Parses the file dependency list (features and per-file dependencies).
     pub fn parse(bytes: &[u8]) -> Result<Self> {
         let mut c = ByteCursor::new(bytes);
         let feature_count = c.read_u32()? as usize;

--- a/src/object.rs
+++ b/src/object.rs
@@ -166,6 +166,7 @@ impl ObjectWalkSummary {
 }
 
 impl<'a> ObjectWalker<'a> {
+    /// Starts a walker over the object-section bytes for `version`.
     pub fn new(bytes: &'a [u8], version: Version) -> Self {
         let initial = if bytes.len() >= 4
             && matches!(

--- a/src/object_type.rs
+++ b/src/object_type.rs
@@ -129,6 +129,7 @@ pub enum ObjectType {
 }
 
 impl ObjectType {
+    /// Maps a raw object-type code to its variant; unknown codes are preserved as `Unknown`.
     pub fn from_code(code: u16) -> Self {
         match code {
             0x00 => Self::Unused,
@@ -325,6 +326,7 @@ impl ObjectType {
         )
     }
 
+    /// Upper-case spec-style label (`LINE`, `LWPOLYLINE`, ...) for diagnostics and reports.
     pub fn short_label(self) -> &'static str {
         match self {
             Self::Unused => "UNUSED",

--- a/src/objects/acad_group.rs
+++ b/src/objects/acad_group.rs
@@ -38,6 +38,7 @@ pub struct AcadGroup {
     pub member_handles: Vec<Handle>,
 }
 
+/// Decodes the `AcadGroup` payload that follows the common object header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<AcadGroup> {
     let name = read_tv(c, version)?;
     let unnamed = c.read_b()?;

--- a/src/objects/acad_layout.rs
+++ b/src/objects/acad_layout.rs
@@ -133,6 +133,7 @@ impl AcadLayout {
     }
 }
 
+/// Decodes the `AcadLayout` payload that follows the common object header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<AcadLayout> {
     let flags = c.read_bs()?;
     let layout_name = read_tv(c, version)?;

--- a/src/objects/acad_material.rs
+++ b/src/objects/acad_material.rs
@@ -73,6 +73,7 @@ pub struct AcadMaterial {
     pub luminance_mode: i32,
 }
 
+/// Decodes the `AcadMaterial` payload that follows the common object header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<AcadMaterial> {
     if !version.is_r2007_plus() {
         return Err(Error::Unsupported {

--- a/src/objects/acad_mlinestyle.rs
+++ b/src/objects/acad_mlinestyle.rs
@@ -54,6 +54,7 @@ pub struct AcadMlinestyle {
     pub lines: Vec<MlineStyleLine>,
 }
 
+/// Decodes the `AcadMlinestyle` payload that follows the common object header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<AcadMlinestyle> {
     let name = read_tv(c, version)?;
     let description = read_tv(c, version)?;

--- a/src/objects/acad_plot_settings.rs
+++ b/src/objects/acad_plot_settings.rs
@@ -71,6 +71,7 @@ pub struct AcadPlotSettings {
     pub shade_plot_object_handle: Handle,
 }
 
+/// Decodes the `AcadPlotSettings` payload that follows the common object header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<AcadPlotSettings> {
     let page_setup_name = read_tv(c, version)?;
     let printer_config_name = read_tv(c, version)?;

--- a/src/objects/acad_property_set_data.rs
+++ b/src/objects/acad_property_set_data.rs
@@ -51,6 +51,7 @@ pub enum PropertyDataType {
 }
 
 impl PropertyDataType {
+    /// Maps the property data-type code (spec §19.6.11: 1 integer, 2 real, 3 text, 4 enum, 5 date); anything else is an error.
     pub fn from_raw(raw: u32) -> Result<Self> {
         match raw {
             1 => Ok(Self::Integer),
@@ -90,6 +91,7 @@ pub struct AcadPropertySetData {
     pub properties: Vec<PropertySetProperty>,
 }
 
+/// Decodes the `AcadPropertySetData` payload that follows the common object header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<AcadPropertySetData> {
     let propset_definition_name = read_tv(c, version)?;
     let num_properties = c.read_bl()? as usize;

--- a/src/objects/acad_scale.rs
+++ b/src/objects/acad_scale.rs
@@ -51,6 +51,7 @@ impl AcadScale {
     }
 }
 
+/// Decodes the `AcadScale` payload that follows the common object header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<AcadScale> {
     let scale_name = read_tv(c, version)?;
     let paper_units = c.read_bd()?;

--- a/src/objects/acad_visual_style.rs
+++ b/src/objects/acad_visual_style.rs
@@ -67,6 +67,7 @@ pub struct AcadVisualStyle {
     pub edge_silhouette_color: i16,
 }
 
+/// Decodes the `AcadVisualStyle` payload that follows the common object header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<AcadVisualStyle> {
     if !version.is_r2007_plus() {
         return Err(Error::Unsupported {

--- a/src/objects/class_map_extension.rs
+++ b/src/objects/class_map_extension.rs
@@ -63,6 +63,7 @@ pub struct ClassMapExtension {
     pub entries: Vec<ClassMapExtensionEntry>,
 }
 
+/// Decodes `num_entries` class-map extension records (bounded by `MAX_CLASS_MAP_EXTENSIONS`).
 pub fn decode(
     c: &mut BitCursor<'_>,
     version: Version,

--- a/src/objects/control.rs
+++ b/src/objects/control.rs
@@ -36,6 +36,7 @@ pub struct Control {
     pub num_entries: u32,
 }
 
+/// Decodes the `Control` payload that follows the common object header.
 pub fn decode(c: &mut BitCursor<'_>) -> Result<Control> {
     let num_entries = c.read_bl()? as u32;
     Ok(Control { num_entries })

--- a/src/objects/custom_dict_entry.rs
+++ b/src/objects/custom_dict_entry.rs
@@ -46,6 +46,7 @@ pub struct CustomDictEntries {
     pub entries: Vec<CustomDictEntry>,
 }
 
+/// Decodes the entries of a custom dictionary that follow the common object header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<CustomDictEntries> {
     let num_entries = c.read_bs_u()? as usize;
     if num_entries > MAX_CUSTOM_DICT_ENTRIES {
@@ -63,14 +64,17 @@ pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<CustomDictEntri
 }
 
 impl CustomDictEntries {
+    /// Number of entries.
     pub fn len(&self) -> usize {
         self.entries.len()
     }
 
+    /// `true` when there are no entries.
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
 
+    /// Looks up the handle stored under `key`.
     pub fn get(&self, key: &str) -> Option<&Handle> {
         self.entries
             .iter()

--- a/src/objects/dictionary.rs
+++ b/src/objects/dictionary.rs
@@ -40,6 +40,7 @@ pub struct DictionaryEntry {
     pub value_handle: Handle,
 }
 
+/// Decodes the `Dictionary` payload that follows the common object header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<Dictionary> {
     let num_items = c.read_bl()? as usize;
     if num_items > 1_000_000 {

--- a/src/objects/proxy_entity.rs
+++ b/src/objects/proxy_entity.rs
@@ -39,6 +39,7 @@ pub struct ProxyEntity {
     pub handles: Vec<Handle>,
 }
 
+/// Decodes the `ProxyEntity` payload that follows the common object header.
 pub fn decode(c: &mut BitCursor<'_>, _version: crate::version::Version) -> Result<ProxyEntity> {
     let proxy_class_id = c.read_bl()? as u32;
     let data_length = c.read_bl()? as usize;

--- a/src/objects/proxy_object.rs
+++ b/src/objects/proxy_object.rs
@@ -37,6 +37,7 @@ pub struct ProxyObject {
     pub handles: Vec<Handle>,
 }
 
+/// Decodes the `ProxyObject` payload that follows the common object header.
 pub fn decode(c: &mut BitCursor<'_>, _version: crate::version::Version) -> Result<ProxyObject> {
     let proxy_class_id = c.read_bl()? as u32;
     let data_length = c.read_bl()? as usize;

--- a/src/objects/xrecord.rs
+++ b/src/objects/xrecord.rs
@@ -43,6 +43,7 @@ pub struct XRecord {
     pub cloning_flags: i16,
 }
 
+/// Decodes the `XRecord` payload that follows the common object header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<XRecord> {
     let data_bytes = c.read_bl()? as usize;
     if data_bytes > MAX_XRECORD_BYTES {

--- a/src/section_map.rs
+++ b/src/section_map.rs
@@ -84,6 +84,7 @@ pub struct DataPageHeader {
 impl DataPageHeader {
     pub const PAGE_TYPE: u32 = 0x4163_043B;
 
+    /// Parses the 0x20-byte data page header at `file_offset`.
     pub fn parse(file_bytes: &[u8], file_offset: u64) -> Result<Self> {
         if (file_offset as usize) + 0x20 > file_bytes.len() {
             return Err(Error::Truncated {

--- a/src/tables/appid.rs
+++ b/src/tables/appid.rs
@@ -23,6 +23,7 @@ pub struct AppId {
     pub unknown: u8,
 }
 
+/// Decodes a `AppId` table entry that follows the common object header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<AppId> {
     let header = read_table_entry_header(c, version)?;
     let unknown = c.read_rc()?;

--- a/src/tables/block_record.rs
+++ b/src/tables/block_record.rs
@@ -52,6 +52,7 @@ struct ModernBlockFields {
     string_start: usize,
 }
 
+/// Decodes a `BlockRecord` table entry that follows the common object header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<BlockRecord> {
     let header = read_table_entry_header(c, version)?;
     let is_anonymous = c.read_b()?;

--- a/src/tables/block_record.rs
+++ b/src/tables/block_record.rs
@@ -22,7 +22,7 @@
 
 use crate::bitcursor::BitCursor;
 use crate::entities::{Point3D, read_bd3};
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::tables::{TableEntryHeader, read_table_entry_header, read_tv};
 use crate::version::Version;
 
@@ -37,6 +37,19 @@ pub struct BlockRecord {
     pub num_owned_objects: Option<u32>,
     pub base_point: Point3D,
     pub xref_path: String,
+}
+
+#[derive(Debug, Clone)]
+struct ModernBlockFields {
+    header: TableEntryHeader,
+    is_anonymous: bool,
+    has_attribs: bool,
+    is_xref: bool,
+    xref_overlay: bool,
+    is_loaded_xref: bool,
+    num_owned_objects: Option<u32>,
+    base_point: Point3D,
+    string_start: usize,
 }
 
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<BlockRecord> {
@@ -64,6 +77,269 @@ pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<BlockRecord> {
         base_point,
         xref_path,
     })
+}
+
+/// Decode an R2007+ BLOCK_HEADER whose TV fields live in the object's
+/// trailing string stream.
+///
+/// Public ODA spec v5.4.1 §19.1/§19.4.50 says Unicode strings in R2007+
+/// objects are stored in a separate string stream even though the object
+/// field table still lists the `TV` fields inline. This keeps the legacy
+/// [`decode`] path intact for inline/synthetic streams and gives the object
+/// dispatcher a clean-room split-stream path for real modern DWGs.
+pub(crate) fn decode_modern_split_stream(
+    payload: &[u8],
+    object_body_start: usize,
+    version: Version,
+) -> Result<BlockRecord> {
+    if !version.is_r2007_plus() {
+        let mut c = BitCursor::new(payload);
+        skip_to(&mut c, object_body_start)?;
+        return decode(&mut c, version);
+    }
+
+    let data_end = pre_handle_data_end(payload, version).unwrap_or(payload.len() * 8);
+    let mut data = BitCursor::new(payload);
+    skip_to(&mut data, object_body_start)?;
+    skip_table_object_prefix(&mut data, version)?;
+    let data_start = data.position_bits();
+
+    let parsed_fields = parse_modern_block_fields(&mut data, version).ok();
+    let string_start = parsed_fields
+        .as_ref()
+        .and_then(|fields| {
+            if plausible_tv_at(payload, fields.string_start, data_end, version) {
+                Some(fields.string_start)
+            } else {
+                None
+            }
+        })
+        .or_else(|| find_block_name_string_start(payload, data_start, data_end, version))
+        .ok_or_else(|| Error::SectionMap("BLOCK_HEADER string stream not found".into()))?;
+
+    let mut strings = BitCursor::new(payload);
+    skip_to(&mut strings, string_start)?;
+    let name = read_tv(&mut strings, version)?;
+    let xref_path = read_tv(&mut strings, version).unwrap_or_default();
+    let _description = read_tv(&mut strings, version).unwrap_or_default();
+
+    let mut fields = parsed_fields.unwrap_or_else(|| ModernBlockFields {
+        header: TableEntryHeader::default(),
+        is_anonymous: false,
+        has_attribs: false,
+        is_xref: false,
+        xref_overlay: false,
+        is_loaded_xref: false,
+        num_owned_objects: None,
+        base_point: Point3D {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+        },
+        string_start,
+    });
+    fields.header.name = name;
+
+    Ok(BlockRecord {
+        header: fields.header,
+        is_anonymous: fields.is_anonymous,
+        has_attribs: fields.has_attribs,
+        is_xref: fields.is_xref,
+        xref_overlay: fields.xref_overlay,
+        is_loaded_xref: fields.is_loaded_xref,
+        num_owned_objects: fields.num_owned_objects,
+        base_point: fields.base_point,
+        xref_path,
+    })
+}
+
+fn parse_modern_block_fields(c: &mut BitCursor<'_>, version: Version) -> Result<ModernBlockFields> {
+    let flag64 = c.read_b()?;
+    let xref_index_plus_1 = c.read_bs()?;
+    let is_xref_dependent = c.read_b()?;
+    let is_anonymous = c.read_b()?;
+    let has_attribs = c.read_b()?;
+    let is_xref = c.read_b()?;
+    let xref_overlay = c.read_b()?;
+    let is_loaded_xref = if !matches!(version, Version::R14) {
+        c.read_b()?
+    } else {
+        false
+    };
+    let num_owned_objects = if version.is_r2004_plus() {
+        Some(c.read_bl()? as u32)
+    } else {
+        None
+    };
+    let base_point = read_bd3(c)?;
+    if !matches!(version, Version::R14) {
+        // Insert-count bytes: zero or more non-zero RC values, then 0.
+        for _ in 0..=256 {
+            if c.read_rc()? == 0 {
+                break;
+            }
+        }
+    }
+    if !matches!(version, Version::R14) {
+        let preview_bytes = c.read_bl_u()? as usize;
+        if preview_bytes > 1_000_000 {
+            return Err(Error::SectionMap(format!(
+                "BLOCK_HEADER preview data claims {preview_bytes} bytes"
+            )));
+        }
+        for _ in 0..preview_bytes {
+            let _ = c.read_rc()?;
+        }
+    }
+    if version.is_r2007_plus() {
+        let _insert_units = c.read_bs()?;
+        let _explodable = c.read_b()?;
+        let _block_scaling = c.read_rc()?;
+    }
+
+    Ok(ModernBlockFields {
+        header: TableEntryHeader {
+            name: String::new(),
+            is_xref_dependent,
+            xref_index_plus_1,
+            is_xref_resolved: flag64,
+        },
+        is_anonymous,
+        has_attribs,
+        is_xref,
+        xref_overlay,
+        is_loaded_xref,
+        num_owned_objects,
+        base_point,
+        string_start: c.position_bits(),
+    })
+}
+
+fn skip_table_object_prefix(c: &mut BitCursor<'_>, version: Version) -> Result<()> {
+    const MAX_XDATA_ITERATIONS: usize = 256;
+    for _ in 0..MAX_XDATA_ITERATIONS {
+        let size = c.read_bs_u()? as usize;
+        if size == 0 {
+            break;
+        }
+        let _appid = c.read_handle()?;
+        for _ in 0..size {
+            let _ = c.read_rc()?;
+        }
+    }
+
+    if version.is_r2004_plus() {
+        let _no_xdictionary = c.read_b()?;
+    }
+    if matches!(version, Version::R2013 | Version::R2018) {
+        let _has_binary_data = c.read_b()?;
+    }
+    Ok(())
+}
+
+fn pre_handle_data_end(payload: &[u8], version: Version) -> Option<usize> {
+    if !version.is_r2010_plus() {
+        return None;
+    }
+    let mut c = BitCursor::new(payload);
+    let handle_bits = read_mc_unsigned(&mut c).ok()? as usize;
+    payload.len().checked_mul(8)?.checked_sub(handle_bits)
+}
+
+fn find_block_name_string_start(
+    payload: &[u8],
+    start_bit: usize,
+    end_bit: usize,
+    version: Version,
+) -> Option<usize> {
+    let mut best: Option<(i32, usize)> = None;
+    for bit in start_bit..end_bit {
+        let Some((name, next)) = read_tv_at(payload, bit, version) else {
+            continue;
+        };
+        if next > end_bit || !is_plausible_block_name(&name) {
+            continue;
+        }
+        let score = block_name_score(&name);
+        match best {
+            Some((best_score, _)) if best_score >= score => {}
+            _ => best = Some((score, bit)),
+        }
+    }
+    best.map(|(_, bit)| bit)
+}
+
+fn plausible_tv_at(payload: &[u8], bit: usize, end_bit: usize, version: Version) -> bool {
+    read_tv_at(payload, bit, version)
+        .map(|(name, next)| next <= end_bit && is_plausible_block_name(&name))
+        .unwrap_or(false)
+}
+
+fn read_tv_at(payload: &[u8], bit: usize, version: Version) -> Option<(String, usize)> {
+    let mut c = BitCursor::new(payload);
+    skip_to(&mut c, bit).ok()?;
+    let s = read_tv(&mut c, version).ok()?;
+    Some((s, c.position_bits()))
+}
+
+fn is_plausible_block_name(name: &str) -> bool {
+    if name.is_empty() || name.chars().count() > 255 {
+        return false;
+    }
+    name.chars().all(|ch| {
+        ch == '-'
+            || ch == '_'
+            || ch == '.'
+            || ch == '$'
+            || ch == '*'
+            || ch == '{'
+            || ch == '}'
+            || ch.is_ascii_alphanumeric()
+    })
+}
+
+fn block_name_score(name: &str) -> i32 {
+    let mut score = 0;
+    if name.starts_with("*Model_Space") || name.starts_with("*Paper_Space") {
+        score += 1000;
+    } else if name.starts_with('*') {
+        score += 600;
+    } else if name.starts_with('_') {
+        score += 450;
+    } else if name.starts_with('{') && name.ends_with('}') {
+        score += 400;
+    } else if name
+        .chars()
+        .next()
+        .is_some_and(|ch| ch.is_ascii_alphanumeric())
+    {
+        score += 300;
+    }
+    score + name.chars().count().min(255) as i32
+}
+
+fn skip_to(c: &mut BitCursor<'_>, bit: usize) -> Result<()> {
+    while c.position_bits() < bit {
+        let _ = c.read_b()?;
+    }
+    Ok(())
+}
+
+fn read_mc_unsigned(cursor: &mut BitCursor<'_>) -> Result<u64> {
+    let mut value: u64 = 0;
+    let mut shift: u32 = 0;
+    for _ in 0..10 {
+        let b = cursor.read_rc()? as u64;
+        value |= (b & 0x7F) << shift;
+        if b & 0x80 == 0 {
+            return Ok(value);
+        }
+        shift += 7;
+        if shift >= 64 {
+            break;
+        }
+    }
+    Err(Error::SectionMap("MC length exceeded 10 bytes".into()))
 }
 
 #[cfg(test)]
@@ -102,5 +378,53 @@ mod tests {
         assert_eq!(b.header.name, "*Model_Space");
         assert_eq!(b.num_owned_objects, Some(42));
         assert!(!b.is_xref);
+    }
+
+    #[test]
+    fn r2007_split_stream_block_record_reads_name_from_string_stream() {
+        let mut w = BitWriter::new();
+        // Object common prefix for table objects: no EED, no xdic.
+        w.write_bs_u(0);
+        w.write_b(true);
+
+        w.write_b(true); // 64 flag
+        w.write_bs(1); // xref index + 1
+        w.write_b(false); // xdep
+        w.write_b(false); // anonymous
+        w.write_b(false); // has attribs
+        w.write_b(false); // is xref
+        w.write_b(false); // overlay
+        w.write_b(false); // loaded bit
+        w.write_bl(0); // owned objects
+        w.write_bd(0.0);
+        w.write_bd(0.0);
+        w.write_bd(0.0);
+        w.write_rc(0); // insert count terminator
+        w.write_bl(0); // preview bytes
+        w.write_bs(0); // insert units
+        w.write_b(true); // explodable
+        w.write_rc(0); // scaling
+
+        write_tu(&mut w, "*Paper_Space");
+        w.write_bs_u(0); // xref path
+        w.write_bs_u(0); // description
+
+        let bytes = w.into_bytes();
+        let block = decode_modern_split_stream(&bytes, 0, Version::R2007).unwrap();
+        assert_eq!(block.header.name, "*Paper_Space");
+        assert_eq!(block.xref_path, "");
+        assert_eq!(block.num_owned_objects, Some(0));
+        assert!(block.header.is_xref_resolved);
+        assert!(
+            block.base_point.x == 0.0 && block.base_point.y == 0.0 && block.base_point.z == 0.0
+        );
+    }
+
+    fn write_tu(w: &mut BitWriter, s: &str) {
+        w.write_bs_u(s.encode_utf16().count() as u16);
+        for unit in s.encode_utf16() {
+            w.write_rc((unit & 0xFF) as u8);
+            w.write_rc((unit >> 8) as u8);
+        }
     }
 }

--- a/src/tables/dimstyle.rs
+++ b/src/tables/dimstyle.rs
@@ -68,6 +68,7 @@ pub struct DimStyleEntry {
 // [`DimStyleEntry`].
 pub type DimStyle = DimStyleEntry;
 
+/// Decodes a `DimStyleEntry` table entry that follows the common object header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<DimStyleEntry> {
     let header = read_table_entry_header(c, version)?;
     let dimscale = c.read_bd()?;

--- a/src/tables/layer.rs
+++ b/src/tables/layer.rs
@@ -34,17 +34,21 @@ pub struct Layer {
 }
 
 impl Layer {
+    /// Bit 0x01 of `flags`: the layer is frozen.
     pub fn is_frozen(&self) -> bool {
         self.flags & 0x01 != 0
     }
+    /// Bit 0x04 of `flags`: the layer is locked.
     pub fn is_locked(&self) -> bool {
         self.flags & 0x04 != 0
     }
+    /// The layer's plot flag (plotted when set).
     pub fn is_plottable(&self) -> bool {
         self.plot_flag
     }
 }
 
+/// Decodes a `Layer` table entry that follows the common object header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<Layer> {
     let header = read_table_entry_header(c, version)?;
     let flags = c.read_bs()?;

--- a/src/tables/ltype.rs
+++ b/src/tables/ltype.rs
@@ -136,6 +136,239 @@ pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<LtypeEntry> {
     })
 }
 
+/// Decode an R2007+ LTYPE whose `TV` fields live in the object's string stream.
+///
+/// ODA v5.4.1 §19.1 says modern Unicode strings are read from the string
+/// stream even when the LTYPE field table lists `TV` inline. The data cursor
+/// therefore parses only the non-string fields at each `TV` site: entry name
+/// and description come from the string stream, while dash text uses LTYPE's
+/// fixed text area/index scheme.
+pub(crate) fn decode_modern_split_stream(
+    payload: &[u8],
+    object_body_start: usize,
+    version: Version,
+) -> Result<LtypeEntry> {
+    if !version.is_r2007_plus() {
+        let mut c = BitCursor::new(payload);
+        skip_to(&mut c, object_body_start)?;
+        return decode(&mut c, version);
+    }
+
+    let data_end = pre_handle_data_end(payload, version).unwrap_or(payload.len() * 8);
+    decode_modern_split_stream_ordered(payload, object_body_start, data_end, version).or_else(
+        |ordered_error| {
+            decode_simple_ltype_from_string_scan(payload, object_body_start, data_end, version)
+                .map_err(|_| ordered_error)
+        },
+    )
+}
+
+fn decode_modern_split_stream_ordered(
+    payload: &[u8],
+    object_body_start: usize,
+    data_end: usize,
+    version: Version,
+) -> Result<LtypeEntry> {
+    let mut data = BitCursor::new(payload);
+    skip_to(&mut data, object_body_start)?;
+    skip_table_object_prefix(&mut data, version)?;
+
+    let flag64 = data.read_b()?;
+    let xref_index_plus_1 = data.read_bs()?;
+    let is_xref_dependent = data.read_b()?;
+    let pattern_length = data.read_bd()?;
+    let alignment = data.read_rc()?;
+    let num_dashes = data.read_rc()? as usize;
+    if num_dashes > MAX_DASHES {
+        return Err(Error::SectionMap(format!(
+            "LTYPE num_dashes {num_dashes} exceeds spec cap of {MAX_DASHES}"
+        )));
+    }
+
+    let mut dashes = Vec::with_capacity(num_dashes);
+    let mut has_r2007_text_area = false;
+    for _ in 0..num_dashes {
+        let length = data.read_bd()?;
+        let shape_number = data.read_bs()?;
+        let x_offset = data.read_rd()?;
+        let y_offset = data.read_rd()?;
+        let scale = data.read_bd()?;
+        let rotation = data.read_bd()?;
+        let shape_flag = data.read_bs()?;
+        has_r2007_text_area |= shape_flag & 0x02 != 0 || shape_flag & 0x04 != 0;
+        dashes.push(LtypeDash {
+            length,
+            shape_flag,
+            x_offset,
+            y_offset,
+            scale,
+            rotation,
+            shape_number,
+            text: DashText::None,
+        });
+    }
+    if has_r2007_text_area {
+        for _ in 0..512 {
+            let _ = data.read_rc()?;
+        }
+    }
+
+    let mut strings = BitCursor::new(payload);
+    skip_to(&mut strings, data.position_bits())?;
+    let name = read_tv(&mut strings, version)?;
+    if !plausible_ltype_name(&name) {
+        return Err(Error::SectionMap(
+            "LTYPE string stream name not found".into(),
+        ));
+    }
+    let description = read_tv(&mut strings, version).unwrap_or_default();
+    if strings.position_bits() > data_end {
+        return Err(Error::SectionMap(
+            "LTYPE string stream overran pre-handle data".into(),
+        ));
+    }
+
+    Ok(LtypeEntry {
+        header: TableEntryHeader {
+            name,
+            is_xref_dependent,
+            xref_index_plus_1,
+            is_xref_resolved: flag64,
+        },
+        flags: if flag64 { 64 } else { 0 },
+        used_count: 0,
+        description,
+        pattern_length,
+        alignment,
+        dashes,
+    })
+}
+
+fn decode_simple_ltype_from_string_scan(
+    payload: &[u8],
+    object_body_start: usize,
+    data_end: usize,
+    version: Version,
+) -> Result<LtypeEntry> {
+    for string_start in object_body_start..data_end {
+        let Some((name, description)) = read_ltype_string_pair_at(payload, string_start, version)
+        else {
+            continue;
+        };
+        if !plausible_ltype_name(&name) {
+            continue;
+        }
+        let Some(pattern_start) = string_start.checked_sub(18) else {
+            continue;
+        };
+        if pattern_start < object_body_start {
+            continue;
+        }
+        let mut fields = BitCursor::new(payload);
+        skip_to(&mut fields, pattern_start)?;
+        let pattern_length = fields.read_bd()?;
+        let alignment = fields.read_rc()?;
+        let num_dashes = fields.read_rc()?;
+        if fields.position_bits() != string_start || alignment != b'A' || num_dashes != 0 {
+            continue;
+        }
+        return Ok(LtypeEntry {
+            header: TableEntryHeader {
+                name,
+                ..TableEntryHeader::default()
+            },
+            flags: 0,
+            used_count: 0,
+            description,
+            pattern_length,
+            alignment,
+            dashes: Vec::new(),
+        });
+    }
+    Err(Error::SectionMap(
+        "LTYPE string stream name not found".into(),
+    ))
+}
+
+fn read_ltype_string_pair_at(
+    payload: &[u8],
+    string_start: usize,
+    version: Version,
+) -> Option<(String, String)> {
+    let mut strings = BitCursor::new(payload);
+    skip_to(&mut strings, string_start).ok()?;
+    let name = read_tv(&mut strings, version).ok()?;
+    let description = read_tv(&mut strings, version).unwrap_or_default();
+    Some((name, description))
+}
+
+fn plausible_ltype_name(s: &str) -> bool {
+    !s.is_empty()
+        && s.len() <= 255
+        && s.chars().all(|ch| {
+            ch.is_ascii_alphanumeric()
+                || matches!(
+                    ch,
+                    '$' | '-' | '_' | '.' | '*' | ' ' | ',' | '/' | '\\' | '[' | ']'
+                )
+        })
+}
+
+fn skip_table_object_prefix(c: &mut BitCursor<'_>, version: Version) -> Result<()> {
+    const MAX_XDATA_ITERATIONS: usize = 256;
+    for _ in 0..MAX_XDATA_ITERATIONS {
+        let size = c.read_bs_u()? as usize;
+        if size == 0 {
+            break;
+        }
+        let _appid = c.read_handle()?;
+        for _ in 0..size {
+            let _ = c.read_rc()?;
+        }
+    }
+
+    if version.is_r2004_plus() {
+        let _no_xdictionary = c.read_b()?;
+    }
+    if matches!(version, Version::R2013 | Version::R2018) {
+        let _has_binary_data = c.read_b()?;
+    }
+    Ok(())
+}
+
+fn pre_handle_data_end(payload: &[u8], version: Version) -> Option<usize> {
+    if !version.is_r2010_plus() {
+        return None;
+    }
+    let mut c = BitCursor::new(payload);
+    let handle_bits = read_mc_unsigned(&mut c).ok()? as usize;
+    payload.len().checked_mul(8)?.checked_sub(handle_bits)
+}
+
+fn skip_to(c: &mut BitCursor<'_>, bit: usize) -> Result<()> {
+    while c.position_bits() < bit {
+        let _ = c.read_b()?;
+    }
+    Ok(())
+}
+
+fn read_mc_unsigned(cursor: &mut BitCursor<'_>) -> Result<u64> {
+    let mut value: u64 = 0;
+    let mut shift: u32 = 0;
+    for _ in 0..10 {
+        let b = cursor.read_rc()? as u64;
+        value |= (b & 0x7F) << shift;
+        if b & 0x80 == 0 {
+            return Ok(value);
+        }
+        shift += 7;
+        if shift >= 64 {
+            break;
+        }
+    }
+    Err(Error::SectionMap("MC length exceeded 10 bytes".into()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -216,6 +449,31 @@ mod tests {
     }
 
     #[test]
+    fn r2007_split_stream_ltype_reads_name_and_description_from_string_stream() {
+        let mut w = BitWriter::new();
+        // Object common prefix for table objects: no EED, no xdic.
+        w.write_bs_u(0);
+        w.write_b(true);
+
+        w.write_b(false); // 64 flag
+        w.write_bs(0); // xref index + 1
+        w.write_b(false); // xdep
+        w.write_bd(1.0); // pattern length
+        w.write_rc(b'A'); // alignment
+        w.write_rc(0); // no dashes
+
+        write_tu(&mut w, "Continuous");
+        write_tu(&mut w, "Solid line");
+
+        let bytes = w.into_bytes();
+        let entry = decode_modern_split_stream(&bytes, 0, Version::R2007).unwrap();
+        assert_eq!(entry.header.name, "Continuous");
+        assert_eq!(entry.description, "Solid line");
+        assert_eq!(entry.alignment, b'A');
+        assert!(entry.dashes.is_empty());
+    }
+
+    #[test]
     fn rejects_oversized_dash_count() {
         let mut w = BitWriter::new();
         write_header(&mut w, b"EVIL");
@@ -240,5 +498,13 @@ mod tests {
         let err = decode(&mut c, Version::R2000);
         assert!(err.is_err(), "expected error for adversarial dash count");
         assert_eq!(MAX_DASHES, 256);
+    }
+
+    fn write_tu(w: &mut BitWriter, s: &str) {
+        w.write_bs_u(s.encode_utf16().count() as u16);
+        for unit in s.encode_utf16() {
+            w.write_rc((unit & 0xFF) as u8);
+            w.write_rc((unit >> 8) as u8);
+        }
     }
 }

--- a/src/tables/ltype.rs
+++ b/src/tables/ltype.rs
@@ -85,6 +85,7 @@ pub struct LtypeEntry {
 // [`LtypeEntry`].
 pub type LType = LtypeEntry;
 
+/// Decodes a `LtypeEntry` table entry that follows the common object header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<LtypeEntry> {
     let header = read_table_entry_header(c, version)?;
     let flags = c.read_rc()?;

--- a/src/tables/mod.rs
+++ b/src/tables/mod.rs
@@ -55,6 +55,7 @@ pub struct TableEntryHeader {
     pub is_xref_resolved: bool,
 }
 
+/// Reads the name / xref-dependent / xref-index / xref-resolved header shared by every table entry.
 pub fn read_table_entry_header(
     c: &mut BitCursor<'_>,
     version: Version,

--- a/src/tables/style.rs
+++ b/src/tables/style.rs
@@ -56,6 +56,7 @@ impl StyleEntry {
     }
 }
 
+/// Decodes a `StyleEntry` table entry that follows the common object header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<StyleEntry> {
     let header = read_table_entry_header(c, version)?;
     let flags = c.read_rc()?;

--- a/src/tables/ucs.rs
+++ b/src/tables/ucs.rs
@@ -43,6 +43,7 @@ pub struct UcsEntry {
 // [`UcsEntry`].
 pub type Ucs = UcsEntry;
 
+/// Decodes a `UcsEntry` table entry that follows the common object header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<UcsEntry> {
     let header = read_table_entry_header(c, version)?;
     let origin = read_bd3(c)?;

--- a/src/tables/view.rs
+++ b/src/tables/view.rs
@@ -58,6 +58,7 @@ pub struct ViewEntry {
 // [`ViewEntry`].
 pub type View = ViewEntry;
 
+/// Decodes a `ViewEntry` table entry that follows the common object header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<ViewEntry> {
     let header = read_table_entry_header(c, version)?;
     let view_height = c.read_bd()?;

--- a/src/tables/vport.rs
+++ b/src/tables/vport.rs
@@ -69,6 +69,7 @@ pub struct VportEntry {
 // [`VportEntry`].
 pub type VPort = VportEntry;
 
+/// Decodes a `VportEntry` table entry that follows the common object header.
 pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<VportEntry> {
     let header = read_table_entry_header(c, version)?;
     let view_height = c.read_bd()?;

--- a/tests/integration_entity_regression.rs
+++ b/tests/integration_entity_regression.rs
@@ -52,9 +52,9 @@ fn build_line_payload() -> Vec<u8> {
     let mut w = BitWriter::new();
     w.write_b(true); // 2D
     w.write_rd(1.0); // start.x
-    w.write_bd(5.0); // end.x delta
+    w.write_dd(1.0, 6.0); // end.x
     w.write_rd(2.0); // start.y
-    w.write_bd(3.0); // end.y delta
+    w.write_dd(2.0, 5.0); // end.y
     w.write_b(true); // thickness default
     w.write_b(true); // extrusion default
     w.into_bytes()
@@ -251,10 +251,12 @@ fn build_lwpolyline_payload() -> Vec<u8> {
     let mut w = BitWriter::new();
     w.write_bs_u(0); // no flags
     w.write_bl(3); // 3 vertices
-    for (x, y) in [(0.0_f64, 0.0), (10.0, 0.0), (10.0, 10.0)] {
-        w.write_rd(x);
-        w.write_rd(y);
-    }
+    w.write_rd(0.0);
+    w.write_rd(0.0);
+    w.write_dd(0.0, 10.0);
+    w.write_dd(0.0, 0.0);
+    w.write_dd(10.0, 10.0);
+    w.write_dd(0.0, 10.0);
     w.into_bytes()
 }
 

--- a/tests/proptest_roundtrip.rs
+++ b/tests/proptest_roundtrip.rs
@@ -64,6 +64,19 @@ proptest! {
         prop_assert_eq!(c.read_bd().unwrap(), v);
     }
 
+    /// DD — bitdouble with default. Exclude NaN for equality assertion.
+    #[test]
+    fn dd_roundtrip(
+        default in any::<f64>().prop_filter("not NaN", |f| !f.is_nan()),
+        v in any::<f64>().prop_filter("not NaN", |f| !f.is_nan()),
+    ) {
+        let mut w = BitWriter::new();
+        w.write_dd(default, v);
+        let bytes = w.into_bytes();
+        let mut c = BitCursor::new(&bytes);
+        prop_assert_eq!(c.read_dd(default).unwrap(), v);
+    }
+
     /// RC (raw char u8).
     #[test]
     fn rc_roundtrip(v: u8) {

--- a/tests/r2013_entity_values.rs
+++ b/tests/r2013_entity_values.rs
@@ -27,27 +27,10 @@
 //!    AutoCAD's worldspace is `±1e20` but real drawings stay within
 //!    millions of millimeters).
 //!
-//! # Why every test here is `#[ignore]`
-//!
-//! **These invariants FAIL on the current codebase.** Two known gaps
-//! remain after the 0.1.0-alpha.1 dispatcher fixes:
-//!
-//! 1. The handle-driven object walk reaches fixed entity records in
-//!    the R2013 samples, but common-entity/body alignment is still
-//!    wrong. The LINE/CIRCLE/ARC records return dispatcher errors
-//!    instead of typed geometry.
-//! 2. On the AC1032 sample, some typed entity decoders do return
-//!    geometry, but field values are implausible — LINE endpoints
-//!    with magnitudes like 1e+290 — indicating the bit cursor is
-//!    positioned wrong inside the object's payload. Likely causes:
-//!    (a) the object-stream data/string/handle-stream split is not
-//!    modeled correctly for R2010+, or (b) a bit-counting error in
-//!    the common entity preamble shifts every subsequent read.
-//!
-//! Each test is `#[ignore]`'d so `cargo test --release -- --ignored`
-//! reveals the regression without failing the default `cargo test`
-//! run. Remove the `#[ignore]` when the underlying architecture
-//! lands and these invariants hold.
+//! These tests are active because the common-entity/body boundary is
+//! now understood for the R2013/R2018 samples. They guard against
+//! regressing the CMC-color, linetype-scale, and shadow-flag reads that
+//! previously shifted the typed entity body by tens of bits.
 
 use dwg::entities::DecodedEntity;
 use dwg::{DwgFile, Version};
@@ -72,13 +55,35 @@ fn is_plausible_coord(v: f64) -> bool {
     v.is_finite() && v.abs() < 1e12
 }
 
+fn approx_eq(actual: f64, expected: f64) -> bool {
+    (actual - expected).abs() < 1e-9
+}
+
+fn plausible_lwpolyline(poly: &dwg::entities::lwpolyline::LwPolyline) -> bool {
+    if poly.vertices.len() < 2 {
+        return false;
+    }
+    let mut min_x = f64::INFINITY;
+    let mut min_y = f64::INFINITY;
+    let mut max_x = f64::NEG_INFINITY;
+    let mut max_y = f64::NEG_INFINITY;
+    for vertex in &poly.vertices {
+        if !is_plausible_coord(vertex.x) || !is_plausible_coord(vertex.y) {
+            return false;
+        }
+        min_x = min_x.min(vertex.x);
+        min_y = min_y.min(vertex.y);
+        max_x = max_x.max(vertex.x);
+        max_y = max_y.max(vertex.y);
+    }
+    (max_x - min_x).abs() > 1e-9 || (max_y - min_y).abs() > 1e-9
+}
+
 // ================================================================
 // R2013 samples should yield the geometry they contain
 // ================================================================
 
 #[test]
-#[ignore = "#97: R2013 LINE record is reached, but common/body alignment still \
-            errors before a typed LINE is returned"]
 fn r2013_line_sample_decodes_a_line() {
     let Some(file) = open_if_present("line_2013.dwg") else {
         return;
@@ -90,21 +95,32 @@ fn r2013_line_sample_decodes_a_line() {
         .expect("R2013 supports handle walk")
         .expect("decode succeeded");
 
-    let line_count = entities
+    let lines = entities
         .iter()
-        .filter(|e| matches!(e, DecodedEntity::Line(_)))
-        .count();
-    assert!(
-        line_count >= 1,
+        .filter_map(|e| match e {
+            DecodedEntity::Line(line) => Some(line),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        lines.len(),
+        1,
         "line_2013.dwg contains exactly one LINE entity authored \
          in AutoCAD (from nextgis/dwg_samples); the handle-driven \
          walk must reach it and the dispatcher must route type 0x13 \
-         to Line. Currently decoded 0 LINE entities."
+         to Line."
     );
+    let line = lines[0];
+    assert!(line.is_2d);
+    assert!(approx_eq(line.start.x, 50.0));
+    assert!(approx_eq(line.start.y, 50.0));
+    assert!(approx_eq(line.start.z, 0.0));
+    assert!(approx_eq(line.end.x, 100.0));
+    assert!(approx_eq(line.end.y, 100.0));
+    assert!(approx_eq(line.end.z, 0.0));
 }
 
 #[test]
-#[ignore = "#97: R2013 CIRCLE record alignment still errors before typed geometry"]
 fn r2013_circle_sample_decodes_a_circle() {
     let Some(file) = open_if_present("circle_2013.dwg") else {
         return;
@@ -121,7 +137,6 @@ fn r2013_circle_sample_decodes_a_circle() {
 }
 
 #[test]
-#[ignore = "#97: R2013 ARC record alignment still errors before typed geometry"]
 fn r2013_arc_sample_decodes_an_arc() {
     let Some(file) = open_if_present("arc_2013.dwg") else {
         return;
@@ -139,9 +154,6 @@ fn r2013_arc_sample_decodes_an_arc() {
 // ================================================================
 
 #[test]
-#[ignore = "#97: sample_AC1032 decodes some LINE/CIRCLE/POINT records, but \
-            some coordinates have implausible magnitudes, indicating \
-            bit-cursor offset error inside object payloads"]
 fn all_decoded_geometry_has_plausible_coordinates() {
     // Pick every version that supports handle walking.
     let samples = [
@@ -233,4 +245,142 @@ fn all_decoded_geometry_has_plausible_coordinates() {
         offending.len(),
         offending.join("\n")
     );
+}
+
+#[test]
+fn sample_ac1032_decodes_most_line_bodies_plausibly() {
+    let Some(file) = open_if_present("sample_AC1032.dwg") else {
+        return;
+    };
+    assert_eq!(file.version(), Version::R2018);
+
+    let (entities, _summary) = file.decoded_entities().unwrap().unwrap();
+    let lines = entities
+        .iter()
+        .filter_map(|e| match e {
+            DecodedEntity::Line(line) => Some(line),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let nondegenerate = lines
+        .iter()
+        .filter(|line| {
+            let dx = line.end.x - line.start.x;
+            let dy = line.end.y - line.start.y;
+            let dz = line.end.z - line.start.z;
+            let len = (dx * dx + dy * dy + dz * dz).sqrt();
+            len.is_finite() && len > 1e-9 && len < 1e9
+        })
+        .count();
+
+    assert!(
+        lines.len() >= 80,
+        "sample_AC1032.dwg should decode the modelspace LINE population; got {}",
+        lines.len()
+    );
+    assert!(
+        nondegenerate >= 80,
+        "sample_AC1032.dwg should decode at least 80 nondegenerate LINE bodies; got {nondegenerate}"
+    );
+}
+
+#[test]
+fn sample_ac1032_decodes_common_lwpolyline_bodies_plausibly() {
+    let Some(file) = open_if_present("sample_AC1032.dwg") else {
+        return;
+    };
+    assert_eq!(file.version(), Version::R2018);
+
+    let (entities, _summary) = file.decoded_entities().unwrap().unwrap();
+    let polylines = entities
+        .iter()
+        .filter_map(|e| match e {
+            DecodedEntity::LwPolyline(polyline) => Some(polyline),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let plausible = polylines
+        .iter()
+        .filter(|polyline| plausible_lwpolyline(polyline))
+        .count();
+
+    assert!(
+        plausible >= 10,
+        "sample_AC1032.dwg should decode at least 10 finite, nondegenerate \
+         LWPOLYLINE bodies after the first-RD/subsequent-DD fix; decoded {} \
+         LWPOLYLINEs, plausible {plausible}",
+        polylines.len()
+    );
+}
+
+#[test]
+fn sample_ac1032_recovers_modern_block_record_names() {
+    let Some(file) = open_if_present("sample_AC1032.dwg") else {
+        return;
+    };
+    assert_eq!(file.version(), Version::R2018);
+
+    let (entities, _summary) = file.decoded_entities().unwrap().unwrap();
+    let names = entities
+        .iter()
+        .filter_map(|e| match e {
+            DecodedEntity::BlockRecord(block) => Some(block.header.name.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    for expected in [
+        "*Model_Space",
+        "*Paper_Space",
+        "_ArchTick",
+        "MyBlock",
+        "my_block",
+        "my_block_v2",
+        "my-dynamic-block",
+    ] {
+        assert!(
+            names.contains(&expected),
+            "missing BLOCK_HEADER name {expected:?}; decoded names: {names:?}"
+        );
+    }
+    assert!(
+        names.len() >= 20,
+        "sample_AC1032.dwg should recover the modern BLOCK_HEADER string stream; got {} names: {names:?}",
+        names.len()
+    );
+}
+
+#[test]
+fn sample_ac1032_recovers_simple_modern_ltype_names() {
+    let Some(file) = open_if_present("sample_AC1032.dwg") else {
+        return;
+    };
+    assert_eq!(file.version(), Version::R2018);
+
+    let (entities, _summary) = file.decoded_entities().unwrap().unwrap();
+    let ltypes = entities
+        .iter()
+        .filter_map(|e| match e {
+            DecodedEntity::Ltype(ltype) => Some(ltype),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let names = ltypes
+        .iter()
+        .map(|ltype| ltype.header.name.as_str())
+        .collect::<Vec<_>>();
+
+    for expected in ["ByBlock", "ByLayer", "Continuous"] {
+        assert!(
+            names.contains(&expected),
+            "missing LTYPE name {expected:?}; decoded names: {names:?}"
+        );
+    }
+    let continuous = ltypes
+        .iter()
+        .find(|ltype| ltype.header.name == "Continuous")
+        .expect("Continuous LTYPE should be decoded");
+    assert_eq!(continuous.description, "Solid line");
+    assert_eq!(continuous.alignment, b'A');
+    assert!(continuous.dashes.is_empty());
 }


### PR DESCRIPTION
## Summary
Recovers ~1,400 lines of April 2026 decoder work that was left uncommitted in the reconnaissance checkout, re-gated on a clean clone: modern (R2007+) `LTYPE` and `BLOCK_HEADER` table paths that read names from the split string stream, `LWPOLYLINE` DD vertex decoding, `LINE` DD end coordinates, `BitCursor::read_dd`, real-DWG regression tests, and the re-measured coverage docs.

## Motivation
Symbol-table names (block records, linetypes) and correct polyline vertices are exactly what Revit-exported DWGs are made of, and this is the step toward dwg-rs being usable as a documented-format oracle for rvt-rs geometry. Measured aggregate real-file coverage moves from 7.3% to 20.1% on the 19-file local sample set; the R2018 sample from 13.8% to 44.2%.

## Changes
See the CHANGELOG entries this PR adds (dated 2026-04-29, #103): `src/tables/{ltype,block_record}.rs`, `src/entities/{dispatch,line,lwpolyline}.rs`, `src/bitcursor.rs`, `src/bitwriter.rs`, `src/common_entity.rs`, `src/element_encoder.rs`, tests (`r2013_entity_values`, `integration_entity_regression`, `proptest_roundtrip`), examples (two new trace probes), README / STATUS / ROADMAP / docs numbers.

## Testing
- [x] `cargo build --all-targets`, `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`: clean
- [x] `cargo test --all-targets`: every suite green (649 lib tests + integration suites)
- [x] `examples/coverage_report.rs` re-run today against the same sample set reproduces the README table exactly: 458 decoded / 1,660 skipped / 163 errored / 20.1%; `sample_AC1032.dwg` 329 / 337 / 79 / 44.2%
- Note: the original working tree and `.git` were archived byte-for-byte first (`~/Developer/archive/dwg-rs-uncommitted-2026-08-30/`); the recon checkout is untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large changes to bit-aligned entity and table decoders on production DWG payloads; regressions would misdecode geometry or names, though real-DWG tests and coverage metrics mitigate that.
> 
> **Overview**
> This PR lands a batch of **#103** real-file decoder fixes that realign R2013/R2018 payloads and recover more symbol-table strings on modern DWGs. Measured corpus decode success rises from **~7.3% to ~20.1%** aggregate (AC1032 **~13.8% → ~44.2%**), with README/ROADMAP/STATUS and announcement copy updated to match.
> 
> **Bit primitives and geometry:** Adds **`read_dd` / `write_dd`** and switches **`LINE`** end points from BD deltas to **DD** defaults (each start coordinate). **`LWPOLYLINE`** vertices use first-point **`RD/RD`**, then **`DD/DD`** chained from the previous vertex. **`common_entity`** preamble is corrected for traced R2013/R2018 data (drops obsolete modern layer/linetype bits, R2013+ DS-data bit, **RC** `shadow_flags`, R2004+ CMC suffix skips without eating handle-stream bits).
> 
> **R2007+ tables:** **`BLOCK_HEADER`** and simple **`LTYPE`** records get split **string-stream** decode paths in `block_record` / `ltype`, wired from **`dispatch`** with legacy inline fallback. Dump example prints `BlockRecord` and `LTYPE` names.
> 
> **Verification:** **`tests/r2013_entity_values`** is active (no `#[ignore]`) with assertions on `line_2013.dwg`, AC1032 LINE/LWPOLYLINE populations, and expected block/ltype names. New forensic examples **`trace_entity_boundary`** and **`trace_table_entry`** support boundary debugging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0e3a03a2eb8e9cfb7ba427af4fdb86da2233461. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->