### PR TITLE
fix(class-map): the class record's version fields are BL, not BS (closes #37)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -441,7 +441,7 @@ list does not start at a fixed offset:
 [20..24]  RL  (R2010+) unknown, observed 0
 [24..28]  RL  (R2010+) size of the class data area, in bits
 -- bit stream: byte 20 on R2004, byte 28 on R2010+ --
-BS max_class_number, RC, RC, B, then one record per class
+BL max_class_number, B, then one record per class
 ```
 
 From R2007 the records themselves split the same way object records do:
@@ -449,6 +449,71 @@ every record's non-string fields first, then `3 × N` strings as a block
 in record order. `ClassMap::parse` accepts a table only when its class
 numbers run consecutively from 500, so a mislocated stream reports no
 classes rather than a desynchronised list a dispatcher would trust.
+
+### The class record's width fields are `BL`, not `BS` (2026-08-30, #37)
+
+The spec describes this record twice and the two descriptions disagree:
+§10.2 (R18+) gives `BS max_class_number` + `RC 0x00` + `RC 0x00`,
+`BS dwg_version` and `BS maintenance_version`; §5.8 (R2007) gives
+`BL max_class_number` and `BL` for both version fields. The bytes side
+with §5.8, and the readings are bit-identical almost everywhere:
+
+| Tag | `BS` consumes | `BL` consumes |
+|---|---|---|
+| `10` | 2 bits (value 0) | 2 bits (value 0) |
+| `01` | 10 bits (one byte) | 10 bits (one byte) |
+| `00` | 18 bits (`RS`) | 34 bits (`RL`) |
+
+`BS max_class_number` + two `RC 0x00` is 34 bits over the same four
+little-endian bytes as a tag-`00` `BL`, so the header never
+discriminates. The record tail does — but only when a version field
+exceeds 255, which no class on `arc_2004` / `arc_2010` / `arc_2013`
+does. On `sample_AC1032.dwg` four classes do:
+
+| Class | DXF name | `num_objects` | `dwg_version` | `maintenance_version` | record width |
+|---|---|---|---|---|---|
+| 508 | `MLEADERSTYLE` | 2 | 33 | 329 | 113 bits |
+| 516 | `ACDBDETAILVIEWSTYLE` | 2 | 33 | 329 | 113 bits |
+| 520 | `WIPEOUT` | 1 | 33 | 329 | 113 bits |
+| 526 | `MULTILEADER` | 15 | 33 | 329 | 113 bits |
+
+Every other record on that file is 57-89 bits wide. Reading the
+329 as a `BS` consumes 18 bits instead of 34, so record 8 ran 16 bits
+long, record 9 hit a reserved `BL` tag, and the consecutiveness check
+threw the whole table away — leaving 194 `Custom(N)` records
+undispatchable.
+
+Three independent measurements confirm the corrected field list. With
+it, exactly `max_class_number - 500 + 1` records decode with
+consecutive class numbers, and the `3 × N` strings that follow end
+precisely where the section's §19.4.1 string-stream trailer says they
+should:
+
+| File | records | records end | strings end | trailer at `size_in_bits − 32` | trailer length word |
+|---|---|---|---|---|---|
+| `arc_2010.dwg` | 10 | 877 | 8665 | 8682 | 7788 = 8665 − 877 |
+| `arc_2013.dwg` | 9 | 788 | 7826 | 7843 | 7038 = 7826 − 788 |
+| `sample_AC1032.dwg` | 50 | 4093 | 49897 | 49930 | 45804 = 49897 − 4093 |
+
+(bit offsets relative to the start of the bit stream). On the
+pre-R2007 layout, where the names are inline and there is no string
+block, the equivalent check is the declared size: `arc_2004.dwg`'s ten
+records consume 5161 of the 5168 bits its header declares, the
+remaining 7 being byte padding. A fourth check
+is the `num_objects` field the record tail now carries: summed over the
+corpus and compared with what `all_objects()` actually walks, it agrees
+exactly on the high-count classes — VISUALSTYLE 240 / 240, SCALE
+186 / 186, ACDBDETAILVIEWSTYLE 11 / 11, ACDBSECTIONVIEWSTYLE 11 / 11,
+MLEADERSTYLE 11 / 11, TABLESTYLE 10 / 10,
+BLOCKGRIPLOCATIONCOMPONENT 6 / 6 — a coincidence the mis-aligned
+reading could not produce. Where the two disagree (DICTIONARYVAR
+104 / 72, MULTILEADER 15 / 10, LAYOUT 4 / 0, CELLSTYLEMAP 18 / 3) the
+shortfall is on the *walk* side, i.e. objects the handle-map walker
+does not reach — a separate gap, not a class-table one.
+
+Reproduce with `cargo run --release --example probe_class_layout --
+samples/sample_AC1032.dwg`, which prints the per-field bit offsets,
+the record widths, the resolved names, and the trailer arithmetic.
 
 ## 8. Write pipeline (current scope)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,65 @@ once the public API stabilizes at 0.1.0.
 
 ## [Unreleased]
 
+### Fixed — the R2018 `AcDb:Classes` record layout (2026-08-30, closes #37)
+
+- **`dwg_version` and `maintenance_version` are `BL`, not `BS`.** The
+  ODA v5.4.1 spec states the class record twice and the two statements
+  disagree: §10.2 (R18+) gives `BS max_class_number` + `RC 0x00` +
+  `RC 0x00`, `BS dwg_version`, `BS maintenance_version`; §5.8 (R2007)
+  gives `BL` for all three. The bytes side with §5.8. `BS` and `BL`
+  are bit-identical on tags `10` (2 bits, zero) and `01` (10 bits, one
+  byte) and differ only on tag `00`, where `BS` takes an 18-bit `RS`
+  and `BL` a 34-bit `RL` — so the §10.2 reading survives every file
+  whose classes keep both version fields under 256.
+- **`sample_AC1032.dwg` is the first file that does not.** Four of its
+  classes — MLEADERSTYLE (508), ACDBDETAILVIEWSTYLE (516), WIPEOUT
+  (520), MULTILEADER (526) — record `dwg_version = 33`,
+  `maintenance_version = 329`, making those records 113 bits wide
+  where every other record on the file is 57-89. Reading the 329 as a
+  `BS` lost 16 bits at record 8; record 9 then hit the reserved `11`
+  `BL` tag, the consecutiveness check discarded the whole table, and
+  all 194 `Custom(N)` objects on the file fell through to
+  `Unhandled`. All 50 classes (500..=549) now decode.
+- **Corroborated three ways.** With the corrected list, exactly
+  `max_class_number - 500 + 1` records decode with consecutive class
+  numbers on `arc_2010` / `arc_2013` / `sample_AC1032`; the `3 × N`
+  strings that follow end precisely at the section's §19.4.1
+  string-stream trailer (length words 7788 / 7038 / 45804 bits, each
+  equal to the measured span); and the `num_objects` field the record
+  tail now carries matches the object walk exactly on the high-count
+  classes (VISUALSTYLE 240/240, SCALE 186/186, MLEADERSTYLE 11/11,
+  TABLESTYLE 10/10). Evidence table in `ARCHITECTURE.md` §7e.
+- **`ClassDef` gained `num_objects`, `dwg_version` and
+  `maintenance_version`**, and `write_class_map` now round-trips them
+  instead of writing zeros — the writer stays the exact inverse of the
+  parser, including the oversized-`BL` case, which a new
+  BitWriter-built test pins on both layouts.
+- **`examples/probe_class_layout.rs`** is the reproducer: per-field bit
+  offsets, record widths, resolved class names and the string-stream
+  trailer arithmetic for any R2004+ file.
+- **`examples/coverage_report.rs`** now names custom classes in its
+  unhandled histogram (`VISUALSTYLE (custom class)` rather than
+  `CUSTOM(502) (0x01F6)`); a class number is per-file, so the name is
+  the only meaningful aggregate key.
+
+Measured on the 19-file local corpus, `examples/coverage_report.rs`:
+
+| Corpus slice | Before | After |
+|---|---|---|
+| R2004 (AC1018) × 3 | 489 / 108 / 0 / 81.9 % | 489 / 108 / 0 / 81.9 % |
+| R2010 (AC1024) × 3 | 438 / 105 / 0 / 80.7 % | 438 / 105 / 0 / 80.7 % |
+| R2013 (AC1027) × 3 | 291 / 105 / 0 / 73.5 % | 291 / 105 / 0 / 73.5 % |
+| R2018 (AC1032) × 1 | 488 / 231 / 26 / 65.5 % | **533 / 166 / 46 / 71.5 %** |
+| **Aggregate** | **1706 / 549 / 26 / 74.8 %** | **1751 / 484 / 46 / 76.8 %** |
+
+65 R2018 records left *skipped*: 45 now decode (its 33 SCALE among
+them) and 20 now reach a decoder and fail — MULTILEADER (10), MESH
+(3), ACAD_TABLE (2), plus WIPEOUT, IMAGE, IMAGEDEF, ACDBDICTIONARYWDFLT
+and DICTIONARYVAR — almost all with "Bit cursor exhausted" inside the
+common entity preamble, i.e. the R2007+ preamble gap tracked under
+#103. Those 20 were always broken; the class table was hiding them.
+
 ### Fixed — non-entity objects were unreachable and read `TV` inline (2026-08-30, #103, closes #33, closes #32)
 
 - **No non-entity object was dispatched at all.** `decode_from_raw`

--- a/README.md
+++ b/README.md
@@ -27,23 +27,30 @@ local `samples/` set:
 | R2004 (AC1018)      | 3 | 489 | 108 | 0 | **81.9 %** |
 | R2010 (AC1024)      | 3 | 438 | 105 | 0 | **80.7 %** |
 | R2013 (AC1027)      | 3 | 291 | 105 | 0 | **73.5 %** |
-| R2018 (AC1032)      | 1 | 488 | 231 | 26 | **65.5 %** |
-| **Aggregate** | **19** | **1706** | **549** | **26** | **74.8 %** |
+| R2018 (AC1032)      | 1 | 533 | 166 | 46 | **71.5 %** |
+| **Aggregate** | **19** | **1751** | **484** | **46** | **76.8 %** |
 
 Per-entity-type error concentration in the measured corpus:
 
 | Type code | DXF name | Occurrences as error |
 |-----------|----------|-----------------------|
+| 526 | `MULTILEADER` (custom class) | 10 |
 | 0x4E (78) | `HATCH` | 5 |
+| 517 | `MESH` (custom class) | 3 |
 | 0x39 (57) | `LTYPE` | 3 |
 | 0x07 (7) | `INSERT` | 3 |
 | 0x1A (26) | `DIMENSION` (diameter) | 2 |
 | 0x24 (36) | `SPLINE` | 2 |
-| 0x2C (44) | `MTEXT` | 1 |
-| ... | (long tail) | 8 |
+| 523 | `ACAD_TABLE` (custom class) | 2 |
+| ... | (long tail, 1 each) | 16 |
 
-All 24 remaining errors are in the single R2018 file. Every R2004, R2010 and
-R2013 sample now decodes with **zero** errors.
+All 46 remaining errors are in the single R2018 file. Every R2004, R2010 and
+R2013 sample now decodes with **zero** errors. The error count rose from 26
+when the R2018 `AcDb:Classes` table started resolving: 65 records left
+*skipped*, 45 of them decoding and the other 20 now reaching a decoder and
+failing (mostly in the common entity preamble). Surfacing those 20 is honest
+reporting of a real gap, not a regression — they were always broken, they
+were previously invisible.
 
 **Translation:** the 27 entity decoders in [`src/entities/*.rs`](./src/entities/)
 are verified against hand-crafted synthetic input, and the R2013/R2018
@@ -81,7 +88,7 @@ real-file decode gap is the 0.2.0 milestone.
 | HandleMap + ClassMap parsing | ✓ shipped | — |
 | Header variables | ✓ shipped | Strict + lossy variants |
 | Object-stream walker (R2004+) | ✓ shipped | R14 / R2000 / R2007 pending (#104) |
-| Per-entity field decoders | ⚠ alpha | Broad synthetic coverage; real-file aggregate currently ~74.8% (#103) |
+| Per-entity field decoders | ⚠ alpha | Broad synthetic coverage; real-file aggregate currently ~76.8% (#103) |
 | Entity graph (owner / reactors / blocks / layers) | ⚠ partial | Resolver APIs exist; trailing-handle/block traversal gaps remain |
 | Symbol tables (LAYER / LTYPE / STYLE / DIMSTYLE / …) | ⚠ partial | R2007+ BLOCK_HEADER and simple LTYPE names decode; broader content fields pending |
 | SVG / PDF export | ⚠ alpha | SVG writer + paged-SVG PDF path; output quality depends on decoded geometry |
@@ -265,8 +272,8 @@ $ cargo deny check                                                # no advisorie
 
 Tests exercise the container layer end-to-end across all 19 corpus files and verify
 bit-level round-trip properties for every primitive. They do **not** verify that every
-entity decoder succeeds on every real-world drawing — that's what the 74.8 %
-aggregate / 65.5 % AC1032 coverage numbers above measure. Both classes of
+entity decoder succeeds on every real-world drawing — that's what the 76.8 %
+aggregate / 71.5 % AC1032 coverage numbers above measure. Both classes of
 testing are needed.
 
 ## Safety

--- a/STATUS.md
+++ b/STATUS.md
@@ -12,9 +12,9 @@ scrolling the changelog.
 - **Integration tests:** DXF round-trip (7), glTF smoke (3), SVG
   goldens (3), fuzz-corpus regression (6), write-path (5),
   entity-regression (18), real-DWG value regression (8).
-- **Current real-file decode coverage:** 1,706 decoded / 549 skipped /
-  26 errored / 74.8% on the local 19-file `samples/` corpus. The
-  R2018 `sample_AC1032.dwg` sample is 488 / 231 / 26 / 65.5%, and it
+- **Current real-file decode coverage:** 1,751 decoded / 484 skipped /
+  46 errored / 76.8% on the local 19-file `samples/` corpus. The
+  R2018 `sample_AC1032.dwg` sample is 533 / 166 / 46 / 71.5%, and it
   is the only file with any errors — the R2004, R2010 and R2013
   samples all decode with zero.
 - **Fuzz targets:** 9 (lz77 / bitcursor / dwg-file-open / section-map /
@@ -198,8 +198,8 @@ scrolling the changelog.
 These have genuine open scope requiring focused work, not stubs.
 
 - **Current real-file decode baseline:** the 2026-08-30
-  `examples/coverage_report.rs ../../samples` run reports 1706 decoded,
-  549 skipped, 26 errored, 74.8% aggregate coverage. This is the
+  `examples/coverage_report.rs ../../samples` run reports 1751 decoded,
+  484 skipped, 46 errored, 76.8% aggregate coverage. This is the
   practical product-readiness blocker even though synthetic decoder
   tests are broad.
 
@@ -208,22 +208,25 @@ These have genuine open scope requiring focused work, not stubs.
   ACAD_SCALE now dispatch through `src/objects/modern.rs`, taking their
   `TV` fields from the R2007+ string stream and checking their data
   fields end exactly on the record's data-stream boundary. Still
-  unreached, in descending record count on the corpus: VISUALSTYLE
-  (216 records), MATERIAL (27), LAYOUT (31), MLEADERSTYLE (12),
-  TABLESTYLE (10), MLINESTYLE (10). MATERIAL / VISUALSTYLE /
+  unreached, in descending record count on the corpus (counts as of
+  the 2026-08-30 run, which names custom classes now that the R2018
+  class table resolves): VISUALSTYLE (240 records), LAYOUT (31),
+  MATERIAL (30), ACDBDETAILVIEWSTYLE (11), ACDBSECTIONVIEWSTYLE (11),
+  MLEADERSTYLE (11), MLINESTYLE (10), TABLESTYLE (10).
+  MATERIAL / VISUALSTYLE /
   PROPERTYSET_DATA decode only a documented prefix of their fields, so
   they cannot satisfy the boundary check; LAYOUT (which embeds the
   PLOTSETTINGS field list) and MLINESTYLE have field lists this crate
   has not yet matched against real bytes.
 
-- **#33 R2018 `AcDb:Classes` record layout.** `ClassMap::parse` now
-  reads the class table correctly on R2004, R2010 and R2013 (10 / 10 /
-  9 classes, names and object counts matching the object stream). On
-  `sample_AC1032.dwg` the ninth record does not decode with the same
-  field list, so the parser's consecutiveness check rejects the table
-  and every `Custom(N)` object in that file — 194 records, including
-  its 33 SCALE records — stays `Unhandled`. This is the single largest
-  remaining lever on the R2018 sample.
+- **R2018 entity preamble for custom-class entities** (surfaced by
+  #37). With the class table resolving on `sample_AC1032.dwg`, its
+  MULTILEADER (10), MESH (3), ACAD_TABLE (2), WIPEOUT (1) and IMAGE
+  (1) records now reach their decoders and fail in the *common entity
+  preamble* — "Bit cursor exhausted: wanted 8 bits, 3 bits remain" —
+  before any per-entity field is read. That is the same R2007+
+  preamble/handle-stream boundary problem tracked under #103, now
+  visible on five more classes.
 
 - **R2007+ symbol-table common object prefix.** `tables/modern.rs`
   omits the `BL num_reactors` that `objects/modern.rs` measured as

--- a/examples/coverage_report.rs
+++ b/examples/coverage_report.rs
@@ -97,11 +97,21 @@ fn main() -> ExitCode {
         for (tc, _msg) in &summary.errors {
             type_histo.entry(*tc).or_default().2 += 1;
         }
+        // Custom(N) codes mean nothing on their own — the DXF class
+        // name comes from this file's AcDb:Classes table, so an
+        // unhandled custom object is only honest when it is named.
+        let class_map = file.class_map().and_then(std::result::Result::ok);
         for entity in &entities {
             if let DecodedEntity::Unhandled { type_code, kind } = entity {
-                *unhandled_histo
-                    .entry(format!("{kind} (0x{type_code:04X})"))
-                    .or_default() += 1;
+                // Custom class numbers are per-file, so an aggregate
+                // histogram keys them by name alone; built-in codes
+                // keep their code because it is stable across files.
+                let label = class_map
+                    .as_ref()
+                    .and_then(|m| m.by_type_code(*type_code))
+                    .map(|d| format!("{} (custom class)", d.dxf_class_name))
+                    .unwrap_or_else(|| format!("{kind} (0x{type_code:04X})"));
+                *unhandled_histo.entry(label).or_default() += 1;
             }
         }
         totals.decoded += summary.decoded;

--- a/examples/probe_class_layout.rs
+++ b/examples/probe_class_layout.rs
@@ -1,0 +1,213 @@
+//! Where does every field of every `AcDb:Classes` record start and end?
+//!
+//! # What this proves
+//!
+//! That the R2007+ class record ends with **five `BL`s**
+//! (`num_objects`, `dwg_version`, `maintenance_version`, and two
+//! unknowns) and not with the `BL`, `BS`, `BS`, `BL`, `BL` spelled out
+//! in ODA Open Design Specification v5.4.1 §10.2. The two readings are
+//! bit-identical while `dwg_version` and `maintenance_version` stay
+//! below 256; they diverge by sixteen bits the first time one of them
+//! does not, which is issue #37.
+//!
+//! The probe prints, per record, the absolute bit offset of every
+//! field, the record's total width, and the decoded values — the class
+//! numbers must run 500, 501, 502, … with no gap. It then prints the
+//! §19.4.1 string-stream trailer of the section, which is the
+//! independent check: the trailer's length word must equal the span
+//! between the end of the last record and the end of the last string.
+//!
+//! ```sh
+//! cargo run --release --example probe_class_layout -- samples/sample_AC1032.dwg
+//! ```
+//!
+//! Expected on `sample_AC1032.dwg` (AC1032): 50 records, 500..=549,
+//! last record ending on bit 4093, string block ending on bit 49897,
+//! trailer length word 45804 = 49897 − 4093.
+//!
+//! On a pre-R2007 file the names are inline in each record and there is
+//! no string block, so the check is the declared size instead: on
+//! `arc_2004.dwg` the ten records consume 5161 of the 5168 bits the
+//! header declares, the remaining 7 being byte padding.
+
+use dwg::DwgFile;
+use dwg::bitcursor::BitCursor;
+use dwg::error::Result;
+
+/// Read a `TU` (UTF-16LE) string the way the R2007+ class list stores
+/// its three names: `BS` code-unit count, then that many LE `u16`s.
+fn read_tu(c: &mut BitCursor<'_>) -> Result<String> {
+    let len = c.read_bs_u()? as usize;
+    let mut units = Vec::with_capacity(len);
+    for _ in 0..len {
+        let lo = u16::from(c.read_rc()?);
+        let hi = u16::from(c.read_rc()?);
+        units.push((hi << 8) | lo);
+    }
+    if units.last() == Some(&0) {
+        units.pop();
+    }
+    Ok(String::from_utf16_lossy(&units))
+}
+
+/// Read a `TV` the pre-R2007 way: `BS` byte count, then that many
+/// 8-bit characters.
+fn read_tv8(c: &mut BitCursor<'_>) -> Result<String> {
+    let len = c.read_bs_u()? as usize;
+    let mut bytes = Vec::with_capacity(len);
+    for _ in 0..len {
+        bytes.push(c.read_rc()?);
+    }
+    if bytes.last() == Some(&0) {
+        bytes.pop();
+    }
+    Ok(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+/// A cursor parked on absolute bit `bit` of `bytes`.
+fn cursor_at(bytes: &[u8], bit: usize) -> Option<BitCursor<'_>> {
+    let mut c = BitCursor::new(bytes.get(bit / 8..)?);
+    for _ in 0..(bit % 8) {
+        c.read_b().ok()?;
+    }
+    Some(c)
+}
+
+/// Read a 16-bit value at `bit` with the `RS` byte order the string-
+/// stream trailer uses (low byte first).
+fn word_at(bytes: &[u8], bit: usize) -> Option<u16> {
+    Some(cursor_at(bytes, bit)?.read_rs().ok()? as u16)
+}
+
+fn main() -> Result<()> {
+    let path = std::env::args()
+        .nth(1)
+        .expect("usage: probe_class_layout <file.dwg>");
+    let file = DwgFile::open(&path)?;
+    let version = file.version();
+    let Some(bytes) = file.read_section("AcDb:Classes") else {
+        println!("{path} ({version}) has no named AcDb:Classes section");
+        return Ok(());
+    };
+    let bytes = bytes?;
+
+    let bit_start = if version.is_r2007_plus() { 28 } else { 20 };
+    let size_bytes = u32::from_le_bytes(bytes[16..20].try_into().expect("4 bytes")) as usize;
+    let size_bits = if version.is_r2007_plus() {
+        u32::from_le_bytes(bytes[24..28].try_into().expect("4 bytes")) as usize
+    } else {
+        size_bytes * 8
+    };
+    println!("{path}  ({version})");
+    println!(
+        "section {} bytes, class data area {size_bytes} bytes / {size_bits} bits, \
+         bit stream starts at byte {bit_start}",
+        bytes.len()
+    );
+
+    let data = &bytes[bit_start..];
+    let mut c = BitCursor::new(data);
+    let max_class_number = c.read_bl_u()?;
+    let flag = c.read_b()?;
+    println!(
+        "BL max_class_number = {max_class_number}, B = {flag} (header is {} bits)",
+        c.position_bits()
+    );
+
+    let expected = (max_class_number as usize).saturating_sub(500) + 1;
+    println!();
+    println!(
+        "{:>4} {:>7} {:>7} {:>5}  {:>6} {:>6} {:>6} {:>6} {:>6} {:>6}",
+        "cls", "start", "end", "bits", "ver", "proxy", "icid", "num", "dwgv", "maint"
+    );
+    let split = version.is_r2007_plus();
+    let mut widths = Vec::new();
+    let mut inline_names = Vec::new();
+    for i in 0..expected {
+        let start = c.position_bits();
+        let class_number = c.read_bs_u()?;
+        let version_flag = c.read_bs()?;
+        if !split {
+            // Pre-R2007 the three names sit inline, 8-bit, right here.
+            inline_names.push((read_tv8(&mut c)?, read_tv8(&mut c)?, read_tv8(&mut c)?));
+        }
+        let was_a_proxy = c.read_b()?;
+        let item_class_id = c.read_bs_u()?;
+        let num_objects = c.read_bl_u()?;
+        let dwg_version = c.read_bl_u()?;
+        let maintenance_version = c.read_bl_u()?;
+        let _unknown1 = c.read_bl()?;
+        let _unknown2 = c.read_bl()?;
+        let end = c.position_bits();
+        widths.push(end - start);
+        let flag = if class_number as usize == 500 + i {
+            " "
+        } else {
+            "  <-- NOT CONSECUTIVE"
+        };
+        println!(
+            "{class_number:>4} {start:>7} {end:>7} {:>5}  {version_flag:>6} {:>6} 0x{item_class_id:04X} \
+             {num_objects:>6} {dwg_version:>6} {maintenance_version:>6}{flag}",
+            end - start,
+            u8::from(was_a_proxy),
+        );
+    }
+    let records_end = c.position_bits();
+    println!();
+    println!(
+        "{expected} records, {records_end} bits, widths {}..{}",
+        widths.iter().min().copied().unwrap_or(0),
+        widths.iter().max().copied().unwrap_or(0)
+    );
+
+    if !split {
+        println!("pre-R2007: names are inline in each record, no string block");
+        println!();
+        for (i, (app, cpp, dxf)) in inline_names.iter().enumerate() {
+            println!("{:>4}  {app:<24} {cpp:<38} {dxf}", 500 + i);
+        }
+        println!();
+        println!(
+            "class data area is {} bits; the records consumed {records_end}, \
+             leaving {} bits of byte padding",
+            size_bytes * 8,
+            size_bytes * 8 - records_end
+        );
+        return Ok(());
+    }
+
+    println!();
+    for i in 0..expected {
+        let app = read_tu(&mut c)?;
+        let cpp = read_tu(&mut c)?;
+        let dxf = read_tu(&mut c)?;
+        println!("{:>4}  {app:<24} {cpp:<38} {dxf}", 500 + i);
+    }
+    let strings_end = c.position_bits();
+
+    // §19.4.1 string-stream trailer, measured to sit at
+    // `size_bits - 32` relative to the start of the bit stream.
+    let end = size_bits.saturating_sub(32);
+    let present = match cursor_at(data, end.saturating_sub(1)) {
+        Some(mut term) => term.read_b().unwrap_or(false),
+        None => false,
+    };
+    let w1 = word_at(data, end.saturating_sub(17)).unwrap_or(0);
+    let str_len = if w1 & 0x8000 != 0 {
+        let w2 = word_at(data, end.saturating_sub(33)).unwrap_or(0);
+        (u32::from(w1 & 0x7FFF)) | (u32::from(w2) << 15)
+    } else {
+        u32::from(w1)
+    };
+    println!();
+    println!("string block read forward: {records_end}..{strings_end}");
+    println!(
+        "string-stream trailer at {end} (= size_bits - 32): present = {present}, \
+         length word = {str_len}"
+    );
+    println!(
+        "trailer agrees with the forward read: {}",
+        u32::try_from(strings_end - records_end) == Ok(str_len)
+    );
+    Ok(())
+}

--- a/src/classes.rs
+++ b/src/classes.rs
@@ -19,24 +19,54 @@
 //! [20..24]  RL  (R2010+) unknown, observed 0
 //! [24..28]  RL  (R2010+) size of the class data area, in bits
 //! -- bit stream starts here: byte 20 on R2004, byte 28 on R2010+ --
-//!   BS   max_class_number
-//!   RC   unknown
-//!   RC   unknown
+//!   BL   max_class_number
 //!   B    unknown
 //!   // then one record per custom class:
 //!   BS   class_number
 //!   BS   version / proxy flags
-//!   TV   app_name
-//!   TV   cpp_class_name
-//!   TV   dxf_class_name
+//!   TV   app_name          -- inline pre-R2007, string block from R2007
+//!   TV   cpp_class_name    -- inline pre-R2007, string block from R2007
+//!   TV   dxf_class_name    -- inline pre-R2007, string block from R2007
 //!   B    was_a_proxy
 //!   BS   item_class_id  (0x1F2 proxy entity, 0x1F3 proxy object)
 //!   BL   num_objects           -- R2004+
-//!   BS   dwg_version           -- R2004+
-//!   BS   maintenance_version   -- R2004+
+//!   BL   dwg_version           -- R2004+
+//!   BL   maintenance_version   -- R2004+
 //!   BL   unknown               -- R2004+
 //!   BL   unknown               -- R2004+
 //! ```
+//!
+//! # The spec states this record two different ways; the bytes pick one
+//!
+//! The ODA Open Design Specification v5.4.1 describes the class table
+//! twice, and the two descriptions disagree on three fields:
+//!
+//! | Field | §10.2 (R18+) | §5.8 (R2007) |
+//! |---|---|---|
+//! | `max_class_number` | `BS` + `RC 0x00` + `RC 0x00` | `BL` |
+//! | `dwg_version` | `BS` | `BL` |
+//! | `maintenance_version` | `BS` | `BL` |
+//!
+//! §5.8 is the one the bytes agree with, and the two readings are
+//! *bit-identical* for most values, which is why the disagreement went
+//! unnoticed until `sample_AC1032.dwg`:
+//!
+//! - `BS` and `BL` share the 2-bit tag alphabet (`01` → one byte,
+//!   `10` → zero). They diverge only on tag `00`, where `BS` consumes a
+//!   16-bit `RS` and `BL` a 32-bit `RL`.
+//! - `BS max_class_number` + two `RC`s consumes 2 + 16 + 16 = 34 bits;
+//!   `BL max_class_number` with tag `00` consumes 2 + 32 = 34 bits over
+//!   the same four little-endian bytes. Identical whenever the value
+//!   exceeds 255, which every real `max_class_number` (≥ 500) does.
+//!
+//! So the §10.2 reading survives on any file whose class records all
+//! carry `dwg_version ≤ 255` and `maintenance_version ≤ 255`. On
+//! `sample_AC1032.dwg` four classes — MLEADERSTYLE (508),
+//! ACDBDETAILVIEWSTYLE (516), WIPEOUT (520) and MULTILEADER (526) —
+//! record `dwg_version = 33`, `maintenance_version = 329`. Reading
+//! that `BL` as a `BS` consumes 18 bits instead of 34 and loses 16
+//! bits of alignment per occurrence, which is the drift reported in
+//! issue #37.
 //!
 //! # Why the header length is measured, not assumed
 //!
@@ -50,18 +80,47 @@
 //!
 //! The offsets above are read off the bytes:
 //!
-//! | File | Bytes 16.. | First bits after the header | Decodes to |
+//! | File | Bytes 16.. | First bits after the header | `BL` decodes to |
 //! |---|---|---|---|
-//! | `arc_2004.dwg` (AC1018) | `86 02 00 00` then `3F 40 40 00 …` | `00` + `1111110100000001` | `BS` = 509 |
-//! | `arc_2010.dwg` (AC1024) | `42 04 00 00 00 00 00 00 0A 22 00 00` then `3F 40 40 00 …` | same | `BS` = 509 |
-//! | `arc_2013.dwg` (AC1027) | `D9 03 00 00 00 00 00 00 C3 1E 00 00` then `3F 00 40 00 …` | `00` + `1111110000000001` | `BS` = 508 |
-//! | `sample_AC1032.dwg` (AC1032) | `66 18 00 00 00 00 00 00 2A C3 00 00` then `09 40 80 00 …` | `00` + `0010010100000010` | `BS` = 549 |
+//! | `arc_2004.dwg` (AC1018) | `86 02 00 00` then `3F 40 40 00 …` | `00` + `FD 01 00 00` | 509 |
+//! | `arc_2010.dwg` (AC1024) | `42 04 00 00 00 00 00 00 0A 22 00 00` then `3F 40 40 00 …` | same | 509 |
+//! | `arc_2013.dwg` (AC1027) | `D9 03 00 00 00 00 00 00 C3 1E 00 00` then `3F 00 40 00 …` | `00` + `FC 01 00 00` | 508 |
+//! | `sample_AC1032.dwg` (AC1032) | `66 18 00 00 00 00 00 00 2A C3 00 00` then `09 40 80 00 …` | `00` + `25 02 00 00` | 549 |
 //!
 //! and every one of those matches the highest `Custom(N)` type code the
 //! object stream of that file actually uses (508 / 508 / 507 / 547).
 //! Continuing to parse from there yields class numbers that run
 //! 500, 501, 502, … consecutively up to `max_class_number - 1`, which is
 //! the check [`ClassMap::parse`] applies before accepting a table.
+//!
+//! # The record count and the string block corroborate each other
+//!
+//! On R2007+ the three names of every record live in one string block
+//! that follows the last record, so a record list that stops one bit
+//! early pairs every name with the wrong class. Three independent
+//! measurements agree that reading exactly
+//! `max_class_number - 500 + 1` records with the field list above
+//! lands on the first bit of that block:
+//!
+//! | File | records | last record ends | string block ends | `AcDb:Classes` string-stream end bit |
+//! |---|---|---|---|---|
+//! | `arc_2010.dwg` | 10 | 877 | 8665 | 8682 = `size_in_bits` (8714) − 32 |
+//! | `arc_2013.dwg` | 9 | 788 | 7826 | 7843 = `size_in_bits` (7875) − 32 |
+//! | `sample_AC1032.dwg` | 50 | 4093 | 49897 | 49930 = `size_in_bits` (49962) − 32 |
+//!
+//! (bit offsets relative to the start of the bit stream.) The
+//! right-hand column is the §19.4.1 string-stream trailer: its
+//! terminating bit is set in all three files, and its length word
+//! reads 7788 / 7038 / 45804 bits — exactly the span between the end
+//! of the last record and the end of the last string in each file.
+//! `sample_AC1032.dwg` exercises the two-word form
+//! (`0xB2EC` has bit 15 set, second word 1 →
+//! `(0xB2EC & 0x7FFF) | (1 << 15) = 45804`).
+//!
+//! The parser does not need the trailer — the record count comes from
+//! `max_class_number` and the strings follow the records directly —
+//! but it is the strongest available check that the field list above
+//! is the real one, so `examples/probe_class_layout.rs` prints it.
 //!
 //! R2007 (`AC1021`) is not in the table above because this crate cannot
 //! read that release's sections yet (`STATUS.md` #110); its header is
@@ -95,6 +154,15 @@ pub struct ClassDef {
     /// 0x1F2 → proxy entity, 0x1F3 → proxy object, anything else is
     /// a vendor-specific dynamic class (IMAGE, TABLE, MLEADER, ...).
     pub item_class_id: u16,
+    /// Number of objects of this class in the drawing (DXF group 91).
+    /// Zero on pre-R2004 files, which do not record it.
+    pub num_objects: u32,
+    /// Release code of the AutoCAD build that last wrote this class
+    /// definition (20 = R2000 … 33 = R2018). Zero pre-R2004.
+    pub dwg_version: u32,
+    /// Maintenance-release counter of that build. Zero pre-R2004, and
+    /// the field that overflows a `BS` on R2018 — see the module docs.
+    pub maintenance_version: u32,
 }
 
 /// Parsed custom class table.
@@ -130,11 +198,13 @@ impl ClassMap {
         ) as usize;
 
         let mut c = BitCursor::new(&bytes[bit_start..]);
-        let Ok(max_class_number) = c.read_bs_u() else {
+        // §5.8: `BL max_class_number` then one unknown `B`. §10.2
+        // spells the same 34 bits as `BS` + `RC 0x00` + `RC 0x00`; see
+        // the module docs for why only `BL` generalises.
+        let Ok(max_class_number) = c.read_bl_u() else {
             return Ok(Self::default());
         };
-        // Two unknown RCs and one unknown B close the class-list header.
-        if c.read_rc().is_err() || c.read_rc().is_err() || c.read_b().is_err() {
+        if c.read_b().is_err() {
             return Ok(Self::default());
         }
 
@@ -164,7 +234,7 @@ impl ClassMap {
             .enumerate()
             .all(|(i, d)| d.class_number as usize == FIRST_CUSTOM_CLASS_NUMBER as usize + i);
         Ok(Self {
-            max_class_number: u32::from(max_class_number),
+            max_class_number,
             classes: if consecutive { classes } else { Vec::new() },
         })
     }
@@ -197,9 +267,11 @@ fn read_inline_class_record(c: &mut BitCursor<'_>, version: Version) -> Option<C
     let dxf_class_name = read_tv(c, version).ok()?;
     let was_a_proxy = c.read_b().ok()?;
     let item_class_id = c.read_bs_u().ok()?;
-    if version.is_r2004_plus() {
-        read_r2004_record_tail(c)?;
-    }
+    let tail = if version.is_r2004_plus() {
+        read_r2004_record_tail(c)?
+    } else {
+        RecordTail::default()
+    };
     if app_name.is_empty() && cpp_class_name.is_empty() && dxf_class_name.is_empty() {
         return None;
     }
@@ -211,6 +283,9 @@ fn read_inline_class_record(c: &mut BitCursor<'_>, version: Version) -> Option<C
         dxf_class_name,
         was_a_proxy,
         item_class_id,
+        num_objects: tail.num_objects,
+        dwg_version: tail.dwg_version,
+        maintenance_version: tail.maintenance_version,
     })
 }
 
@@ -229,11 +304,18 @@ fn read_inline_class_record(c: &mut BitCursor<'_>, version: Version) -> Option<C
 /// order, and the 28th read is junk. `arc_2010.dwg` agrees with ten
 /// records, 500..=509.
 ///
-/// `sample_AC1032.dwg` (R2018) declares 50 records but its ninth record
-/// does not decode with this field list — see `STATUS.md`. This
-/// function returns what it read; [`ClassMap::parse`]'s consecutiveness
-/// check then rejects the short list rather than pairing 9 records with
-/// strings meant for 50.
+/// `sample_AC1032.dwg` (R2018) declares 50 records; with
+/// `maintenance_version` read as the `BL` §5.8 specifies, all 50
+/// decode as 500..=549 and the 150 strings that follow read
+/// `ACDBDICTIONARYWDFLT`, `ACDBPLACEHOLDER`, `LAYOUT`,
+/// `DICTIONARYVAR`, `TABLESTYLE`, `MATERIAL`, `VISUALSTYLE`, `SCALE`,
+/// `MLEADERSTYLE`, … `ACDBPERSSUBENTMANAGER` — the last string ending
+/// exactly on the section's string-stream boundary.
+///
+/// A short read means the string block does not start where this
+/// function is about to look, so the names would be paired with the
+/// wrong classes; the function then reports nothing rather than a
+/// desynchronised list.
 fn read_split_stream_classes(c: &mut BitCursor<'_>, expected: usize) -> Vec<ClassDef> {
     let mut classes = Vec::with_capacity(expected.min(64));
     for _ in 0..expected {
@@ -269,7 +351,7 @@ fn read_split_stream_class_record(c: &mut BitCursor<'_>) -> Option<ClassDef> {
     let version_flag = c.read_bs().ok()?;
     let was_a_proxy = c.read_b().ok()?;
     let item_class_id = c.read_bs_u().ok()?;
-    read_r2004_record_tail(c)?;
+    let tail = read_r2004_record_tail(c)?;
     Some(ClassDef {
         class_number,
         version: version_flag,
@@ -278,18 +360,34 @@ fn read_split_stream_class_record(c: &mut BitCursor<'_>) -> Option<ClassDef> {
         dxf_class_name: String::new(),
         was_a_proxy,
         item_class_id,
+        num_objects: tail.num_objects,
+        dwg_version: tail.dwg_version,
+        maintenance_version: tail.maintenance_version,
     })
 }
 
-/// `BL num_objects`, `BS dwg_version`, `BS maintenance_version` and two
-/// unknown `BL`s — the five fields R2004 added to every class record.
-fn read_r2004_record_tail(c: &mut BitCursor<'_>) -> Option<()> {
-    let _num_objects = c.read_bl_u().ok()?;
-    let _dwg_version = c.read_bs().ok()?;
-    let _maintenance_version = c.read_bs().ok()?;
+/// The three carried values of the five-field record tail R2004 added.
+#[derive(Default)]
+struct RecordTail {
+    num_objects: u32,
+    dwg_version: u32,
+    maintenance_version: u32,
+}
+
+/// `BL num_objects`, `BL dwg_version`, `BL maintenance_version` and two
+/// unknown `BL`s — the five fields R2004 added to every class record
+/// (§5.8). The two trailing unknowns are 0 on every file measured.
+fn read_r2004_record_tail(c: &mut BitCursor<'_>) -> Option<RecordTail> {
+    let num_objects = c.read_bl_u().ok()?;
+    let dwg_version = c.read_bl_u().ok()?;
+    let maintenance_version = c.read_bl_u().ok()?;
     let _unknown1 = c.read_bl().ok()?;
     let _unknown2 = c.read_bl().ok()?;
-    Some(())
+    Some(RecordTail {
+        num_objects,
+        dwg_version,
+        maintenance_version,
+    })
 }
 
 // TV string reading is delegated to `crate::tables::read_tv`, which
@@ -316,8 +414,8 @@ fn read_r2004_record_tail(c: &mut BitCursor<'_>) -> Option<()> {
 // [20..] / [28..]                  — the bit-packed class list
 // ```
 //
-// The bit-packed list opens with `BS max_class_number`, two unknown
-// `RC`s and one unknown `B`, then one record per class. Pre-R2007 a
+// The bit-packed list opens with `BL max_class_number` and one unknown
+// `B`, then one record per class. Pre-R2007 a
 // record carries its three `TV`s inline; from R2007 the non-string
 // fields of every record come first and the `3 × N` strings follow as a
 // block, in record order. A trailing CRC-8 (§2.14.1, seed 0xC0C1)
@@ -361,11 +459,12 @@ fn class_list_max(classes: &ClassMap) -> u16 {
         .unwrap_or_else(|| classes.max_class_number.min(u32::from(u16::MAX)) as u16)
 }
 
-/// Write the five fields R2004 added to every class record, all zero.
-fn write_r2004_record_tail(w: &mut BitWriter) {
-    w.write_bl(0); // num_objects
-    w.write_bs(0); // dwg_version
-    w.write_bs(0); // maintenance_version
+/// Write the five fields R2004 added to every class record — the
+/// inverse of [`read_r2004_record_tail`], all five as `BL` per §5.8.
+fn write_r2004_record_tail(w: &mut BitWriter, def: &ClassDef) {
+    w.write_bl_u(def.num_objects);
+    w.write_bl_u(def.dwg_version);
+    w.write_bl_u(def.maintenance_version);
     w.write_bl(0); // unknown
     w.write_bl(0); // unknown
 }
@@ -374,15 +473,25 @@ fn write_r2004_record_tail(w: &mut BitWriter) {
 ///
 /// `writer` is used for internal bit-packing; the returned `Vec<u8>` is
 /// the fully-assembled section bytes ready for LZ77 compression by the
-/// section writer. The 16-byte sentinel, 4-byte size-in-bits header,
-/// 4-byte `max_class_number`, and trailing CRC-8 are included; the
-/// caller composes this with the R2004+ page framing layer.
+/// section writer. The 16-byte sentinel, the byte-aligned size header
+/// and the trailing CRC-8 are included; the caller composes this with
+/// the R2004+ page framing layer.
 ///
 /// The internal `writer` argument is there purely so the function
 /// signature matches the write-path convention used by the element
 /// encoders (`trait ElementEncoder`) — the actual class bytes are
 /// produced in a fresh [`BitWriter`] and then prefixed / suffixed by
-/// the sentinel, size header, max-class-number, and CRC.
+/// the sentinel, size header, and CRC.
+///
+/// # Not a byte-exact AutoCAD emitter
+///
+/// This is the inverse of [`ClassMap::parse`], not a reproduction of
+/// what AutoCAD writes. Two known differences on R2007+: the
+/// `size in bits` header is written as the bit length of the class
+/// data alone, where real files carry that length plus 32 (see the
+/// module docs), and the §19.4.1 string-stream trailer that real files
+/// append after the string block is not emitted. Neither is read back
+/// by [`ClassMap::parse`], so the round trip is exact.
 ///
 /// # CRC
 ///
@@ -397,9 +506,7 @@ pub fn write_class_map(
     use crate::crc::crc8;
 
     let mut inner = BitWriter::new();
-    inner.write_bs_u(class_list_max(classes));
-    inner.write_rc(0); // unknown
-    inner.write_rc(0); // unknown
+    inner.write_bl_u(u32::from(class_list_max(classes)));
     inner.write_b(true); // unknown
     if version.is_r2007_plus() {
         for def in &classes.classes {
@@ -407,7 +514,7 @@ pub fn write_class_map(
             inner.write_bs(def.version);
             inner.write_b(def.was_a_proxy);
             inner.write_bs_u(def.item_class_id);
-            write_r2004_record_tail(&mut inner);
+            write_r2004_record_tail(&mut inner, def);
         }
         for def in &classes.classes {
             write_tv(&mut inner, &def.app_name, version);
@@ -424,7 +531,7 @@ pub fn write_class_map(
             inner.write_b(def.was_a_proxy);
             inner.write_bs_u(def.item_class_id);
             if version.is_r2004_plus() {
-                write_r2004_record_tail(&mut inner);
+                write_r2004_record_tail(&mut inner, def);
             }
         }
     }
@@ -521,6 +628,9 @@ mod tests {
                     dxf_class_name: "TABLE".to_string(),
                     was_a_proxy: false,
                     item_class_id: 0x1F2,
+                    num_objects: 3,
+                    dwg_version: 25,
+                    maintenance_version: 20,
                 },
                 ClassDef {
                     class_number: 501,
@@ -530,6 +640,11 @@ mod tests {
                     dxf_class_name: "WIPEOUT".to_string(),
                     was_a_proxy: true,
                     item_class_id: 0x1F2,
+                    // The R2018 drift value: > 255, so this field's `BL`
+                    // takes the 32-bit tag-`00` form a `BS` misreads.
+                    num_objects: 1,
+                    dwg_version: 33,
+                    maintenance_version: 329,
                 },
             ],
         }
@@ -554,6 +669,60 @@ mod tests {
         assert_eq!(parsed.max_class_number, 501);
         assert_eq!(parsed.classes, map.classes);
         assert_eq!(parsed.by_type_code(501).unwrap().dxf_class_name, "WIPEOUT");
+    }
+
+    /// Issue #37 in one fixture: a `maintenance_version` above 255
+    /// encodes as a tag-`00` `BL` (2 + 32 bits). Reading it as a `BS`
+    /// consumes 2 + 16 and loses sixteen bits of alignment, which on
+    /// `sample_AC1032.dwg` desynchronised the class list at record 9
+    /// and dropped all 50 classes.
+    ///
+    /// The fixture puts the oversized field in the *first* of three
+    /// records so a `BS` reader cannot reach record 2 at all.
+    #[test]
+    fn parse_reads_a_maintenance_version_wider_than_a_byte() {
+        let map = ClassMap {
+            max_class_number: 502,
+            classes: (0..3)
+                .map(|i| ClassDef {
+                    class_number: 500 + i,
+                    version: 0,
+                    app_name: "ACDB_MLEADERSTYLE_CLASS".to_string(),
+                    cpp_class_name: "AcDbMLeaderStyle".to_string(),
+                    dxf_class_name: "MLEADERSTYLE".to_string(),
+                    was_a_proxy: false,
+                    item_class_id: 0x1F3,
+                    num_objects: 2,
+                    dwg_version: 33,
+                    maintenance_version: if i == 0 { 329 } else { 42 },
+                })
+                .collect(),
+        };
+        for version in [Version::R2004, Version::R2018] {
+            let mut w = BitWriter::new();
+            let bytes = write_class_map(&map, &mut w, version).unwrap();
+            let parsed = ClassMap::parse(&bytes, version).unwrap();
+            assert_eq!(parsed.classes.len(), 3, "{version}");
+            assert_eq!(parsed.classes, map.classes, "{version}");
+            assert_eq!(parsed.classes[0].maintenance_version, 329, "{version}");
+            assert_eq!(parsed.classes[2].class_number, 502, "{version}");
+        }
+    }
+
+    /// The record tail's three carried values survive the round trip —
+    /// `num_objects` is the count this crate cross-checks against the
+    /// object stream when validating that the table is located right.
+    #[test]
+    fn write_class_map_round_trips_the_record_tail_values() {
+        let map = sample_map();
+        let mut w = BitWriter::new();
+        let bytes = write_class_map(&map, &mut w, Version::R2018).unwrap();
+        let parsed = ClassMap::parse(&bytes, Version::R2018).unwrap();
+        let wipeout = parsed.by_type_code(501).unwrap();
+        assert_eq!(wipeout.num_objects, 1);
+        assert_eq!(wipeout.dwg_version, 33);
+        assert_eq!(wipeout.maintenance_version, 329);
+        assert_eq!(parsed.by_type_code(500).unwrap().num_objects, 3);
     }
 
     /// A table whose class numbers do not run consecutively from 500


### PR DESCRIPTION
## Summary

`sample_AC1032.dwg`'s `AcDb:Classes` list desynchronised at record 9, so all 194 `Custom(N)` objects on the file — its 33 SCALE records included — stayed `Unhandled`. The cause is a **contradiction inside the ODA spec** that the bytes settle.

The spec states the class record twice:

| Field | §10.2 (R18+) | §5.8 (R2007) |
|---|---|---|
| `max_class_number` | `BS` + `RC 0x00` + `RC 0x00` | `BL` |
| `dwg_version` | `BS` | `BL` |
| `maintenance_version` | `BS` | `BL` |

`BS` and `BL` are **bit-identical** on tag `10` (2 bits, zero) and tag `01` (10 bits, one byte), and differ only on tag `00`, where `BS` takes an 18-bit `RS` and `BL` a 34-bit `RL`. `BS max_class_number` + two `RC 0x00` is also 34 bits over the same four little-endian bytes as a tag-`00` `BL`, so the header never discriminates. The §10.2 reading therefore survives on any file whose classes keep both version fields under 256 — which is every class on `arc_2004`, `arc_2010` and `arc_2013`.

`sample_AC1032.dwg` is the first file that doesn't:

| Class | DXF name | `num_objects` | `dwg_version` | `maintenance_version` | record width |
|---|---|---|---|---|---|
| 508 | `MLEADERSTYLE` | 2 | 33 | 329 | 113 bits |
| 516 | `ACDBDETAILVIEWSTYLE` | 2 | 33 | 329 | 113 bits |
| 520 | `WIPEOUT` | 1 | 33 | 329 | 113 bits |
| 526 | `MULTILEADER` | 15 | 33 | 329 | 113 bits |

Every other record on that file is 57-89 bits. Reading the `329` as a `BS` consumes 18 bits instead of 34, so record 8 ran 16 bits long, record 9 hit the reserved `11` `BL` tag, and the consecutiveness guard threw the whole table away.

## The R2018 class-record layout, with evidence

```text
[0..16]   sentinel
[16..20]  RL  size of the class data area, in bytes
[20..24]  RL  (R2010+) unknown, observed 0
[24..28]  RL  (R2010+) size of the class data area, in bits
-- bit stream: byte 20 on R2004, byte 28 on R2010+ --
BL max_class_number
B  unknown
-- then max_class_number - 500 + 1 records: --
BS class_number
BS version / proxy flags
TV app_name / cpp_class_name / dxf_class_name   (inline pre-R2007; string block from R2007)
B  was_a_proxy
BS item_class_id
BL num_objects
BL dwg_version           <-- BS in §10.2
BL maintenance_version   <-- BS in §10.2
BL unknown (0 on every file measured)
BL unknown (0 on every file measured)
```

**1. The record count lands exactly on the string block.** On R2007+ all `3 × N` names live in one block after the last record, so a list that stops one bit early mis-pairs every name. With the corrected field list, reading exactly `max_class_number - 500 + 1` records lands on the block's first bit and the names come out in order (`ACDBDICTIONARYWDFLT`, `ACDBPLACEHOLDER`, `LAYOUT`, … `ACDBPERSSUBENTMANAGER` on AC1032).

**2. The §19.4.1 string-stream trailer agrees independently.** Its terminating bit is set on all three files and its length word equals the measured span, including the two-word form on AC1032 (`0xB2EC` has bit 15 set, second word 1 → `(0xB2EC & 0x7FFF) | (1 << 15) = 45804`):

| File | records | records end | strings end | trailer at `size_in_bits − 32` | length word |
|---|---|---|---|---|---|
| `arc_2010.dwg` | 10 | 877 | 8665 | 8682 | 7788 = 8665 − 877 |
| `arc_2013.dwg` | 9 | 788 | 7826 | 7843 | 7038 = 7826 − 788 |
| `sample_AC1032.dwg` | 50 | 4093 | 49897 | 49930 | 45804 = 49897 − 4093 |

(bit offsets relative to the start of the bit stream.) On the pre-R2007 layout the equivalent check is the declared size: `arc_2004.dwg`'s ten records consume 5161 of the 5168 bits its header declares, the remaining 7 being byte padding.

**3. `num_objects` matches the object walk.** The field is now carried on `ClassDef`; summed over the corpus against what `all_objects()` walks it agrees exactly on the high-count classes — VISUALSTYLE 240/240, SCALE 186/186, ACDBDETAILVIEWSTYLE 11/11, ACDBSECTIONVIEWSTYLE 11/11, MLEADERSTYLE 11/11, TABLESTYLE 10/10, BLOCKGRIPLOCATIONCOMPONENT 6/6. Where the two disagree (DICTIONARYVAR 104/72, MULTILEADER 15/10, LAYOUT 4/0) the shortfall is on the walk side — objects the handle-map walker doesn't reach — not the class table.

`examples/probe_class_layout.rs` prints all of this:

```sh
cargo run --release --example probe_class_layout -- samples/sample_AC1032.dwg
```

## Measured coverage

`cargo run --release --example coverage_report -- <19-file samples dir>`:

| Corpus slice | Before | After |
|---|---|---|
| R2004 (AC1018) × 3 | 489 / 108 / 0 / 81.9 % | 489 / 108 / 0 / 81.9 % |
| R2010 (AC1024) × 3 | 438 / 105 / 0 / 80.7 % | 438 / 105 / 0 / 80.7 % |
| R2013 (AC1027) × 3 | 291 / 105 / 0 / 73.5 % | 291 / 105 / 0 / 73.5 % |
| R2018 (AC1032) × 1 | 488 / 231 / 26 / 65.5 % | **533 / 166 / 46 / 71.5 %** |
| **Aggregate** | **1706 / 549 / 26 / 74.8 %** | **1751 / 484 / 46 / 76.8 %** |

65 R2018 records left *skipped*. 45 of them now decode (the 33 SCALE records among them). The other 20 now reach a decoder and fail: MULTILEADER (10), MESH (3), ACAD_TABLE (2), WIPEOUT, IMAGE, IMAGEDEF, ACDBDICTIONARYWDFLT, DICTIONARYVAR — almost all with `Bit cursor exhausted: wanted 8 bits, 3 bits remain` inside the *common entity preamble*, before any per-entity field is read. That is the R2007+ preamble/handle-stream gap already tracked under #103, now visible on five more classes. Those 20 were always broken; the missing class table was hiding them.

## Also in this PR

- `ClassDef` gained `num_objects`, `dwg_version`, `maintenance_version`; `write_class_map` round-trips them instead of writing zeros, so the writer is still the exact inverse of the parser — including the oversized-`BL` case, pinned by a new BitWriter-built test on both the inline (R2004) and split (R2018) layouts.
- `write_class_map`'s doc now states plainly where it is *not* a byte-exact AutoCAD emitter (the size-in-bits header and the string-stream trailer), since neither is read back.
- `examples/coverage_report.rs` names custom classes in its unhandled histogram — `VISUALSTYLE (custom class)` rather than `CUSTOM(502) (0x01F6)`. A class number is per-file, so the name is the only meaningful aggregate key; this also merged two entries that were the same class under different numbers on different files.

## Spec sections

- ODA Open Design Specification for .dwg files v5.4.1 **§5.8** — `AcDb:Classes` for R2007+: `RL` size in bytes, `RL` total size in bits, `BL` maximum class number, `B`, class data, string stream data, `B`. Record tail `BL` / `BL` / `BL` / `BL` / `BL`. **This is the description the bytes match.**
- **§10.2** — `AcDb:Classes` for R18+: the `BS` + `RC` + `RC` header and `BS` version fields. Bit-identical on the observed value range; wrong on `sample_AC1032.dwg`.
- **§10.1** — R13-R15 layout (no `max_class_number`, no record tail), unchanged here and still unreachable in practice: those releases do not expose the section by name.
- **§19.4.1** — string-stream location, reused as the corroborating check.
- **§2.1 / §2.3 / §2.4** — `B` / `BS` / `BL` tag alphabets, which is what makes the two spec readings collide.

## Source provenance

**Clean-room declaration.** I certify that:

1. All code and tests in this PR were written from scratch for this repository.
2. Sources consulted were limited to those `CLEANROOM.md` lists as allowed: the freely-redistributable ODA *Open Design Specification for .dwg files* v5.4.1 PDF (§5.8, §10.1, §10.2, §19.4.1, §2.x), and first-party byte inspection of the publicly-available sample DWGs in the local corpus (`nextgis/dwg_samples` lineage plus `sample_AC1032.dwg`). No Autodesk SDK source, no ODA SDK / Teigha source, no LibreDWG, no decompilation of any Autodesk or ODA binary, and no copyleft-licensed DWG implementation code.
3. The spec sections this PR relies on are cited above and in the diff (`src/classes.rs` module docs, `ARCHITECTURE.md` §7e, `examples/probe_class_layout.rs`).
4. I have never had access to any of the forbidden sources in a commercial or NDA'd context.

## Gate

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --release` (693 lib + all integration suites), `cargo deny check all`, `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --all-features`, and `cargo +1.85.0 test --no-run` (MSRV) all pass. The canonical-corpus fixtures did not move: the class-map writer change only affects the record tail, which those fixtures do not pin.

Closes #37

https://claude.ai/code/session_01BaHKf1Rw5aJBGK5y3xmx7C

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bit-level layout for the class table and custom-type dispatch on R2004+; impact is mitigated by consecutiveness checks, round-trip tests, and a fixture for maintenance_version > 255.
> 
> **Overview**
> **Fixes R2018 `AcDb:Classes` parsing** so custom object types dispatch by DXF name instead of falling through as anonymous `Custom(N)`.
> 
> The ODA spec disagrees on whether `max_class_number`, `dwg_version`, and `maintenance_version` are `BS` or `BL`; the old parser followed §10.2. That matches §5.8 while values stay ≤255, but on `sample_AC1032.dwg` four classes use `maintenance_version = 329`, which misreads as `BS` and desynchronizes the table at record 9. The consecutiveness guard then drops the whole map, leaving **194 custom objects undispatchable**. The parser and `write_class_map` now use **`BL` for those fields** (§5.8), and **`ClassDef`** carries **`num_objects`**, **`dwg_version`**, and **`maintenance_version`** with writer round-trip.
> 
> Adds **`examples/probe_class_layout.rs`** for bit-offset / string-trailer verification, and **`coverage_report`** labels unhandled custom types by **DXF class name**. Corpus aggregate decode rate moves **74.8% → 76.8%** on the R2018 sample; **error count rises** because objects that were skipped now hit decoders and fail in the common entity preamble (#103), not because of a regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01b6c8452ec1d2d8584550f7971f1232ae87df96. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->