### PR TITLE
fix(entities): the R2010+ entity graphics-preview block is sized by a BLL, not an RL

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -147,7 +147,7 @@ bit granularity. Key methods:
 |-----------------|--------------------------------------------------|--------------------------|
 | `read_b`        | 1 bit                                            | `bool`                   |
 | `read_bb`       | 2 bits                                           | `0..=3`                  |
-| `read_3b`       | 1-3 bits (early-stop on 0)                       | `{0, 2, 6, 7}`           |
+| `read_3b`       | 3 raw bits (the BLL byte count)                  | `0..=7`                  |
 | `read_bs`       | 2-bit tag + {16, 8, 0, 0} bit payload            | `i16`                    |
 | `read_bl`       | 2-bit tag + {32, 8, 0, reserved} bit payload     | `i32`                    |
 | `read_bd`       | 2-bit tag + {64, 0, 0, reserved} bit payload     | `f64`                    |
@@ -514,6 +514,60 @@ does not reach — a separate gap, not a class-table one.
 Reproduce with `cargo run --release --example probe_class_layout --
 samples/sample_AC1032.dwg`, which prints the per-field bit offsets,
 the record widths, the resolved names, and the trailer arithmetic.
+
+## 7f. The entity graphics-preview block (finding, 2026-08-30)
+
+The common entity preamble (§19.4.1) opens with the EED chain, then a
+single `B` "graphics present" flag. When that flag is set, a size field
+and that many bytes of proxy graphics follow — and **the size field
+changes width across the release bands**:
+
+| Release band | Graphics size field |
+|---|---|
+| R13 - R2007 | `RL` (32 bits) |
+| R2010+ | `BLL` (§2.4 — a three-bit byte count, then that many LE bytes) |
+
+Read as an `RL` on R2018 the field yields sizes in the millions of
+bytes for records a few hundred bytes long, and the byte-skip loop runs
+off the end of the record inside the preamble, before any
+entity-specific field.
+
+**Custom classes were a correlation, not a cause.** AutoCAD writes
+proxy graphics for entities whose class it does not implement natively,
+so the flag is set on MULTILEADER / MESH / ACAD_TABLE / WIPEOUT / IMAGE
+and clear on LINE / TEXT / MTEXT. The preamble is byte-for-byte the same
+field list either way; the graphics branch simply had no coverage until
+the R2018 class table started resolving (#41) and those records began
+reaching a decoder.
+
+**The `BLL` byte count is three raw bits.** The crate previously read
+the `3B` code as a stop-at-zero prefix, which can only produce
+`{0, 2, 6, 7}` — a set with no encoding for "one byte", which the file
+requires. Measured on `sample_AC1032.dwg`:
+
+| record | prefix bits | size bytes | preamble ends at bit |
+|---|---|---|---|
+| IMAGE `0x662` | `001` + `8C` | 140 | 1213 |
+| WIPEOUT `0x44D` | `001` + `8C` | 140 | 1213 |
+| MULTILEADER `0x66E` | `010` + `50 03` | 848 | 6885 |
+| MULTILEADER `0x818` | `010` + `98 02` | 664 | 5413 |
+| MESH `0x343` | `010` + `28 25` | 9512 | 76197 |
+| MESH `0x380` | `010` + `08 24` | 9224 | 73893 |
+
+The check that this is right is what follows the block: every one of
+those records then reads `entmode = 2`, `num_reactors = 0`,
+`no_xdictionary = true`, colour `0x0100`, linetype scale `1.0`, all
+flag fields `0`, `invisibility = 0`, `lineweight = 0x1D` — bit-for-bit
+the values every plain LINE / TEXT / MTEXT record in the same file
+carries. `examples/probe_entity_preamble.rs` prints both readings side
+by side for any record.
+
+Two more things fall out of the same two records. The IMAGE and the
+WIPEOUT are **bit-identical for their first 175 bits**, which is how we
+know `AcDbWipeout` stores a raster-image record verbatim; and an IMAGE
+clip boundary of type 1 (rectangle) carries **no vertex count** — the
+two corners follow the boundary type directly, while the polygon form
+(type 2) does carry the count.
 
 ## 8. Write pipeline (current scope)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,74 @@ once the public API stabilizes at 0.1.0.
 
 ## [Unreleased]
 
+### Fixed — the R2010+ entity graphics-preview block is sized by a `BLL` (2026-08-30, closes #42)
+
+- **The common entity preamble's graphics-preview size is an `RL` up to
+  R2007 and a `BLL` (§2.4) from R2010 on.** Reading it as an `RL` on
+  R2018 produced preview sizes in the millions of bytes for records only
+  a few hundred bytes long, and the preamble ran off the end of the
+  record: `Bit cursor exhausted: wanted 8 bits, 3 bits remain`, before
+  any entity-specific field. That was all 20 errors #41 newly surfaced
+  on `sample_AC1032.dwg` — MULTILEADER (10), MESH (3), ACAD_TABLE (2),
+  WIPEOUT, IMAGE.
+- **Custom classes are a correlation, not a cause.** AutoCAD writes
+  proxy graphics for entities whose class it does not implement
+  natively, so the `graphics present` flag is set on exactly the
+  custom-class records and clear on LINE / TEXT / MTEXT. The preamble
+  itself is identical for both; the graphics branch was simply never
+  exercised without one. Nothing in the class record — `was_a_proxy`,
+  `is_an_entity`, proxy flags — changes the field list.
+- **`3B` is three raw bits, not a stop-at-zero prefix code.** The old
+  reading could only produce `{0, 2, 6, 7}`, a set with no way to say
+  "one byte". The bytes require exactly that: the IMAGE at handle
+  `0x662` and the WIPEOUT at `0x44D` both write `001` + `0x8C` = 140
+  bytes of preview; MULTILEADER `0x66E` writes `010` + `0x50 0x03` =
+  848; MESH `0x343` writes 9512. Every one of those lands the rest of
+  the preamble on fields matching the values every plain entity in the
+  same file carries (`entmode = 2`, `num_reactors = 0`,
+  `no_xdictionary`, colour `0x0100`, linetype scale `1.0`,
+  `invisibility = 0`, `lineweight = 0x1D`). `BitWriter::write_bll` now
+  emits the exact byte count instead of rounding up to a representable
+  prefix length.
+- New probe `examples/probe_entity_preamble.rs` traces every entity's
+  preamble under both readings and prints the bits left to the record's
+  data boundary.
+
+### Fixed — IMAGE / WIPEOUT / MESH bodies on R2018 (2026-08-30)
+
+- **An IMAGE clip boundary of type 1 (rectangle) carries no vertex
+  count.** The two corners follow the boundary type directly. The `BL`
+  the decoder read there consumed the first 34 bits of the `-0.5`
+  corner of `sample_AC1032.dwg`'s IMAGE, silently returning a wrong
+  rectangle and overrunning the record. The polygon form (type 2) does
+  carry the count — the WIPEOUT on the same file reads `4` there,
+  followed by four `RD2` vertices that end one bit before its data
+  boundary.
+- **WIPEOUT stores a raster-image record.** The two records are
+  bit-identical for their first 175 bits, and decoding the WIPEOUT with
+  the IMAGE field list closes it exactly on its boundary. The previous
+  WIPEOUT field list (`BL clip_state`, `BS` count, `BD2` vertices,
+  `B show_clipped`, three `RC`s) matched no part of those bytes — it was
+  decoding the graphics-preview payload as geometry.
+  `entities::wipeout::Wipeout` is now an alias for
+  `entities::image::Image` and `wipeout::decode` takes a `Version`.
+- **A MESH's face-list count is a count of `BL` entries, not of
+  faces**, and edge endpoints are `BL`, not `BS`. Both real MESH
+  records now decode: 62 vertices / 336 face-list entries / 72 faces /
+  132 edges and 64 / 320 / 64 / 128, with Euler characteristics 2 and 0
+  — the independent check that the lists were read at the right
+  offsets. The crease array has its own `BL` count. `decode` now
+  rejects any face index or edge endpoint outside the vertex cage.
+  Three bits before the data boundary are left unread and documented
+  rather than guessed: both records hold `100` there.
+- `Mesh::edges` is now `Vec<(u32, u32)>`.
+
+### Changed
+
+- `examples/coverage_report.rs` names the type in its error histogram,
+  resolving custom classes through the file's `AcDb:Classes` table the
+  way the unhandled histogram already did (closes #16).
+
 ### Fixed — the R2018 `AcDb:Classes` record layout (2026-08-30, closes #37)
 
 - **`dwg_version` and `maintenance_version` are `BL`, not `BS`.** The

--- a/README.md
+++ b/README.md
@@ -27,30 +27,29 @@ local `samples/` set:
 | R2004 (AC1018)      | 3 | 489 | 108 | 0 | **81.9 %** |
 | R2010 (AC1024)      | 3 | 438 | 105 | 0 | **80.7 %** |
 | R2013 (AC1027)      | 3 | 291 | 105 | 0 | **73.5 %** |
-| R2018 (AC1032)      | 1 | 533 | 166 | 46 | **71.5 %** |
-| **Aggregate** | **19** | **1751** | **484** | **46** | **76.8 %** |
+| R2018 (AC1032)      | 1 | 537 | 169 | 39 | **72.1 %** |
+| **Aggregate** | **19** | **1755** | **487** | **39** | **76.9 %** |
 
 Per-entity-type error concentration in the measured corpus:
 
-| Type code | DXF name | Occurrences as error |
-|-----------|----------|-----------------------|
-| 526 | `MULTILEADER` (custom class) | 10 |
-| 0x4E (78) | `HATCH` | 5 |
-| 517 | `MESH` (custom class) | 3 |
-| 0x39 (57) | `LTYPE` | 3 |
-| 0x07 (7) | `INSERT` | 3 |
-| 0x1A (26) | `DIMENSION` (diameter) | 2 |
-| 0x24 (36) | `SPLINE` | 2 |
-| 523 | `ACAD_TABLE` (custom class) | 2 |
-| ... | (long tail, 1 each) | 16 |
+| DXF name | Occurrences as error |
+|----------|-----------------------|
+| `MULTILEADER` (custom class) | 10 |
+| `HATCH` (0x004E) | 5 |
+| `INSERT` (0x0007) | 3 |
+| `LTYPE` (0x0039) | 3 |
+| `DIMENSION_DIAMETER` (0x001A) | 2 |
+| `SPLINE` (0x0024) | 2 |
+| ... | (long tail, 1 each) | 14 |
 
-All 46 remaining errors are in the single R2018 file. Every R2004, R2010 and
-R2013 sample now decodes with **zero** errors. The error count rose from 26
-when the R2018 `AcDb:Classes` table started resolving: 65 records left
-*skipped*, 45 of them decoding and the other 20 now reaching a decoder and
-failing (mostly in the common entity preamble). Surfacing those 20 is honest
-reporting of a real gap, not a regression — they were always broken, they
-were previously invisible.
+All 39 remaining errors are in the single R2018 file. Every R2004, R2010 and
+R2013 sample decodes with **zero** errors. The R2018 count peaked at 46 when
+the `AcDb:Classes` table started resolving and 20 custom-class entities began
+reaching a decoder for the first time; the common entity preamble's
+graphics-preview block is now sized correctly on R2010+ (a `BLL`, not an `RL`
+— see [`src/common_entity.rs`](./src/common_entity.rs)), so IMAGE, WIPEOUT,
+ACAD_TABLE and both real MESH records get past it. The ten MULTILEADER
+failures are now in the MLEADER *body*, not the preamble.
 
 **Translation:** the 27 entity decoders in [`src/entities/*.rs`](./src/entities/)
 are verified against hand-crafted synthetic input, and the R2013/R2018
@@ -88,7 +87,7 @@ real-file decode gap is the 0.2.0 milestone.
 | HandleMap + ClassMap parsing | ✓ shipped | — |
 | Header variables | ✓ shipped | Strict + lossy variants |
 | Object-stream walker (R2004+) | ✓ shipped | R14 / R2000 / R2007 pending (#104) |
-| Per-entity field decoders | ⚠ alpha | Broad synthetic coverage; real-file aggregate currently ~76.8% (#103) |
+| Per-entity field decoders | ⚠ alpha | Broad synthetic coverage; real-file aggregate currently ~76.9% (#103) |
 | Entity graph (owner / reactors / blocks / layers) | ⚠ partial | Resolver APIs exist; trailing-handle/block traversal gaps remain |
 | Symbol tables (LAYER / LTYPE / STYLE / DIMSTYLE / …) | ⚠ partial | R2007+ BLOCK_HEADER and simple LTYPE names decode; broader content fields pending |
 | SVG / PDF export | ⚠ alpha | SVG writer + paged-SVG PDF path; output quality depends on decoded geometry |
@@ -272,8 +271,8 @@ $ cargo deny check                                                # no advisorie
 
 Tests exercise the container layer end-to-end across all 19 corpus files and verify
 bit-level round-trip properties for every primitive. They do **not** verify that every
-entity decoder succeeds on every real-world drawing — that's what the 76.8 %
-aggregate / 71.5 % AC1032 coverage numbers above measure. Both classes of
+entity decoder succeeds on every real-world drawing — that's what the 76.9 %
+aggregate / 72.1 % AC1032 coverage numbers above measure. Both classes of
 testing are needed.
 
 ## Safety

--- a/STATUS.md
+++ b/STATUS.md
@@ -12,9 +12,9 @@ scrolling the changelog.
 - **Integration tests:** DXF round-trip (7), glTF smoke (3), SVG
   goldens (3), fuzz-corpus regression (6), write-path (5),
   entity-regression (18), real-DWG value regression (8).
-- **Current real-file decode coverage:** 1,751 decoded / 484 skipped /
-  46 errored / 76.8% on the local 19-file `samples/` corpus. The
-  R2018 `sample_AC1032.dwg` sample is 533 / 166 / 46 / 71.5%, and it
+- **Current real-file decode coverage:** 1,755 decoded / 487 skipped /
+  39 errored / 76.9% on the local 19-file `samples/` corpus. The
+  R2018 `sample_AC1032.dwg` sample is 537 / 169 / 39 / 72.1%, and it
   is the only file with any errors — the R2004, R2010 and R2013
   samples all decode with zero.
 - **Fuzz targets:** 9 (lz77 / bitcursor / dwg-file-open / section-map /
@@ -198,10 +198,38 @@ scrolling the changelog.
 These have genuine open scope requiring focused work, not stubs.
 
 - **Current real-file decode baseline:** the 2026-08-30
-  `examples/coverage_report.rs ../../samples` run reports 1751 decoded,
-  484 skipped, 46 errored, 76.8% aggregate coverage. This is the
+  `examples/coverage_report.rs ../../samples` run reports 1755 decoded,
+  487 skipped, 39 errored, 76.9% aggregate coverage. This is the
   practical product-readiness blocker even though synthetic decoder
   tests are broad.
+
+- **#42 R2007+ custom-class entity preamble — closed.** The
+  graphics-preview block that follows a set `graphics present` flag is
+  sized by a `BLL` (§2.4) from R2010 on, not the `RL` used up to R2007,
+  and the `BLL` byte-count prefix is three raw bits. AutoCAD writes
+  proxy graphics for classes it does not implement natively, so that
+  flag is set on exactly the custom-class entities and clear on
+  LINE / TEXT / MTEXT — which is why the whole failure population looked
+  class-shaped. Nothing about the class record changes the preamble.
+  Measured on `sample_AC1032.dwg`: IMAGE `0x662` and WIPEOUT `0x44D`
+  carry 140-byte previews (`001` + `8C`), MULTILEADER `0x66E` 848 bytes
+  (`010` + `50 03`), MESH `0x343` 9512 bytes. All 20 preamble failures
+  are gone; the ten MULTILEADER errors are now MLEADER *body* failures
+  (#31).
+
+- **#44 CUSTOM(727) — not a type-code bug.** The three records read
+  `tag = 01` + `0xE7` + `0x1F0` = 727, which is exactly what the byte
+  says. They are not objects: handle `0x1607` decodes a handle field
+  with `counter = 11` (an 11-byte handle value), handle `0x15E6`
+  decodes `code 9 counter 0 value 0`, and their `MS` sizes (29,927 /
+  23,087 bytes) are inconsistent with their `MC` handle-stream sizes
+  (14,220 / 687 bits). Two more handle-map entries show the same
+  signature (`0x13E2` → CUSTOM(517), `0x13E7` → CUSTOM(564)), and six
+  handle-map offsets already point past the end of the assembled
+  section: the map addresses up to byte 1,289,590 while
+  `AcDb:AcDbObjects` assembles to 1,192,851 bytes, its own declared
+  size. The defect is in the handle-map / section-assembly address
+  space (#43), not in `read_object_type`.
 
 - **#33 remaining non-entity objects.** DICTIONARY, DICTIONARYVAR,
   XRECORD, ACDB_PLACEHOLDER, the ten `*_CONTROL` owners, ACAD_GROUP and

--- a/examples/coverage_report.rs
+++ b/examples/coverage_report.rs
@@ -15,7 +15,7 @@
 //! [`dump_decoded_entities`](../examples/dump_decoded_entities.rs).
 
 use dwg::entities::DecodedEntity;
-use dwg::{DwgFile, entities::DispatchSummary};
+use dwg::{DwgFile, ObjectType, entities::DispatchSummary};
 use std::collections::BTreeMap;
 use std::env;
 use std::path::PathBuf;
@@ -45,7 +45,7 @@ fn main() -> ExitCode {
     }
 
     let mut totals = DispatchSummary::default();
-    let mut type_histo: BTreeMap<u16, (usize, usize, usize)> = BTreeMap::new();
+    let mut type_histo: BTreeMap<String, usize> = BTreeMap::new();
     let mut unhandled_histo: BTreeMap<String, usize> = BTreeMap::new();
 
     println!(
@@ -93,14 +93,20 @@ fn main() -> ExitCode {
             summary.decoded_ratio() * 100.0
         );
 
-        // Accumulate per-type histogram via error dedup.
-        for (tc, _msg) in &summary.errors {
-            type_histo.entry(*tc).or_default().2 += 1;
-        }
         // Custom(N) codes mean nothing on their own — the DXF class
         // name comes from this file's AcDb:Classes table, so an
         // unhandled custom object is only honest when it is named.
         let class_map = file.class_map().and_then(std::result::Result::ok);
+        // Accumulate per-type histogram via error dedup, keyed by the
+        // same name the unhandled histogram uses.
+        for (tc, _msg) in &summary.errors {
+            let label = class_map
+                .as_ref()
+                .and_then(|m| m.by_type_code(*tc))
+                .map(|d| format!("{} (custom class)", d.dxf_class_name))
+                .unwrap_or_else(|| format!("{} (0x{tc:04X})", ObjectType::from_code(*tc)));
+            *type_histo.entry(label).or_default() += 1;
+        }
         for entity in &entities {
             if let DecodedEntity::Unhandled { type_code, kind } = entity {
                 // Custom class numbers are per-file, so an aggregate
@@ -131,14 +137,11 @@ fn main() -> ExitCode {
     );
     println!();
     if !type_histo.is_empty() {
-        println!("Error histogram by type code (top 10):");
-        let mut err_counts: Vec<(u16, usize)> = type_histo
-            .iter()
-            .map(|(tc, (_, _, err))| (*tc, *err))
-            .collect();
-        err_counts.sort_by_key(|(_, cnt)| std::cmp::Reverse(*cnt));
-        for (tc, cnt) in err_counts.iter().take(10) {
-            println!("  type_code {tc:<5} → {cnt} errors");
+        println!("Error histogram by kind (top 10):");
+        let mut rows: Vec<(&String, &usize)> = type_histo.iter().collect();
+        rows.sort_by_key(|(label, cnt)| (std::cmp::Reverse(**cnt), (*label).clone()));
+        for (label, cnt) in rows.iter().take(10) {
+            println!("  {label:<32} → {cnt} errors");
         }
     }
     if !unhandled_histo.is_empty() {

--- a/examples/probe_entity_preamble.rs
+++ b/examples/probe_entity_preamble.rs
@@ -1,0 +1,209 @@
+//! Where does the R2007+ common entity preamble (§19.4.1) end, and
+//! does the graphics-preview block use an `RL` or a `BLL` size?
+//!
+//! # What this measures
+//!
+//! Every entity record carries a self-checking boundary
+//! ([`dwg::object::data_end_bit`]): on R2010+ it is the first bit of the
+//! record's string stream (or the start of its handle stream when the
+//! record holds no strings). The common entity preamble must fit inside
+//! that budget — a preamble that overruns it is decoding the wrong
+//! fields.
+//!
+//! For every entity record this probe traces the preamble field by
+//! field, twice:
+//!
+//! - **RL** — the graphics-preview block's size is read as a 32-bit `RL`
+//!   (the R13-R2007 shape);
+//! - **BLL** — the size is read as a `BLL` (§2.4: a 3-bit byte count
+//!   then that many little-endian bytes), the R2010+ shape.
+//!
+//! It prints, per record, whether each variant completed and how many
+//! bits are left between the end of the preamble and `data_end_bit`. A
+//! variant that overruns the record, or that leaves a negative budget,
+//! is wrong.
+//!
+//! ```sh
+//! cargo run --release --example probe_entity_preamble -- samples/sample_AC1032.dwg
+//! cargo run --release --example probe_entity_preamble -- samples/sample_AC1032.dwg 526
+//! ```
+
+use dwg::bitcursor::BitCursor;
+use dwg::error::Result;
+use dwg::version::Version;
+use dwg::{DwgFile, ObjectType};
+
+/// How the graphics-preview block's size field is encoded.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum GfxSize {
+    Rl,
+    Bll,
+}
+
+/// Trace one entity's preamble, returning `(end_bit, had_graphics, gfx_bytes, log)`.
+fn trace(
+    c: &mut BitCursor<'_>,
+    version: Version,
+    gfx: GfxSize,
+    log: &mut Vec<String>,
+) -> Result<(bool, u64)> {
+    // EED chain.
+    let mut eed_groups = 0usize;
+    loop {
+        let size = c.read_bs_u()?;
+        if size == 0 {
+            break;
+        }
+        eed_groups += 1;
+        let _appid = c.read_handle()?;
+        for _ in 0..size {
+            let _ = c.read_rc()?;
+        }
+        if eed_groups > 256 {
+            break;
+        }
+    }
+    log.push(format!("eed_groups={eed_groups} @{}", c.position_bits()));
+
+    let had_graphics = c.read_b()?;
+    let mut gfx_bytes = 0u64;
+    if had_graphics {
+        let at = c.position_bits();
+        gfx_bytes = match gfx {
+            GfxSize::Rl => c.read_rl()? as u64,
+            GfxSize::Bll => c.read_bll()?,
+        };
+        log.push(format!(
+            "gfx size field @{at}..{} = {gfx_bytes}",
+            c.position_bits()
+        ));
+        for _ in 0..gfx_bytes {
+            let _ = c.read_rc()?;
+        }
+    }
+    log.push(format!(
+        "had_graphics={had_graphics} gfx_bytes={gfx_bytes} @{}",
+        c.position_bits()
+    ));
+
+    let raw_mode = c.read_bb()?;
+    let num_reactors = c.read_bl()?;
+    let no_xdict = if version.is_r2004_plus() {
+        c.read_b()?
+    } else {
+        true
+    };
+    let binary_chain = if matches!(version, Version::R2013 | Version::R2018) {
+        c.read_b()?
+    } else {
+        false
+    };
+    log.push(format!(
+        "entmode={raw_mode} reactors={num_reactors} no_xdict={no_xdict} ds={binary_chain} @{}",
+        c.position_bits()
+    ));
+
+    let color_raw = c.read_bs_u()?;
+    if version.is_r2004_plus() {
+        let flags = color_raw >> 8;
+        if flags & 0x20 != 0 {
+            let _ = c.read_bl()?;
+        }
+        if flags & 0x40 == 0 && flags & 0x80 != 0 {
+            let _ = c.read_bl()?;
+        }
+    }
+    let ltype_scale = c.read_bd()?;
+    let ltype_flags = c.read_bb()?;
+    let plotstyle = c.read_bb()?;
+    log.push(format!(
+        "color=0x{color_raw:04X} lts={ltype_scale} ltf={ltype_flags} ps={plotstyle} @{}",
+        c.position_bits()
+    ));
+    let (material, shadow) = if version.is_r2007_plus() {
+        (c.read_bb()?, c.read_rc()?)
+    } else {
+        (0, 0)
+    };
+    if version.is_r2010_plus() {
+        let _ = c.read_b()?;
+        let _ = c.read_b()?;
+        let _ = c.read_b()?;
+    }
+    let invis = c.read_bs()?;
+    let lw = c.read_rc()?;
+    log.push(format!(
+        "mat={material} shadow={shadow} invis={invis} lw={lw} END @{}",
+        c.position_bits()
+    ));
+    Ok((had_graphics, gfx_bytes))
+}
+
+fn main() -> Result<()> {
+    let mut args = std::env::args().skip(1);
+    let path = args.next().expect("usage: <file.dwg> [type-code]");
+    let want: Option<u16> = args.next().map(|s| {
+        let t = s.trim_start_matches("0x");
+        u16::from_str_radix(t, if s.starts_with("0x") { 16 } else { 10 })
+            .expect("type code must be decimal or 0x-hex")
+    });
+
+    let file = DwgFile::open(&path)?;
+    let version = file.version();
+    let objects = file
+        .all_objects()
+        .expect("this version has no object-stream walk")?;
+    let class_map = file.class_map().and_then(std::result::Result::ok);
+
+    println!("{path}  ({version})");
+    for object in &objects {
+        if let Some(code) = want {
+            if object.type_code != code {
+                continue;
+            }
+        } else if !object.is_entity() {
+            continue;
+        }
+        let label = match object.kind {
+            ObjectType::Custom(code) => class_map
+                .as_ref()
+                .and_then(|m| m.by_type_code(code))
+                .map(|d| d.dxf_class_name.clone())
+                .unwrap_or_else(|| format!("{}", object.kind)),
+            other => format!("{other}"),
+        };
+        let data_end = dwg::object::data_end_bit(object, version);
+        let body = dwg::object::body_cursor(object, version).map(|c| c.position_bits());
+        println!();
+        println!(
+            "0x{:04X} {label} handle=0x{:X} payload={}b body_at={:?} data_end={:?}",
+            object.type_code,
+            object.handle.value,
+            object.raw.len() * 8,
+            body.as_ref().ok(),
+            data_end
+        );
+        for (name, gfx) in [("RL ", GfxSize::Rl), ("BLL", GfxSize::Bll)] {
+            let mut log = Vec::new();
+            let mut c = match dwg::object::body_cursor(object, version) {
+                Ok(c) => c,
+                Err(e) => {
+                    println!("  {name}: body_cursor failed: {e}");
+                    continue;
+                }
+            };
+            match trace(&mut c, version, gfx, &mut log) {
+                Ok((had_gfx, gfx_bytes)) => {
+                    let end = c.position_bits();
+                    let budget = data_end.map(|d| d as isize - end as isize);
+                    println!("  {name}: ok end={end} budget={budget:?} gfx={had_gfx}/{gfx_bytes}B");
+                }
+                Err(e) => println!("  {name}: ERR {e}"),
+            }
+            for line in &log {
+                println!("      {line}");
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/bitcursor.rs
+++ b/src/bitcursor.rs
@@ -12,7 +12,7 @@
 //! |------|------------------------|-----------|
 //! | §2.0 | [`BitCursor::read_b`]      | single bit → bool |
 //! | §2.0 | [`BitCursor::read_bb`]     | two-bit code 0..3 |
-//! | §2.1 | [`BitCursor::read_3b`]     | 1-3 bits, variable-length 0..7 |
+//! | §2.1 | [`BitCursor::read_3b`]     | three raw bits, 0..=7 |
 //! | §2.2 | [`BitCursor::read_bs`]     | bitshort: 00=16-bit / 01=8-bit / 10=0 / 11=256 |
 //! | §2.3 | [`BitCursor::read_bl`]     | bitlong: 00=32-bit / 01=8-bit / 10=0 / 11=reserved |
 //! | §2.4 | [`BitCursor::read_bll`]    | bitlonglong: 3-bit length + that many LE bytes |
@@ -156,24 +156,26 @@ impl<'a> BitCursor<'a> {
     }
 
     // ================================================================
-    // §2.1 — 3B (1 to 3 bits; used from R24 onward for entmode-like fields)
+    // §2.1 — 3B (three bits; the byte-count prefix of a BLL, R24+)
     //
-    // "Keep reading bits until a zero bit is encountered or until the 3rd
-    //  bit is read, whatever comes first. Each time a bit is read, shift
-    //  the previously read bits to the left. Result is 0-7."
+    // Measured, not assumed. The earlier reading here was a prefix code
+    // that stopped at the first zero bit, so it could only produce
+    // {0, 2, 6, 7} — a set that cannot express a one-byte BLL. The one
+    // place this crate reads a real `BLL` from a real file is the
+    // R2010+ entity graphics-preview size (§19.4.1), and on
+    // `sample_AC1032.dwg` those fields require lengths of exactly 1 and
+    // 2 bytes: the IMAGE at handle 0x662 stores `001` + `0x8C` = 140
+    // bytes of preview, the MULTILEADER at handle 0x66E stores
+    // `010` + `0x50 0x03` = 848 bytes. Both land the rest of the
+    // preamble on a byte-aligned boundary whose entity-mode, colour,
+    // linetype-scale and lineweight fields match every other entity in
+    // the file. A prefix-coded read of the same bits yields length 0 and
+    // desynchronises the record — see `examples/probe_entity_preamble.rs`.
     // ================================================================
 
-    /// Reads a `3B` (1- to 3-bit length prefix, R24+).
+    /// Reads a `3B` (three raw bits, `0..=7`) — the byte-count prefix of a `BLL`.
     pub fn read_3b(&mut self) -> Result<u8> {
-        let mut result: u8 = 0;
-        for _ in 0..3 {
-            let bit = self.read_bits(1)? as u8;
-            result = (result << 1) | bit;
-            if bit == 0 {
-                break;
-            }
-        }
-        Ok(result)
+        Ok(self.read_bits(3)? as u8)
     }
 
     // ================================================================
@@ -624,16 +626,20 @@ mod tests {
 
     // §2.1 — 3B
     #[test]
-    fn read_3b_stops_at_zero() {
-        // "0..." → 0
-        let bytes = [0b0000_0000];
-        assert_eq!(BitCursor::new(&bytes).read_3b().unwrap(), 0);
-        // "10..." → 10 → 2
-        let bytes = [0b1000_0000];
-        assert_eq!(BitCursor::new(&bytes).read_3b().unwrap(), 0b10);
-        // "111..." → 7
-        let bytes = [0b1110_0000];
-        assert_eq!(BitCursor::new(&bytes).read_3b().unwrap(), 0b111);
+    fn read_3b_is_three_raw_bits() {
+        for value in 0u8..=7 {
+            let bytes = [value << 5];
+            assert_eq!(
+                BitCursor::new(&bytes).read_3b().unwrap(),
+                value,
+                "value={value}"
+            );
+        }
+        // Three bits, always — the next read starts at bit 3.
+        let bytes = [0b0011_1111];
+        let mut c = BitCursor::new(&bytes);
+        assert_eq!(c.read_3b().unwrap(), 0b001);
+        assert_eq!(c.position_bits(), 3);
     }
 
     // Byte alignment between objects, per §2.14.

--- a/src/bitwriter.rs
+++ b/src/bitwriter.rs
@@ -96,42 +96,29 @@ impl BitWriter {
         self.write_bits(v as u64, 2);
     }
 
-    /// 3B per spec §2.1 (as interpreted by [`crate::bitcursor::BitCursor::read_3b`]).
+    /// 3B per spec §2.1 (as measured by [`crate::bitcursor::BitCursor::read_3b`]).
     ///
-    /// The reader accumulates bits MSB-first, shifting into a `u8`,
-    /// stopping early on a 0-bit or after 3 bits. That produces a
-    /// closed set of four representable values:
-    ///
-    /// | bits | value |
-    /// |------|-------|
-    /// | `0`   | 0 |
-    /// | `10`  | 2 |
-    /// | `110` | 6 |
-    /// | `111` | 7 |
-    ///
-    /// Returns [`Error::Invalid3B`] for any value outside that set —
-    /// this is the preferred fallible API. [`write_3b`](Self::write_3b)
-    /// is kept as a convenience wrapper that `.expect`s the result for
-    /// call sites that have statically validated the input.
+    /// Three raw bits, MSB first, so every value `0..=7` is
+    /// representable in a fixed width. Returns [`Error::Invalid3B`] for
+    /// anything larger — this is the preferred fallible API.
+    /// [`write_3b`](Self::write_3b) is kept as a convenience wrapper
+    /// that `.expect`s the result for call sites that have statically
+    /// validated the input.
     pub fn try_write_3b(&mut self, v: u8) -> Result<()> {
-        match v {
-            0 => self.write_bits(0b0, 1),
-            2 => self.write_bits(0b10, 2),
-            6 => self.write_bits(0b110, 3),
-            7 => self.write_bits(0b111, 3),
-            _ => return Err(Error::Invalid3B { value: v }),
+        if v > 7 {
+            return Err(Error::Invalid3B { value: v });
         }
+        self.write_bits(v as u64, 3);
         Ok(())
     }
 
     /// Convenience wrapper around [`try_write_3b`](Self::try_write_3b)
     /// that panics on invalid input. Prefer the fallible form at any
-    /// call site where the value is not statically one of `{0, 2, 6, 7}`.
+    /// call site where the value is not statically in `0..=7`.
     ///
     /// # Panics
     ///
-    /// Panics with [`Error::Invalid3B`] formatting when `v` is outside
-    /// the representable set.
+    /// Panics with [`Error::Invalid3B`] formatting when `v > 7`.
     pub fn write_3b(&mut self, v: u8) {
         self.try_write_3b(v).expect("invalid 3B value");
     }
@@ -183,19 +170,19 @@ impl BitWriter {
         self.write_bl(v as i32);
     }
 
-    /// BLL (R24+) per spec §2.4: a 3B prefix-coded length followed by
-    /// that many little-endian data bytes.
+    /// BLL (R24+) per spec §2.4: a 3B byte count followed by that many
+    /// little-endian data bytes.
     ///
-    /// Because 3B can only represent lengths `{0, 2, 6, 7}` (spec §2.1,
-    /// prefix code), the writer must choose the smallest representable
-    /// length that fits the value. Encoding layout:
+    /// The count is three raw bits, so it spans `0..=7` and the writer
+    /// emits the exact number of bytes the value needs:
     ///
-    /// | range of `v`              | length | payload bytes | total bits (incl. prefix) |
-    /// |---------------------------|--------|---------------|---------------------------|
-    /// | `0`                       | 0      | 0             | 1                         |
-    /// | `1..=0xFFFF`              | 2      | 2             | 18                        |
-    /// | `0x10000..=0xFFFF_FFFF_FFFF` | 6    | 6             | 51                        |
-    /// | `0x1_0000_0000_0000..=(1<<56)-1` | 7 | 7           | 59                        |
+    /// | range of `v`                     | length | total bits (incl. prefix) |
+    /// |----------------------------------|--------|---------------------------|
+    /// | `0`                              | 0      | 3                         |
+    /// | `1..=0xFF`                       | 1      | 11                        |
+    /// | `0x100..=0xFFFF`                 | 2      | 19                        |
+    /// | …                                | …      | …                         |
+    /// | `0x1_0000_0000_0000..=(1<<56)-1` | 7      | 59                        |
     ///
     /// Values requiring more than 56 bits (`v >= 1 << 56`) return
     /// [`Error::BllOverflow`] — the encoding cannot represent them.
@@ -205,12 +192,8 @@ impl BitWriter {
         } else {
             ((64 - v.leading_zeros()) as usize).div_ceil(8)
         };
-        // Round up to the nearest representable prefix-coded length.
         let len: u8 = match byte_count {
-            0 => 0,
-            1 | 2 => 2,
-            3..=6 => 6,
-            7 => 7,
+            0..=7 => byte_count as u8,
             _ => return Err(Error::BllOverflow { value: v }),
         };
         self.try_write_3b(len)?;
@@ -516,11 +499,11 @@ mod tests {
         assert_eq!(c.read_mc().unwrap(), i64::MAX);
     }
 
-    /// `try_write_3b` returns `Err(Error::Invalid3B)` for values
-    /// outside `{0, 2, 6, 7}` instead of panicking.
+    /// `try_write_3b` returns `Err(Error::Invalid3B)` for values above
+    /// `7` instead of panicking.
     #[test]
     fn try_write_3b_rejects_invalid_values() {
-        for bad in [1u8, 3, 4, 5, 8, 15, 255] {
+        for bad in [8u8, 9, 15, 128, 255] {
             let mut w = BitWriter::new();
             let err = w.try_write_3b(bad).unwrap_err();
             assert!(
@@ -532,17 +515,14 @@ mod tests {
 
     #[test]
     fn try_write_3b_accepts_representable_values() {
-        for good in [0u8, 2, 6, 7] {
+        for good in 0u8..=7 {
             let mut w = BitWriter::new();
             assert!(w.try_write_3b(good).is_ok(), "good={good}");
         }
     }
 
     /// BLL must round-trip across the full byte-length spectrum the
-    /// prefix code can represent. The encoder upgrades counts of
-    /// `{1, 3, 4, 5, 7, 8}` bytes to the next larger representable
-    /// length, padding the value with zeros — the reader reconstructs
-    /// the original integer either way.
+    /// three-bit count can represent (0..=7 bytes).
     #[test]
     fn bll_roundtrip_spans_representable_range() {
         let values: [u64; 11] = [

--- a/src/common_entity.rs
+++ b/src/common_entity.rs
@@ -15,7 +15,8 @@
 //!       BS   size_bits
 //!       H    appid_handle
 //!       RC*  app_data
-//! B   graphics_present     -- if true, RL size + bytes follow
+//! B   graphics_present     -- if true, a size field + that many bytes
+//!                             follow: RL up to R2007, BLL from R2010
 //! BB  entmode              -- entity mode (see [`EntityMode`])
 //! BL  num_reactors
 //! B   no_xdictionary_handle (R2004+)
@@ -163,6 +164,44 @@ fn skip_extended_data(c: &mut BitCursor<'_>) -> Result<bool> {
     )))
 }
 
+/// Size in bytes of the graphics-preview block that follows a set
+/// `graphics present` flag in the common entity preamble (§19.4.1).
+///
+/// # Measured
+///
+/// Up to R2007 the size is an `RL`. From R2010 it is a `BLL` (§2.4).
+/// On `sample_AC1032.dwg` (R2018) reading it as an `RL` yields sizes in
+/// the millions of bytes for records only a few hundred bytes long, and
+/// the preamble runs off the end of the record — the 20 errors of #42.
+/// Reading it as a `BLL` lands every one of those records on a preamble
+/// whose remaining fields match the values every plain entity in the
+/// same file carries (`entmode = 2`, `num_reactors = 0`,
+/// `no_xdictionary = true`, colour `0x0100`, linetype scale `1.0`, all
+/// flag fields `0`, `invisibility = 0`, `lineweight = 0x1D`):
+///
+/// | record            | `BLL` prefix bits | size (bytes) | preamble ends |
+/// |-------------------|-------------------|--------------|---------------|
+/// | IMAGE `0x662`     | `001` + `8C`      | 140          | bit 1213      |
+/// | WIPEOUT `0x44D`   | `001` + `8C`      | 140          | bit 1213      |
+/// | MULTILEADER `0x66E` | `010` + `50 03` | 848          | bit 6885      |
+/// | MESH `0x343`      | `010` + `28 25`   | 9512         | bit 76197     |
+///
+/// The preview block is what makes these records custom-class-only in
+/// practice: AutoCAD writes proxy graphics for entities whose class is
+/// not built in, so the `graphics present` flag is set on exactly the
+/// MULTILEADER / MESH / ACAD_TABLE / WIPEOUT / IMAGE records and clear
+/// on LINE / TEXT / MTEXT. Nothing about the *class* changes the
+/// preamble; the graphics block is simply never exercised without one.
+///
+/// `examples/probe_entity_preamble.rs` prints both readings side by side.
+fn read_graphics_size(c: &mut BitCursor<'_>, version: Version) -> Result<u64> {
+    if version.is_r2010_plus() {
+        c.read_bll()
+    } else {
+        Ok(c.read_rl()? as u64)
+    }
+}
+
 /// Read the **non-entity** object's common data (§19.4.2), advancing
 /// past it, and return the reactor count.
 ///
@@ -217,9 +256,12 @@ pub fn read_common_entity_data(
     let had_extended = skip_extended_data(c)?;
 
     // -- Graphics preview ----------------------------------------------------
+    // The size of the preview block is an `RL` up to R2007 and a `BLL`
+    // (§2.4 — three-bit byte count, then that many little-endian bytes)
+    // from R2010 on. See [`read_graphics_size`] for the measurement.
     let had_graphics = c.read_b()?;
     if had_graphics {
-        let gfx_size = c.read_rl()? as usize;
+        let gfx_size = read_graphics_size(c, version)?;
         // Skip exactly gfx_size bytes.
         for _ in 0..gfx_size {
             let _ = c.read_rc()?;
@@ -403,9 +445,9 @@ mod tests {
         w.write_rc(0xAA);
         w.write_rc(0xBB);
         w.write_bs_u(0); // terminator
-        // Graphics: present, 3 bytes.
+        // Graphics: present, 3 bytes. R2010+ sizes the block with a BLL.
         w.write_b(true);
-        w.write_rl(3);
+        w.write_bll(3).unwrap();
         w.write_rc(0x11);
         w.write_rc(0x22);
         w.write_rc(0x33);
@@ -445,5 +487,85 @@ mod tests {
         assert_eq!(ce.shadow_flags, 0b11);
         assert_eq!(ce.invisibility, 1);
         assert_eq!(ce.lineweight, 0x05);
+    }
+
+    /// The R2018 shape measured on `sample_AC1032.dwg`: a 140-byte
+    /// graphics-preview block sized by a `BLL` (`001` + `0x8C`), then a
+    /// preamble carrying the values every entity in that file shares.
+    ///
+    /// Written with the same size field read as an `RL` this record
+    /// claims millions of bytes of preview and the reader runs off the
+    /// end — the failure mode of #42.
+    #[test]
+    fn r2018_graphics_block_is_sized_by_a_bll() {
+        let mut w = BitWriter::new();
+        w.write_bs_u(0); // no XDATA
+        w.write_b(true); // graphics present
+        w.write_bll(140).unwrap();
+        for i in 0..140u16 {
+            w.write_rc(i as u8);
+        }
+        let after_graphics = w.position_bits();
+        w.write_bb(0b10); // entmode = InBlock
+        w.write_bl(0); // num_reactors
+        w.write_b(true); // no xdictionary
+        w.write_b(false); // no AcDs binary data
+        w.write_bs_u(0x0100); // CMC colour, no suffixes
+        w.write_bd(1.0); // linetype scale
+        w.write_bb(0b00); // ltype flags
+        w.write_bb(0b00); // plotstyle flag
+        w.write_bb(0b00); // material flag
+        w.write_rc(0); // shadow flags
+        w.write_b(false);
+        w.write_b(false);
+        w.write_b(false);
+        w.write_bs(0); // invisibility
+        w.write_rc(0x1D); // lineweight (BYLAYER)
+        let end = w.position_bits();
+
+        // 1 BS tag + 1 flag bit + 3 count bits + 8 length bits + 140 bytes.
+        assert_eq!(after_graphics, 2 + 1 + 3 + 8 + 140 * 8);
+
+        let bytes = w.into_bytes();
+        let mut c = BitCursor::new(&bytes);
+        let ce = read_common_entity_data(&mut c, Version::R2018).unwrap();
+        assert!(ce.had_graphics);
+        assert!(!ce.had_extended_data);
+        assert_eq!(ce.mode, EntityMode::InBlock);
+        assert_eq!(ce.num_reactors, 0);
+        assert!(ce.no_xdictionary);
+        assert_eq!(ce.invisibility, 0);
+        assert_eq!(ce.lineweight, 0x1D);
+        assert_eq!(c.position_bits(), end);
+    }
+
+    /// Up to R2007 the same block is sized by an `RL`.
+    #[test]
+    fn r2004_graphics_block_is_sized_by_an_rl() {
+        let mut w = BitWriter::new();
+        w.write_bs_u(0);
+        w.write_b(true);
+        w.write_rl(4);
+        for _ in 0..4 {
+            w.write_rc(0xEE);
+        }
+        w.write_bb(0b00);
+        w.write_bl(0);
+        w.write_b(true);
+        w.write_bs_u(0x0100);
+        w.write_bd(1.0);
+        w.write_bb(0b00);
+        w.write_bb(0b00);
+        w.write_bs(0);
+        w.write_rc(0x1D);
+        let end = w.position_bits();
+
+        let bytes = w.into_bytes();
+        let mut c = BitCursor::new(&bytes);
+        let ce = read_common_entity_data(&mut c, Version::R2004).unwrap();
+        assert!(ce.had_graphics);
+        assert_eq!(ce.mode, EntityMode::ByLayer);
+        assert_eq!(ce.lineweight, 0x1D);
+        assert_eq!(c.position_bits(), end);
     }
 }

--- a/src/entities/dispatch.rs
+++ b/src/entities/dispatch.rs
@@ -397,7 +397,7 @@ pub fn decode_from_raw_with_class_map(
                 .map(DecodedEntity::Underlay)
                 .map_err(|e| e.to_string())
         }
-        "WIPEOUT" | "ACDBWIPEOUT" => wipeout::decode(&mut cursor)
+        "WIPEOUT" | "ACDBWIPEOUT" => wipeout::decode(&mut cursor, version)
             .map(DecodedEntity::Wipeout)
             .map_err(|e| e.to_string()),
         // MESH (subdivision surface) — R2010+ custom class §19.4.66.

--- a/src/entities/image.rs
+++ b/src/entities/image.rs
@@ -22,13 +22,26 @@
 //! RC    fade             -- 0..100
 //! (R2010+) B clip_mode    -- 0 = outside, 1 = inside
 //! BS    clip_boundary_type  -- 1 = rectangle, 2 = polygon
-//! BL    num_clip_verts
 //! (if clip_boundary_type == 1)
-//!   RD2  corner_1
+//!   RD2  corner_1        -- no vertex count precedes these
 //!   RD2  corner_2
 //! (else)
+//!   BL   num_clip_verts
 //!   RD2 × num_clip_verts
 //! ```
+//!
+//! # Measured — the rectangle form carries no vertex count
+//!
+//! `sample_AC1032.dwg` (R2018) holds one IMAGE (handle `0x662`) and one
+//! WIPEOUT (handle `0x44D`), which shares this layout. The IMAGE is a
+//! 994 × 965 raster with `clip_boundary_type = 1`; its clip corners
+//! `(-0.5, -0.5)` and `(993.5, 964.5)` occupy bits 1663..1919 of a
+//! record whose data stream ends at bit 1920. Reading a `BL` count
+//! between the type and the corners consumes the first 34 bits of the
+//! `-0.5`, which both mis-decodes the rectangle and overruns the record.
+//! The WIPEOUT has `clip_boundary_type = 2`, and there the `BL` count
+//! *is* present: `4`, followed by four `RD2` vertices spanning bits
+//! 1673..2185 of a record ending at 2186.
 
 use crate::bitcursor::BitCursor;
 use crate::entities::{Point2D, Point3D, Vec3D, read_bd3};
@@ -80,12 +93,18 @@ pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<Image> {
         false
     };
     let clip_boundary_type = c.read_bs()?;
-    let num_clip_verts = c.read_bl()? as usize;
+    // Measured: the rectangle form (type 1) writes its two corners
+    // straight after the type — no count field. See the module docs.
+    let num_clip_verts = if clip_boundary_type == 1 {
+        2
+    } else {
+        c.read_bl()? as usize
+    };
     // Real IMAGE clip boundaries are a handful of vertices; 100K is a
     // conservative upper bound. Also cross-check against remaining
-    // payload bits (each vertex is ≥ 4 bits — two BB dispatch tags).
+    // payload bits (each vertex is 128 bits — two RDs).
     const IMAGE_MAX_CLIP_VERTS: usize = 100_000;
-    if num_clip_verts > IMAGE_MAX_CLIP_VERTS || num_clip_verts > c.remaining_bits() {
+    if num_clip_verts > IMAGE_MAX_CLIP_VERTS || num_clip_verts * 128 > c.remaining_bits() {
         return Err(Error::SectionMap(format!(
             "IMAGE clip verts {num_clip_verts} exceeds cap \
              ({IMAGE_MAX_CLIP_VERTS} or remaining_bits {})",
@@ -163,8 +182,7 @@ mod tests {
         w.write_rc(50);
         w.write_rc(50);
         w.write_rc(0);
-        w.write_bs(1); // rectangle
-        w.write_bl(2); // num verts
+        w.write_bs(1); // rectangle — no vertex count follows
         w.write_rd(0.0);
         w.write_rd(0.0);
         w.write_rd(1920.0);
@@ -180,6 +198,52 @@ mod tests {
             }
         );
         assert!(matches!(i.clip_boundary, ClipBoundary::Rectangle { .. }));
+    }
+
+    /// The measured `sample_AC1032.dwg` IMAGE body (handle `0x662`):
+    /// a 994 × 965 raster whose rectangular clip boundary follows the
+    /// boundary type with no vertex count in between.
+    #[test]
+    fn decodes_the_measured_rectangle_image_body() {
+        let mut w = BitWriter::new();
+        w.write_bl(0);
+        w.write_bd(0.0); // insertion point (0, 15, 0)
+        w.write_bd(15.0);
+        w.write_bd(0.0);
+        w.write_bd(0.010416666666666664); // u vector = 1/96 in X
+        w.write_bd(0.0);
+        w.write_bd(0.0);
+        w.write_bd(6.37836874555913e-19); // v vector = 1/96 in Y
+        w.write_bd(0.010416666666666666);
+        w.write_bd(0.0);
+        w.write_rd(994.0); // image size in pixels
+        w.write_rd(965.0);
+        w.write_bs(7); // display flags
+        w.write_b(false); // clipping off
+        w.write_rc(50);
+        w.write_rc(50);
+        w.write_rc(0);
+        w.write_b(false); // clip mode (R2010+)
+        w.write_bs(1); // rectangle
+        w.write_rd(-0.5); // corners, straight after the type
+        w.write_rd(-0.5);
+        w.write_rd(993.5);
+        w.write_rd(964.5);
+        let end = w.position_bits();
+
+        let bytes = w.into_bytes();
+        let mut c = BitCursor::new(&bytes);
+        let i = decode(&mut c, Version::R2018).unwrap();
+        assert_eq!(i.image_size, Point2D { x: 994.0, y: 965.0 });
+        assert_eq!(i.brightness, 50);
+        assert_eq!(
+            i.clip_boundary,
+            ClipBoundary::Rectangle {
+                lower_left: Point2D { x: -0.5, y: -0.5 },
+                upper_right: Point2D { x: 993.5, y: 964.5 },
+            }
+        );
+        assert_eq!(c.position_bits(), end);
     }
 
     #[test]

--- a/src/entities/mesh.rs
+++ b/src/entities/mesh.rs
@@ -9,29 +9,60 @@
 //! Pre-R2010 files never emit this entity; older versions are treated
 //! as [`crate::error::Error::Unsupported`].
 //!
-//! # Stream shape (R2010+, L4-34)
+//! # Stream shape (R2010+) — measured
 //!
 //! ```text
-//! BS   version             -- 0 or 1 (encoding variant)
+//! BS   version             -- 2 on both measured records
 //! B    blend_crease        -- whether creases are blended at corners
 //! BS   subdivision_level   -- smoothing steps applied at render time
 //! BS   vertex_count        -- control-cage vertices
 //! BD3  × vertex_count      -- vertex positions (world coords)
-//! BL   face_count          -- faces in the control cage
-//! (per face)
+//! BL   face_list_size      -- number of BL entries in the face list,
+//!                             NOT the number of faces
+//! (repeated until face_list_size entries are consumed)
 //!   BL face_vertex_count   -- 3 for tri, 4 for quad, >4 for n-gon
 //!   BL × face_vertex_count -- vertex indices into the positions array
 //! BL   edge_count
 //! (per edge)
-//!   BS start_index         -- vertex index
-//!   BS end_index           -- vertex index
-//! BD   × edge_count        -- crease values (0.0 = smooth)
+//!   BL start_index         -- vertex index
+//!   BL end_index           -- vertex index
+//! BL   crease_count
+//! BD   × crease_count      -- crease values (0.0 = smooth)
 //! ```
 //!
-//! The cross-field-count stream (a single `BL face_count` followed by
-//! per-face counts) reuses the defensive pattern from
-//! [`crate::entities::lwpolyline::decode`]: every claimed count is capped against both a
-//! hard ceiling and [`BitCursor::remaining_bits`].
+//! ## What the bytes say
+//!
+//! `sample_AC1032.dwg` (R2018) holds two decodable MESH records. Read
+//! with the count above as a *face* count, the second face-vertex count
+//! comes out as 132 / 128 and the parse dies; read as a flat entry
+//! count the two records close on themselves exactly:
+//!
+//! | handle | verts | face-list entries | faces | edges | creases | V − E + F |
+//! |--------|-------|-------------------|-------|-------|---------|-----------|
+//! | `0x343` | 62   | 336               | 72    | 132   | 132     | 2         |
+//! | `0x380` | 64   | 320               | 64    | 128   | 128     | 0         |
+//!
+//! The Euler characteristics (2 = closed surface, 0 = one-handle torus)
+//! are the independent check that the face and edge lists were read at
+//! the right offsets, and every face index and edge endpoint is below
+//! the vertex count — which [`decode`] enforces.
+//!
+//! Edge endpoints are `BL`, not `BS`: with `BS` the first pair of the
+//! `0x343` mesh reads `(1, 60)` correctly but the list then walks off
+//! its own budget.
+//!
+//! ## The three bits this decoder does not read
+//!
+//! After the last crease both records leave exactly **3 bits** before
+//! the data/handle-stream boundary, and both hold `100`. That is
+//! consistent with a trailing `BL` of 0 followed by one bit of byte
+//! padding, but two records that both encode zero cannot distinguish a
+//! `BL` from a `BS` from two spare bits, so this decoder stops at the
+//! last crease and the offsets are recorded here instead of guessed.
+//!
+//! Every claimed count is capped against both a hard ceiling and
+//! [`BitCursor::remaining_bits`], the defensive pattern from
+//! [`crate::entities::lwpolyline::decode`].
 //!
 //! # Version gating
 //!
@@ -50,9 +81,10 @@ use crate::version::Version;
 // against observed vertex / face / edge counts in real subdivision meshes.
 // ========================================================================
 const CAP_VERTICES: usize = 1_000_000;
-const CAP_FACES: usize = 1_000_000;
+const CAP_FACE_LIST: usize = 8_000_000;
 const CAP_FACE_VERTICES: usize = 64;
 const CAP_EDGES: usize = 4_000_000;
+const CAP_CREASES: usize = 4_000_000;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Mesh {
@@ -68,10 +100,22 @@ pub struct Mesh {
     /// One entry per face; each entry is a list of vertex indices.
     pub faces: Vec<Vec<u32>>,
     /// Edge endpoints as `(start_vertex_index, end_vertex_index)` pairs.
-    pub edges: Vec<(u16, u16)>,
+    pub edges: Vec<(u32, u32)>,
     /// Crease value per edge — 0.0 = smooth, >0.0 = sharpened at that
     /// subdivision step count.
     pub creases: Vec<f64>,
+}
+
+/// Every face and edge index addresses the vertex array. A parse that
+/// has drifted produces indices far past its end, so this is the
+/// decoder's cheapest self-check — it fires long before the counts do.
+fn check_index(index: u32, num_vertices: usize, what: &'static str) -> Result<u32> {
+    if index as usize >= num_vertices {
+        return Err(Error::SectionMap(format!(
+            "MESH {what} index {index} is outside the {num_vertices}-vertex cage"
+        )));
+    }
+    Ok(index)
 }
 
 fn bounds_check(n: usize, field: &'static str, cap: usize, remaining_bits: usize) -> Result<()> {
@@ -115,10 +159,18 @@ pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<Mesh> {
         vertices.push(read_bd3(c)?);
     }
 
-    let num_faces = c.read_bl_u()? as usize;
-    bounds_check(num_faces, "face_count", CAP_FACES, c.remaining_bits())?;
-    let mut faces = Vec::with_capacity(num_faces);
-    for _ in 0..num_faces {
+    // Measured: this count is the *length of the face list in `BL`
+    // entries*, not a face count. See the module docs.
+    let face_list_size = c.read_bl_u()? as usize;
+    bounds_check(
+        face_list_size,
+        "face_list_size",
+        CAP_FACE_LIST,
+        c.remaining_bits(),
+    )?;
+    let mut faces: Vec<Vec<u32>> = Vec::new();
+    let mut consumed = 0usize;
+    while consumed < face_list_size {
         let fvc = c.read_bl_u()? as usize;
         bounds_check(
             fvc,
@@ -126,10 +178,18 @@ pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<Mesh> {
             CAP_FACE_VERTICES,
             c.remaining_bits(),
         )?;
+        consumed += 1;
+        if consumed + fvc > face_list_size {
+            return Err(Error::SectionMap(format!(
+                "MESH face of {fvc} vertices overruns the {face_list_size}-entry \
+                 face list ({consumed} entries already read)"
+            )));
+        }
         let mut vs = Vec::with_capacity(fvc);
         for _ in 0..fvc {
-            vs.push(c.read_bl_u()?);
+            vs.push(check_index(c.read_bl_u()?, num_vertices, "face vertex")?);
         }
+        consumed += fvc;
         faces.push(vs);
     }
 
@@ -137,16 +197,18 @@ pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<Mesh> {
     bounds_check(num_edges, "edge_count", CAP_EDGES, c.remaining_bits())?;
     let mut edges = Vec::with_capacity(num_edges);
     for _ in 0..num_edges {
-        let a = c.read_bs_u()?;
-        let b = c.read_bs_u()?;
+        let a = check_index(c.read_bl_u()?, num_vertices, "edge start")?;
+        let b = check_index(c.read_bl_u()?, num_vertices, "edge end")?;
         edges.push((a, b));
     }
 
-    // One crease per edge. ODA §19.4.66 states the crease array's length
-    // equals edge_count; enforcing that here keeps mis-sized streams
-    // from silently succeeding.
-    let mut creases = Vec::with_capacity(num_edges);
-    for _ in 0..num_edges {
+    // Measured: the crease array carries its own `BL` count, which
+    // equalled `edge_count` on both records of `sample_AC1032.dwg` but
+    // is read rather than assumed.
+    let num_creases = c.read_bl_u()? as usize;
+    bounds_check(num_creases, "crease_count", CAP_CREASES, c.remaining_bits())?;
+    let mut creases = Vec::with_capacity(num_creases);
+    for _ in 0..num_creases {
         creases.push(c.read_bd()?);
     }
 
@@ -182,7 +244,7 @@ mod tests {
         hdr: &MeshHeader,
         vertices: &[Point3D],
         faces: &[&[u32]],
-        edges: &[(u16, u16)],
+        edges: &[(u32, u32)],
         creases: &[f64],
     ) {
         w.write_bs_u(hdr.version);
@@ -194,7 +256,10 @@ mod tests {
             w.write_bd(v.y);
             w.write_bd(v.z);
         }
-        w.write_bl(faces.len() as i32);
+        // The face list is sized in BL entries: one count per face plus
+        // that face's indices.
+        let face_list_size: usize = faces.iter().map(|f| 1 + f.len()).sum();
+        w.write_bl(face_list_size as i32);
         for f in faces {
             w.write_bl(f.len() as i32);
             for &i in *f {
@@ -203,9 +268,10 @@ mod tests {
         }
         w.write_bl(edges.len() as i32);
         for &(a, b) in edges {
-            w.write_bs_u(a);
-            w.write_bs_u(b);
+            w.write_bl_u(a);
+            w.write_bl_u(b);
         }
+        w.write_bl(creases.len() as i32);
         for &c in creases {
             w.write_bd(c);
         }
@@ -240,7 +306,7 @@ mod tests {
         ];
         let face_a: &[u32] = &[0, 1, 2];
         let face_b: &[u32] = &[0, 2, 3];
-        let edges = [(0u16, 1u16), (1, 2), (2, 0), (2, 3), (3, 0)];
+        let edges = [(0u32, 1u32), (1, 2), (2, 0), (2, 3), (3, 0)];
         let creases = [0.0f64, 0.0, 1.0, 0.0, 0.0];
         write_mesh(
             &mut w,
@@ -298,7 +364,7 @@ mod tests {
             },
         ];
         let face: &[u32] = &[0, 1, 2];
-        let edges = [(0u16, 1u16), (1, 2), (2, 0)];
+        let edges = [(0u32, 1u32), (1, 2), (2, 0)];
         let creases = [0.5f64, 0.0, 0.25];
         write_mesh(
             &mut w,
@@ -345,20 +411,20 @@ mod tests {
     }
 
     #[test]
-    fn rejects_oversized_face_count() {
+    fn rejects_oversized_face_list_size() {
         let mut w = BitWriter::new();
         // Version + blend + subdivision_level + vertex_count(0)
         w.write_bs_u(0);
         w.write_b(false);
         w.write_bs_u(0);
         w.write_bs_u(0);
-        // face_count far beyond CAP_FACES
-        w.write_bl(2_000_000);
+        // face_list_size far beyond CAP_FACE_LIST
+        w.write_bl(20_000_000);
         let bytes = w.into_bytes();
         let mut c = BitCursor::new(&bytes);
         let err = decode(&mut c, Version::R2010).unwrap_err();
         assert!(
-            matches!(&err, Error::SectionMap(msg) if msg.contains("face_count")),
+            matches!(&err, Error::SectionMap(msg) if msg.contains("face_list_size")),
             "err={err:?}"
         );
     }

--- a/src/entities/wipeout.rs
+++ b/src/entities/wipeout.rs
@@ -1,155 +1,96 @@
-//! WIPEOUT entity (§19.4.86, related to UNDERLAY) — opaque mask.
+//! WIPEOUT entity — opaque mask, stored as a raster-image record.
 //!
 //! WIPEOUT is a polygonal or rectangular mask that hides underlying
-//! entities using the background color. It's implemented as a
-//! custom-class entity (looked up via `AcDb:Classes` under the DXF
-//! name `WIPEOUT` / `ACDBWIPEOUT`).
+//! entities using the background colour. It is a custom-class entity
+//! (looked up via `AcDb:Classes` under the DXF name `WIPEOUT` /
+//! `ACDBWIPEOUT`, C++ class `AcDbWipeout`).
 //!
-//! # Stream shape
+//! # Stream shape — measured, identical to IMAGE
 //!
-//! ```text
-//! BL    clip_state         -- 0=none, 1=rectangle, 2=polygon
-//! BS    num_clip_vertices  -- capped at 100_000
-//! BD2   × num_clip_vertices   clip_polygon
-//! B     show_clipped
-//! RC    brightness         -- 0..100
-//! RC    contrast           -- 0..100
-//! RC    fade               -- 0..100
-//! ```
+//! `AcDbWipeout` writes the [`AcDbRasterImage`](super::image) record
+//! verbatim; this module is a thin alias over [`super::image::decode`].
 //!
-//! Unlike IMAGE and UNDERLAY, WIPEOUT has no external file or
-//! definition handle — the mask is fully described by its own payload.
+//! The evidence is `sample_AC1032.dwg` (R2018), which holds one IMAGE
+//! (handle `0x662`) and one WIPEOUT (handle `0x44D`). Both records
+//! carry a 140-byte graphics-preview block sized by the same `BLL`, and
+//! their data streams are **bit-identical for the first 175 bits** —
+//! through the preview header and into its payload. Decoding the
+//! WIPEOUT with the IMAGE field list yields insertion point
+//! `(271.921…, 3.988…, 0)`, u/v vectors of length `31.7077…`, image
+//! size `(1, 1)`, display flags `7`, clipping `true`, brightness `50`,
+//! contrast `50`, fade `0`, clip mode `0`, clip boundary type `2` and
+//! four clip vertices — and lands on bit 2185 of a record whose data
+//! stream ends at 2186, one bit of byte padding later.
+//!
+//! The previous field list here (`BL clip_state`, `BS count`, `BD2`
+//! vertices, `B show_clipped`, three `RC`s) matched no part of those
+//! bytes; it decoded the graphics-preview payload as geometry.
+//!
+//! Only R2018 has been measured. The pre-R2010 branch is whatever
+//! [`super::image::decode`] does for those versions.
 
 use crate::bitcursor::BitCursor;
-use crate::entities::Point2D;
-use crate::error::{Error, Result};
+use crate::error::Result;
+use crate::version::Version;
 
-/// Decoded WIPEOUT payload.
-#[derive(Debug, Clone, PartialEq)]
-pub struct Wipeout {
-    /// 0 = no clipping, 1 = rectangular clip, 2 = polygonal clip.
-    pub clip_state: i32,
-    pub clip_polygon: Vec<Point2D>,
-    pub show_clipped: bool,
-    pub brightness: u8,
-    pub contrast: u8,
-    pub fade: u8,
-}
-
-/// Real WIPEOUT clip polygons are a handful of vertices. The cap
-/// matches IMAGE / UNDERLAY to catch pathological inputs.
-const WIPEOUT_MAX_CLIP_VERTS: usize = 100_000;
+/// Decoded WIPEOUT payload — the raster-image record, measured
+/// identical to [`super::image::Image`].
+pub type Wipeout = super::image::Image;
 
 /// Decode a WIPEOUT payload. The cursor must already be positioned
 /// past the common entity preamble.
-pub fn decode(c: &mut BitCursor<'_>) -> Result<Wipeout> {
-    let clip_state = c.read_bl()?;
-    let num_clip_vertices = c.read_bs()? as usize;
-    if num_clip_vertices > WIPEOUT_MAX_CLIP_VERTS || num_clip_vertices > c.remaining_bits() {
-        return Err(Error::SectionMap(format!(
-            "WIPEOUT clip verts {num_clip_vertices} exceeds cap \
-             ({WIPEOUT_MAX_CLIP_VERTS} or remaining_bits {})",
-            c.remaining_bits()
-        )));
-    }
-    let mut clip_polygon = Vec::with_capacity(num_clip_vertices);
-    for _ in 0..num_clip_vertices {
-        let x = c.read_bd()?;
-        let y = c.read_bd()?;
-        clip_polygon.push(Point2D { x, y });
-    }
-    let show_clipped = c.read_b()?;
-    let brightness = c.read_rc()?;
-    let contrast = c.read_rc()?;
-    let fade = c.read_rc()?;
-    Ok(Wipeout {
-        clip_state,
-        clip_polygon,
-        show_clipped,
-        brightness,
-        contrast,
-        fade,
-    })
+pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<Wipeout> {
+    super::image::decode(c, version)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::bitwriter::BitWriter;
+    use crate::entities::image::ClipBoundary;
 
+    /// The measured `sample_AC1032.dwg` WIPEOUT body: a polygon clip
+    /// with an explicit vertex count, decoded through the IMAGE layout.
     #[test]
-    fn roundtrip_rect_wipeout() {
+    fn decodes_the_measured_polygon_wipeout_body() {
         let mut w = BitWriter::new();
-        w.write_bl(1); // rect clip
-        w.write_bs(2);
+        w.write_bl(0); // class_version
+        w.write_bd(271.9211288808192); // insertion point
+        w.write_bd(3.988123351850959);
+        w.write_bd(0.0);
+        w.write_bd(31.707742926072683); // u vector
         w.write_bd(0.0);
         w.write_bd(0.0);
-        w.write_bd(10.0);
-        w.write_bd(5.0);
-        w.write_b(false); // don't show clipped
-        w.write_rc(50);
-        w.write_rc(75);
-        w.write_rc(10);
-        let bytes = w.into_bytes();
-        let mut c = BitCursor::new(&bytes);
-        let wp = decode(&mut c).unwrap();
-        assert_eq!(wp.clip_state, 1);
-        assert_eq!(wp.clip_polygon.len(), 2);
-        assert!(!wp.show_clipped);
-        assert_eq!(wp.brightness, 50);
-        assert_eq!(wp.contrast, 75);
-        assert_eq!(wp.fade, 10);
-    }
-
-    #[test]
-    fn roundtrip_polygon_wipeout() {
-        let mut w = BitWriter::new();
-        w.write_bl(2); // polygon clip
-        w.write_bs(4);
-        for (x, y) in [(0.0f64, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)] {
-            w.write_bd(x);
-            w.write_bd(y);
+        w.write_bd(0.0); // v vector
+        w.write_bd(31.707742926072683);
+        w.write_bd(0.0);
+        w.write_rd(1.0); // image size
+        w.write_rd(1.0);
+        w.write_bs(7); // display flags
+        w.write_b(true); // clipping
+        w.write_rc(50); // brightness
+        w.write_rc(50); // contrast
+        w.write_rc(0); // fade
+        w.write_b(false); // clip mode (R2010+)
+        w.write_bs(2); // polygon boundary
+        w.write_bl(4); // vertex count
+        for (x, y) in [(0.0f64, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)] {
+            w.write_rd(x);
+            w.write_rd(y);
         }
-        w.write_b(true);
-        w.write_rc(0);
-        w.write_rc(100);
-        w.write_rc(0);
-        let bytes = w.into_bytes();
-        let mut c = BitCursor::new(&bytes);
-        let wp = decode(&mut c).unwrap();
-        assert_eq!(wp.clip_state, 2);
-        assert_eq!(wp.clip_polygon.len(), 4);
-        assert!(wp.show_clipped);
-        assert_eq!(wp.contrast, 100);
-    }
+        let end = w.position_bits();
 
-    #[test]
-    fn roundtrip_wipeout_no_clip() {
-        let mut w = BitWriter::new();
-        w.write_bl(0);
-        w.write_bs(0);
-        w.write_b(true);
-        w.write_rc(50);
-        w.write_rc(50);
-        w.write_rc(0);
         let bytes = w.into_bytes();
         let mut c = BitCursor::new(&bytes);
-        let wp = decode(&mut c).unwrap();
-        assert_eq!(wp.clip_state, 0);
-        assert!(wp.clip_polygon.is_empty());
-    }
-
-    #[test]
-    fn rejects_excessive_clip_verts() {
-        let mut w = BitWriter::new();
-        w.write_bl(2);
-        w.write_bs(32767); // huge claimed count, no backing payload
-        let bytes = w.into_bytes();
-        let mut c = BitCursor::new(&bytes);
-        let err = decode(&mut c).unwrap_err();
-        assert!(
-            matches!(&err, Error::SectionMap(msg) if msg.contains("WIPEOUT clip verts")),
-            "err={err:?}"
-        );
+        let wp = decode(&mut c, Version::R2018).unwrap();
+        assert_eq!(wp.brightness, 50);
+        assert_eq!(wp.contrast, 50);
+        assert_eq!(wp.fade, 0);
+        assert!(wp.clipping);
+        match &wp.clip_boundary {
+            ClipBoundary::Polygon(pts) => assert_eq!(pts.len(), 4),
+            other => panic!("expected a polygon boundary, got {other:?}"),
+        }
+        assert_eq!(c.position_bits(), end);
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -81,8 +81,8 @@ pub enum Error {
     #[error("Section map parse failed: {0}")]
     SectionMap(String),
 
-    /// The BLL encoding (`spec §2.4`) uses a 3-bit prefix-coded length
-    /// whose representable set is `{0, 2, 6, 7}` bytes. Values in the
+    /// The BLL encoding (`spec §2.4`) uses a three-bit byte count, so
+    /// it spans `0..=7` bytes. Values in the
     /// top byte of a `u64` (`v >= 1 << 56`) cannot fit in the largest
     /// allowed length (7 bytes) and must be rejected at write time.
     #[error(
@@ -91,11 +91,11 @@ pub enum Error {
     )]
     BllOverflow { value: u64 },
 
-    /// The writer was asked to emit a 3B prefix-coded value outside the
-    /// representable set `{0, 2, 6, 7}` (spec §2.1). Internal callers
+    /// The writer was asked to emit a 3B value above 7, which the
+    /// three-bit code cannot hold (spec §2.1). Internal callers
     /// normalize upstream; this variant surfaces the programmer error
     /// without a panic.
-    #[error("invalid 3B value {value}; representable: {{0, 2, 6, 7}} (spec §2.1)")]
+    #[error("invalid 3B value {value}; representable: 0..=7 (spec §2.1)")]
     Invalid3B { value: u8 },
 
     /// The signed modular-char decoder produced a magnitude that cannot

--- a/tests/mutation_failure_modes.rs
+++ b/tests/mutation_failure_modes.rs
@@ -96,19 +96,19 @@ fn bitcursor_exhaustion_errors() {
     assert!(c.read_bs().is_err());
 }
 
-/// BitWriter try_write_3b rejects values outside the representable
-/// set. Required because the panicking write_3b would crash the
-/// writer side on malformed callers.
+/// BitWriter try_write_3b rejects values above 7, which the three-bit
+/// code cannot hold. Required because the panicking write_3b would
+/// crash the writer side on malformed callers.
 #[test]
 fn bitwriter_try_write_3b_rejects_out_of_range() {
-    for bad in [1u8, 3, 4, 5, 8, 15, 100, 255] {
+    for bad in [8u8, 9, 15, 100, 255] {
         let mut w = BitWriter::new();
         assert!(w.try_write_3b(bad).is_err(), "bad={bad}");
     }
 }
 
 /// BitWriter write_bll must reject values requiring more than 56
-/// bits of storage; BLL's 3B prefix-coded length tops out at 7 bytes.
+/// bits of storage; BLL's three-bit byte count tops out at 7 bytes.
 #[test]
 fn bitwriter_write_bll_rejects_above_56_bits() {
     let mut w = BitWriter::new();

--- a/tests/proptest_roundtrip.rs
+++ b/tests/proptest_roundtrip.rs
@@ -18,8 +18,8 @@ use proptest::prelude::*;
 proptest! {
     /// Every (bool, bool, bb_u2, 3b_representable) sequence round-trips.
     #[test]
-    fn bits_b_bb_3b_roundtrip(b1: bool, b2: bool, bb in 0u8..=3u8, choice in 0u8..4u8) {
-        let three_b = match choice { 0 => 0, 1 => 2, 2 => 6, _ => 7 };
+    fn bits_b_bb_3b_roundtrip(b1: bool, b2: bool, bb in 0u8..=3u8, choice in 0u8..=7u8) {
+        let three_b = choice;
         let mut w = BitWriter::new();
         w.write_b(b1);
         w.write_b(b2);


### PR DESCRIPTION
## Summary

The R2007+ common entity preamble did not diverge for custom-class entities. It diverged for entities that carry a **graphics-preview block**, and on R2018 that block's size field is a `BLL` (§2.4), not the `RL` used up to R2007.

AutoCAD writes proxy graphics for entities whose class it does not implement natively, so the `graphics present` flag (§19.4.1) is set on exactly MULTILEADER / MESH / ACAD_TABLE / WIPEOUT / IMAGE and clear on LINE / TEXT / MTEXT. That is the whole correlation with `Custom(N)`. Nothing in the class record — `was_a_proxy`, `is_an_entity`, proxy flags, class-specific headers — changes the preamble field list.

Read as an `RL`, the size came back as 6,946,890 / 8,425,777 / 8,388,672 bytes for records a few hundred bytes long, and the byte-skip loop ran off the end of the record before any entity-specific field: `Bit cursor exhausted: wanted 8 bits, 3 bits remain`.

## Bit evidence

`3B` is **three raw bits**, not a stop-at-zero prefix code. The old reading could produce only `{0, 2, 6, 7}` — a set with no encoding for "one byte", which the file requires.

| record | prefix bits | size (bytes) | preamble ends at bit | data boundary |
|---|---|---|---|---|
| IMAGE `0x662` | `001` + `8C` | 140 | 1213 | 1920 |
| WIPEOUT `0x44D` | `001` + `8C` | 140 | 1213 | 2186 |
| MULTILEADER `0x66E` | `010` + `50 03` | 848 | 6885 | 8687 |
| MULTILEADER `0x818` | `010` + `98 02` | 664 | 5413 | 7151 |
| MESH `0x343` | `010` + `28 25` | 9512 | 76197 | 93985 |
| MESH `0x380` | `010` + `08 24` | 9224 | 73893 | 92597 |

The check is what follows the block. Every one of those records then reads `entmode = 2`, `num_reactors = 0`, `no_xdictionary = true`, colour `0x0100`, linetype scale `1.0`, all flag fields `0`, `invisibility = 0`, `lineweight = 0x1D` — bit for bit the values every plain LINE / TEXT / MTEXT record in the same file carries. With the old `RL` reading not one of them reaches a plausible tail.

New probe `examples/probe_entity_preamble.rs` traces any record's preamble under both readings and prints the bits left to its data boundary.

## Three body fixes that fall out of the same two records

- **An IMAGE clip boundary of type 1 (rectangle) carries no vertex count.** The two corners follow the boundary type directly. The `BL` the decoder read there consumed the first 34 bits of the `-0.5` corner of the IMAGE at `0x662`, silently returning a wrong rectangle and running 33 bits past the record. Measured: corners `(-0.5, -0.5)` and `(993.5, 964.5)` on a 994 × 965 raster, bits 1663..1919 of a record ending at 1920. The polygon form (type 2) *does* carry the count — the WIPEOUT reads `4` there, then four `RD2` vertices spanning 1673..2185 of a record ending at 2186.
- **WIPEOUT stores a raster-image record.** The IMAGE and the WIPEOUT are bit-identical for their first 175 bits, and the IMAGE field list closes the WIPEOUT exactly on its boundary (insertion `(271.921…, 3.988…, 0)`, u/v length `31.7077…`, brightness/contrast/fade `50/50/0`, polygon clip with 4 vertices). The previous WIPEOUT field list (`BL clip_state`, `BS` count, `BD2` vertices, `B show_clipped`, three `RC`s) matched no part of those bytes — it was decoding the graphics-preview payload as geometry. `entities::wipeout::Wipeout` is now an alias for `entities::image::Image`; `wipeout::decode` takes a `Version`.
- **A MESH face-list count counts `BL` entries, not faces**, and edge endpoints are `BL`, not `BS`.

  | handle | verts | face-list entries | faces | edges | creases | V − E + F |
  |---|---|---|---|---|---|---|
  | `0x343` | 62 | 336 | 72 | 132 | 132 | 2 |
  | `0x380` | 64 | 320 | 64 | 128 | 128 | 0 |

  The Euler characteristics (2 = closed surface, 0 = one-handle torus) are the independent check. `decode` now rejects any face index or edge endpoint outside the vertex cage, and the crease array reads its own `BL` count. **Three bits before the data boundary are left unread and documented, not guessed**: both records hold `100` there, consistent with a trailing `BL` of 0 plus one padding bit, but two records that both encode zero cannot distinguish a `BL` from a `BS` from two spare bits.

MULTILEADER and ACAD_TABLE bodies are deliberately left alone: MULTILEADER's ten failures are now inside the MLEADER body (#31), and ACAD_TABLE has no decoder and reports as `Unhandled` with its class name.

## Measured coverage (examples/coverage_report.rs, 19-file corpus)

| Version | Files | Decoded | Skipped | Errored | Rate |
|---|---|---|---|---|---|
| R2004 (AC1018) | 3 | 489 → 489 | 108 → 108 | 0 → 0 | 81.9 % → **81.9 %** |
| R2010 (AC1024) | 3 | 438 → 438 | 105 → 105 | 0 → 0 | 80.7 % → **80.7 %** |
| R2013 (AC1027) | 3 | 291 → 291 | 105 → 105 | 0 → 0 | 73.5 % → **73.5 %** |
| R2018 (AC1032) | 1 | 533 → 537 | 166 → 169 | 46 → 39 | 71.5 % → **72.1 %** |
| **Aggregate** | 19 | 1751 → **1755** | 484 → **487** | 46 → **39** | 76.8 % → **76.9 %** |

All 20 preamble errors are gone. The R2018 error histogram is now MULTILEADER 10, HATCH 5, INSERT 3, LTYPE 3, DIMENSION_DIAMETER 2, SPLINE 2, long tail 14 — no `Bit cursor exhausted` inside a preamble except the one bogus MESH record described below.

## #44 CUSTOM(727) — investigated, and it is not a type-code bug

The three records read `tag = 01`, `RC = 0xE7`, `+ 0x1F0` = 727. That is exactly what the bytes say and the documented R2010+ dispatch. They are not objects at all:

- handle `0x1607` @ 433069 decodes a handle field with `counter = 11` — an 11-byte handle value, which cannot exist;
- handle `0x15E6` @ 1063953 decodes `code 9, counter 0, value 0`, and claims `MS = 29,927` bytes with `MC = 14,220` bits of handle stream;
- two more handle-map entries show the same signature: `0x13E2` → CUSTOM(517) and `0x13E7` → CUSTOM(564), the latter claiming `MC = 280,720` bits.

The root cause is upstream of the type read: the handle map addresses offsets up to **1,289,590** while `AcDb:AcDbObjects` assembles to **1,192,851** bytes — its own declared decompressed size — and six handle-map offsets already fall past the end. The remaining garbage records are offsets that land inside the buffer but on the wrong bytes. That belongs with #43, and `read_object_type` is left untouched.

## Also in this PR

`examples/coverage_report.rs` names the type in its error histogram, resolving custom classes through the file's `AcDb:Classes` table the way the unhandled histogram already did. Closes #16.

## Spec sections

§2.1 (`3B`), §2.4 (`BLL`), §19.1 (object prologue / string stream), §19.4.1 (common entity data), §19.4.35 (AcDbRasterImage), §19.4.66 (AcDbSubDMesh).

## Source provenance

Clean-room. Every layout in this PR was derived from the ODA Open Design Specification v5.4.1 plus a bit-level walk of `sample_AC1032.dwg`; no LibreDWG, ODA SDK, or Autodesk source was read, and no permissively-licensed source or comments were consulted for this change. `CLEANROOM.md` is unchanged because there is nothing new to disclose.

## Gates

`cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --release` (16 suites green), `cargo deny check all`, `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --all-features`, `cargo +1.85.0 test --no-run` — all pass.

Test pins moved with the measurement, each with the reason in place: the `3B` value set (`{0, 2, 6, 7}` → `0..=7`) in `bitcursor`, `bitwriter`, `tests/proptest_roundtrip.rs` and `tests/mutation_failure_modes.rs`; the IMAGE rectangle fixture (dropped its vertex count); the MESH fixture (face-list sizing, `BL` edges, explicit crease count). `tests/canonical_corpus.rs` is untouched and green — the synthetic fixtures carry no graphics-preview block.

Closes #42, closes #16

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core bit primitives (`3B`/`BLL`) and the shared entity preamble used by every decoder on R2010+; wrong semantics would misalign all entities with graphics preview, though tests and real-DWG probes target the measured layouts.
> 
> **Overview**
> Fixes **#42** by reading the common entity preamble’s graphics-preview byte count as **`BLL` on R2010+** (still **`RL` through R2007**) instead of always using `RL`, which blew up preview sizes and exhausted the bit cursor on proxy-graphic entities (IMAGE, WIPEOUT, MESH, MULTILEADER, ACAD_TABLE).
> 
> **`3B` is now three raw bits** (`0..=7`), not a stop-at-zero prefix, so `read_bll` / `write_bll` can encode one-byte lengths; writers emit the exact byte count.
> 
> Follow-on body fixes on R2018: **IMAGE** rectangle clips skip the vertex count; **WIPEOUT** decodes as **`Image`**; **MESH** treats the face list as a **`BL` entry count**, uses **`BL` edge endpoints**, and reads creases from their own **`BL` count** (with index bounds checks).
> 
> Adds **`probe_entity_preamble`** and updates **`coverage_report`** error histograms to resolve custom classes by DXF name. Corpus coverage moves from **46 → 39** errors on `sample_AC1032.dwg` (**72.1%**); remaining MULTILEADER failures are in the MLEADER body, not the preamble.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1569a4f919d70251e94b1a5adfebee73f9a6083. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->