### PR TITLE
feat(objects): derive the ACAD_VISUALSTYLE field list from the data-stream boundary and dispatch it on R2010+

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -424,10 +424,57 @@ boundary:
 
 A decoder that lands anywhere else returns `DecodedEntity::Error`, so a
 wrong field list can never inflate the coverage ratio. That is also why
-MATERIAL, VISUALSTYLE and PROPERTYSET_DATA — which decode a documented
-*prefix* of their fields and stop — are deliberately **not** dispatched,
-along with LAYOUT and MLINESTYLE, whose field lists this crate has not
-yet matched against real bytes.
+MATERIAL and PROPERTYSET_DATA — which read only what their bytes prove
+and stop — are deliberately **not** dispatched, along with LAYOUT and
+MLINESTYLE, whose field lists this crate has not yet matched against
+real bytes.
+
+### 7d.1 Deriving a field list the spec does not carry — VISUALSTYLE
+
+The ODA v5.4.1 object-prescription chapter §20.4 stops at XRECORD; it
+carries no prescription for VISUALSTYLE or MATERIAL, the two largest
+undispatched classes on the corpus. The boundary above is what makes a
+field list for them *checkable* anyway, and it turns out to be strong
+enough to make one **derivable**: search for a token sequence over
+`B / BS / BL / BD / CMC` that lands **every** VISUALSTYLE record of a
+file exactly on its own boundary, requiring every `BD` to decode to a
+plausible double, every `CMC` true-colour word to carry a real colour
+method octet (`0xC0`…`0xC8`), and — once the pattern was visible — every
+other slot to be a `BS` flag in `0..=7`.
+
+On `arc_2010.dwg`'s 24 records that search returns exactly **one**
+answer: a fixed head (`TV` description, `BS` internal style type,
+`BS` 2, `B` internal-use flag) followed by 28 `(value, flag)` pairs. On
+`arc_2013.dwg` it returns exactly one answer too — the same 28 pairs
+plus 30 more — and that R2013 sequence closes on all 24 records of
+`sample_AC1032.dwg` as well. The `(value, flag)` pairing also explains
+the corpus's bit budgets: a flag of `1` costs 10 bits and a flag of `0`
+costs 2, which is why the records of one file differ only in multiples
+of 8, and why the three internal styles that carry `0` in every flag
+are exactly the shortest records in the file.
+
+Independent corroboration comes from the decoded values: the lone `B`
+of the fixed head is `false` on exactly the ten styles AutoCAD's Visual
+Styles Manager lists and `true` on the fourteen it hides; `face_opacity`
+is `0.6` everywhere except `X-Ray`, which is `0.5`; `face_mono_color` is
+white everywhere except `ColorChange`, which is `0x808080`;
+`edge_crease_angle` is `179` on `Conceptual` and `40` on `Hidden`,
+`Sketchy` and `Shades of Gray`.
+
+`examples/probe_field_list.rs` is the tool that measures one candidate
+list against one record:
+
+```sh
+cargo run --release --example probe_field_list -- \
+    samples/arc_2010.dwg 42 BS,BS,B,BS,BS,BD,BD
+```
+
+R2004 and R2007 VISUALSTYLE records store the same styles *without* the
+per-property flags and with a different property count; no sequence
+over the same token set lands their 24 records on their `RL`
+object-data-size boundary, so `objects::acad_visual_style` returns
+`Error::Unsupported` for those bands rather than guessing, and the
+dispatcher maps that to `Unhandled`.
 
 ## 7e. `AcDb:Classes` — where the class list actually starts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,86 @@ once the public API stabilizes at 0.1.0.
 
 ## [Unreleased]
 
+### Added — ACAD_VISUALSTYLE decodes and dispatches on R2010+ (2026-08-30, #38)
+
+- **The ODA spec carries no prescription for this object.** §20.4 runs
+  from `20.4.1 Common Entity Data` to `20.4.104 XRECORD` and stops;
+  VISUALSTYLE appears only in §20.3's list of non-fixed types. The two
+  modules that claimed "§19.6.10 (L6-17)" (VISUALSTYLE) and "§19.6.9
+  (L6-16)" (MATERIAL) were citing sections that do not exist; those
+  citations are withdrawn.
+- **The field list was derived from the boundary, not guessed.** Every
+  record's data fields must end exactly on the first bit of its string
+  stream. Searching for one token sequence over `B / BS / BL / BD / CMC`
+  that lands **all 24** VISUALSTYLE records of `arc_2010.dwg` on that
+  bit — with every `BD` a plausible double, every `CMC` true-colour word
+  a real colour method, and every flag a `BS` in `0..=7` — returns
+  exactly one answer: a fixed head (`TV` description, `BS` internal
+  style type, `BS` 2, `B` internal-use flag) then 28 `(value, flag)`
+  pairs. The same search on `arc_2013.dwg` returns exactly one answer
+  too — the same 28 pairs followed by 30 more — and that R2013 sequence
+  also closes on all 24 records of `sample_AC1032.dwg`.
+- **The pairing explains the corpus's bit budgets.** A flag of `1` costs
+  10 bits and a flag of `0` costs 2, so the records of one file differ
+  only in multiples of 8: `arc_2010.dwg` measures 574 / 774 / 782 / 790
+  / 798 / 806 / 854 / 862 bits, and the three internal styles that carry
+  `0` in every flag (`JitterOff`, `OverhangOff`, `EdgeColorOff`) are
+  exactly the 574-bit ones.
+- **Corroborated by the decoded values.** `is_internal_use_only` — the
+  lone `B` of the fixed head — comes out `false` on exactly ten of the
+  24 records (`2dWireframe`, `Wireframe`, `Hidden`, `Conceptual`,
+  `Realistic`, `Shades of Gray`, `Sketchy`, `X-Ray`, `Shaded with
+  edges`, `Shaded`), which is precisely the set AutoCAD's Visual Styles
+  Manager lists; `face_opacity` is `0.6` everywhere but `X-Ray`
+  (`0.5`); `face_mono_color` is `0xC2FFFFFF` everywhere but
+  `ColorChange` (`0xC2808080`); `edge_crease_angle` is `179` on
+  `Conceptual` and `40` on `Hidden` / `Sketchy` / `Shades of Gray`;
+  `internal_style_type` is a dense `0..=27` in ship order.
+- **R2004 / R2007 decline rather than guess.** Those records store the
+  same styles without the per-property flags and with a different
+  property count, and no sequence over the same token set lands their
+  24 records on the `RL` object-data-size boundary. `decode_object`
+  returns `Error::Unsupported` there, and the dispatcher now maps an
+  `Unsupported` from an object-class decoder to `Unhandled` rather than
+  `Error` — "this release is not determined" is not a broken record.
+- **`examples/probe_field_list.rs`** measures a candidate field list
+  against one real record and prints the delta from the boundary;
+  `examples/dump_decoded_entities.rs` prints VISUALSTYLE values.
+
+### Changed — ACAD_MATERIAL withdraws its unverified field list (2026-08-30, #38)
+
+- The previous `BL ambient_color_method, BS ambient_color, BD …` prefix
+  was wrong from its first field: on `arc_2004.dwg` handle 17 (the
+  `ByLayer` material) it decodes `ambient_color_method = 542113793` and
+  `ambient_color = 17728`, then eight consecutive `BD = 1.0`.
+- `objects::acad_material` now exposes `read_strings`, which reads the
+  name and description from the R2007+ string stream (they were being
+  read inline, i.e. from the wrong stream, on every R2007+ file), the
+  further string-stream entries an R2018 record carries, and the
+  **measured** data-field budget: 1284 bits on R2010 and R2013
+  (bit-identical across all three records of each file), 1264 bits after
+  the two inline `TV`s on R2004, 516 / 516 / 1028 on R2018.
+- What is known about the interior is documented rather than
+  implemented: twelve `BD` slots decode to exactly `1/48` at
+  data-stream bits 46, 120, 250, 324, 510, 584, 706, 780, 900, 974,
+  1096 and 1170 — six pairs, one per texture map, 74 bits apart — and
+  the R2018 record's seven string-stream entries corroborate six map
+  slots. The per-map block layout is not pinned, so MATERIAL stays
+  undispatched and its 30 corpus records stay `Unhandled`.
+
+Measured on the 19-file local corpus, `examples/coverage_report.rs`:
+
+| Corpus slice | Before (0914187) | After |
+|---|---|---|
+| R2004 (AC1018) × 3 | 489 / 108 / 0 / 81.9 % | 489 / 108 / 0 / 81.9 % |
+| R2010 (AC1024) × 3 | 438 / 105 / 0 / 80.7 % | **510 / 33 / 0 / 93.9 %** |
+| R2013 (AC1027) × 3 | 291 / 105 / 0 / 73.5 % | **363 / 33 / 0 / 91.7 %** |
+| R2018 (AC1032) × 1 | 533 / 166 / 46 / 71.5 % | **557 / 142 / 46 / 74.8 %** |
+| **Aggregate** | **1751 / 484 / 46 / 76.8 %** | **1919 / 316 / 46 / 84.1 %** |
+
+168 of the corpus's 240 VISUALSTYLE records now decode — the 72 on the
+three R2004 files are the remainder.
+
 ### Fixed — the R2018 `AcDb:Classes` record layout (2026-08-30, closes #37)
 
 - **`dwg_version` and `maintenance_version` are `BL`, not `BS`.** The

--- a/CLEANROOM.md
+++ b/CLEANROOM.md
@@ -113,3 +113,19 @@ For direct questions about the clean-room posture, open a GitHub
 Discussion or email the maintainer. For legal questions about
 whether this project is safe for your specific use case, consult
 your own counsel.
+
+## 2026-08-30 — VISUALSTYLE property names (Autodesk public DXF Reference, recalled)
+
+PR #47 derives the R2010+ `VISUALSTYLE` field layout entirely from bytes: the
+one token sequence over `B/BS/BL/BD/CMC` that lands every record of a file
+exactly on its string-stream start bit (24/24 records per file, delta 0), with
+decoded values cross-checked against AutoCAD's Visual Styles Manager. The
+**names** given to the 28 (R2010) / 58 (R2013+) value/flag slots follow the
+conventional `AcDbVisualStyle` property ordering as recalled from Autodesk's
+public *DXF Reference* (published documentation, not SDK or product source).
+Only the face-group names are independently corroborated by values; the
+edge/display names are positional labels and may be renamed if a later file
+contradicts them. No code, structure, or layout was taken from that document —
+it contributed vocabulary only. ODA spec v5.4.1 has no VISUALSTYLE or MATERIAL
+section; the `§19.6.9` / `§19.6.10` citations previously in this tree were
+withdrawn in the same PR.

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ local `samples/` set:
 |---------|--------------|---------|---------|---------|--------------|
 | R14 / R2000 / R2007 | 9 | n/a | n/a | n/a | not supported (no handle-map for this layout yet) |
 | R2004 (AC1018)      | 3 | 489 | 108 | 0 | **81.9 %** |
-| R2010 (AC1024)      | 3 | 438 | 105 | 0 | **80.7 %** |
-| R2013 (AC1027)      | 3 | 291 | 105 | 0 | **73.5 %** |
-| R2018 (AC1032)      | 1 | 533 | 166 | 46 | **71.5 %** |
-| **Aggregate** | **19** | **1751** | **484** | **46** | **76.8 %** |
+| R2010 (AC1024)      | 3 | 510 | 33 | 0 | **93.9 %** |
+| R2013 (AC1027)      | 3 | 363 | 33 | 0 | **91.7 %** |
+| R2018 (AC1032)      | 1 | 557 | 142 | 46 | **74.8 %** |
+| **Aggregate** | **19** | **1919** | **316** | **46** | **84.1 %** |
 
 Per-entity-type error concentration in the measured corpus:
 
@@ -88,7 +88,7 @@ real-file decode gap is the 0.2.0 milestone.
 | HandleMap + ClassMap parsing | ✓ shipped | — |
 | Header variables | ✓ shipped | Strict + lossy variants |
 | Object-stream walker (R2004+) | ✓ shipped | R14 / R2000 / R2007 pending (#104) |
-| Per-entity field decoders | ⚠ alpha | Broad synthetic coverage; real-file aggregate currently ~76.8% (#103) |
+| Per-entity field decoders | ⚠ alpha | Broad synthetic coverage; real-file aggregate currently ~84.1% (#103) |
 | Entity graph (owner / reactors / blocks / layers) | ⚠ partial | Resolver APIs exist; trailing-handle/block traversal gaps remain |
 | Symbol tables (LAYER / LTYPE / STYLE / DIMSTYLE / …) | ⚠ partial | R2007+ BLOCK_HEADER and simple LTYPE names decode; broader content fields pending |
 | SVG / PDF export | ⚠ alpha | SVG writer + paged-SVG PDF path; output quality depends on decoded geometry |
@@ -272,8 +272,8 @@ $ cargo deny check                                                # no advisorie
 
 Tests exercise the container layer end-to-end across all 19 corpus files and verify
 bit-level round-trip properties for every primitive. They do **not** verify that every
-entity decoder succeeds on every real-world drawing — that's what the 76.8 %
-aggregate / 71.5 % AC1032 coverage numbers above measure. Both classes of
+entity decoder succeeds on every real-world drawing — that's what the 84.1 %
+aggregate / 74.8 % AC1032 coverage numbers above measure. Both classes of
 testing are needed.
 
 ## Safety

--- a/STATUS.md
+++ b/STATUS.md
@@ -12,11 +12,12 @@ scrolling the changelog.
 - **Integration tests:** DXF round-trip (7), glTF smoke (3), SVG
   goldens (3), fuzz-corpus regression (6), write-path (5),
   entity-regression (18), real-DWG value regression (8).
-- **Current real-file decode coverage:** 1,751 decoded / 484 skipped /
-  46 errored / 76.8% on the local 19-file `samples/` corpus. The
-  R2018 `sample_AC1032.dwg` sample is 533 / 166 / 46 / 71.5%, and it
+- **Current real-file decode coverage:** 1,919 decoded / 316 skipped /
+  46 errored / 84.1% on the local 19-file `samples/` corpus. The
+  R2018 `sample_AC1032.dwg` sample is 557 / 142 / 46 / 74.8%, and it
   is the only file with any errors — the R2004, R2010 and R2013
-  samples all decode with zero.
+  samples all decode with zero. Per version: R2004 81.9%,
+  R2010 93.9%, R2013 91.7%.
 - **Fuzz targets:** 9 (lz77 / bitcursor / dwg-file-open / section-map /
   object-walker / classmap / handlemap / header-vars / rs-fec).
   Seed corpus: 30 hand-crafted inputs across all targets.
@@ -83,8 +84,10 @@ scrolling the changelog.
   decoder asserts its data fields end exactly on the string-stream
   start bit, so a wrong layout errors rather than returning garbage.
 - Named-object dictionary, ACAD_GROUP, ACAD_MLINESTYLE,
-  ACAD_PLOTSETTINGS, ACAD_SCALE, ACAD_MATERIAL, ACAD_VISUALSTYLE,
-  ACAD_PROPERTYSET_DATA, ACAD_LAYOUT.
+  ACAD_PLOTSETTINGS, ACAD_SCALE, ACAD_VISUALSTYLE (R2010+, 58
+  properties on R2013/R2018), ACAD_PROPERTYSET_DATA, ACAD_LAYOUT.
+  ACAD_MATERIAL reads only its strings and its measured bit budget —
+  its data-field layout is not determined.
 
 ### Graph + geometry (Phase 5 + 8)
 - `resolve_entity` / `owner_chain` / `reactor_chain`.
@@ -198,8 +201,8 @@ scrolling the changelog.
 These have genuine open scope requiring focused work, not stubs.
 
 - **Current real-file decode baseline:** the 2026-08-30
-  `examples/coverage_report.rs ../../samples` run reports 1751 decoded,
-  484 skipped, 46 errored, 76.8% aggregate coverage. This is the
+  `examples/coverage_report.rs ../../samples` run reports 1919 decoded,
+  316 skipped, 46 errored, 84.1% aggregate coverage. This is the
   practical product-readiness blocker even though synthetic decoder
   tests are broad.
 
@@ -208,12 +211,12 @@ These have genuine open scope requiring focused work, not stubs.
   ACAD_SCALE now dispatch through `src/objects/modern.rs`, taking their
   `TV` fields from the R2007+ string stream and checking their data
   fields end exactly on the record's data-stream boundary. Still
-  unreached, in descending record count on the corpus (counts as of
-  the 2026-08-30 run, which names custom classes now that the R2018
-  class table resolves): VISUALSTYLE (240 records), LAYOUT (31),
-  MATERIAL (30), ACDBDETAILVIEWSTYLE (11), ACDBSECTIONVIEWSTYLE (11),
-  MLEADERSTYLE (11), MLINESTYLE (10), TABLESTYLE (10).
-  MATERIAL / VISUALSTYLE /
+  VISUALSTYLE now dispatches too on R2010, R2013 and R2018 — 168 of
+  its 240 corpus records. Still unreached, in descending record count
+  on the corpus (counts as of the 2026-08-30 run): VISUALSTYLE on
+  R2004/R2007 (72 records), LAYOUT (31), MATERIAL (30),
+  ACDBDETAILVIEWSTYLE (11), ACDBSECTIONVIEWSTYLE (11), MLEADERSTYLE
+  (11), MLINESTYLE (10), TABLESTYLE (10). MATERIAL and
   PROPERTYSET_DATA decode only a documented prefix of their fields, so
   they cannot satisfy the boundary check; LAYOUT (which embeds the
   PLOTSETTINGS field list) and MLINESTYLE have field lists this crate

--- a/examples/dump_decoded_entities.rs
+++ b/examples/dump_decoded_entities.rs
@@ -358,6 +358,33 @@ fn print_entity(i: usize, e: &DecodedEntity) {
                 s.scale_name, s.paper_units, s.drawing_units, s.is_unit_scale
             );
         }
+        DecodedEntity::VisualStyle(v) => {
+            println!(
+                "[{i}] VISUALSTYLE  description={:?} type={} internal_only={} \
+                 face(model={} quality={} color_mode={} opacity={} specular={}) \
+                 mono_color={:#010X}",
+                v.description,
+                v.internal_style_type,
+                v.is_internal_use_only,
+                v.face_lighting_model,
+                v.face_lighting_quality,
+                v.face_color_mode,
+                v.face_opacity,
+                v.face_specular,
+                v.face_mono_color.rgb,
+            );
+            println!(
+                "             edge(model={} color={:#010X} silhouette={:#010X} \
+                 crease={} opacity={}) extended={} strings={:?}",
+                v.edge_model,
+                v.edge_color.rgb,
+                v.edge_silhouette_color.rgb,
+                v.edge_crease_angle,
+                v.edge_opacity,
+                v.extended.len(),
+                v.trailing_strings,
+            );
+        }
         DecodedEntity::ImageDef(d) => {
             println!(
                 "[{i}] IMAGEDEF  path={:?} size={:?} loaded={}",

--- a/examples/probe_field_list.rs
+++ b/examples/probe_field_list.rs
@@ -1,0 +1,209 @@
+//! Try a candidate field list against one real object record.
+//!
+//! The honesty rule this crate holds every object decoder to is that a
+//! record counts as decoded only when its data fields end *exactly* on
+//! the data-stream boundary — the first bit of the object's string
+//! stream on R2007+, or the `RL` object-data-size on R2000-R2007. This
+//! probe is how a candidate field list gets measured against that
+//! boundary before any of it is written into a decoder.
+//!
+//! ```sh
+//! cargo run --release --example probe_field_list -- \
+//!     samples/arc_2010.dwg 42 TV,BS,BS,BS,BD,BD,BS,RC,BS,BL
+//! ```
+//!
+//! Field-spec tokens are the ODA spec's type codes: `B`, `BB`, `3B`,
+//! `BS`, `BSU`, `BL`, `BLU`, `BLL`, `BD`, `RC`, `RS`, `RL`, `RD`, `TV`,
+//! and `CMC`. A `TV` consumes no data-stream bits on R2007+ (its
+//! characters live in the string stream) and is read inline otherwise.
+//! Prefix a token with a count, e.g. `4*BD`, to repeat it.
+//!
+//! Each field prints its bit offset, width and decoded value, and the
+//! run ends with the delta from the data-stream boundary: `delta 0` is
+//! the only result that means the field list is right.
+
+use dwg::bitcursor::BitCursor;
+use dwg::error::Result;
+use dwg::string_stream::{self, StringReader};
+use dwg::{DwgFile, Version};
+
+/// Advance `c` past the EED chain of the common object data.
+fn skip_eed(c: &mut BitCursor<'_>) -> Result<()> {
+    for _ in 0..256 {
+        let size = c.read_bs_u()? as usize;
+        if size == 0 {
+            return Ok(());
+        }
+        let _appid = c.read_handle()?;
+        for _ in 0..size {
+            let _ = c.read_rc()?;
+        }
+    }
+    Ok(())
+}
+
+/// Read a `TV` from the string stream when the file has one, inline otherwise.
+fn read_tv(
+    c: &mut BitCursor<'_>,
+    strings: &mut Option<StringReader<'_>>,
+    _version: Version,
+) -> Result<String> {
+    if let Some(reader) = strings.as_mut() {
+        return reader.read_tv();
+    }
+    let len = c.read_bs_u()? as usize;
+    let mut bytes = Vec::with_capacity(len);
+    for _ in 0..len {
+        bytes.push(c.read_rc()?);
+    }
+    if bytes.last() == Some(&0) {
+        bytes.pop();
+    }
+    Ok(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+fn expand(spec: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for token in spec.split(',').filter(|t| !t.trim().is_empty()) {
+        let token = token.trim();
+        match token.split_once('*') {
+            Some((n, t)) => {
+                let n: usize = n.parse().expect("repeat count must be a number");
+                for _ in 0..n {
+                    out.push(t.to_ascii_uppercase());
+                }
+            }
+            None => out.push(token.to_ascii_uppercase()),
+        }
+    }
+    out
+}
+
+fn main() -> Result<()> {
+    let mut args = std::env::args().skip(1);
+    let path = args
+        .next()
+        .expect("usage: <file.dwg> <handle> <field-spec>");
+    let handle: u64 = args
+        .next()
+        .expect("usage: <file.dwg> <handle> <field-spec>")
+        .parse()
+        .expect("handle must be decimal");
+    let spec = args.next().unwrap_or_default();
+
+    let file = DwgFile::open(&path)?;
+    let version = file.version();
+    let objects = file
+        .all_objects()
+        .expect("this version has no object-stream walk")?;
+    let object = objects
+        .iter()
+        .find(|o| o.handle.value == handle)
+        .unwrap_or_else(|| panic!("no object with handle {handle}"));
+
+    let data_end = dwg::object::data_end_bit(object, version);
+    let mut strings = match string_stream::locate(&object.raw, version) {
+        Some(stream) => Some(StringReader::new(&object.raw, stream)?),
+        None if version.is_r2007_plus() => Some(StringReader::empty(&object.raw)),
+        None => None,
+    };
+
+    let mut c = dwg::object::body_cursor(object, version)?;
+    skip_eed(&mut c)?;
+    let num_reactors = c.read_bl()?;
+    if version.is_r2004_plus() {
+        let _ = c.read_b()?;
+    }
+    if matches!(version, Version::R2013 | Version::R2018) && c.read_b()? {
+        let _ = c.read_rc()?;
+    }
+
+    println!("{path}  ({version})  handle {handle}");
+    println!(
+        "body starts at bit {}, data ends at {:?}, budget {:?}, num_reactors {num_reactors}",
+        c.position_bits(),
+        data_end,
+        data_end.map(|e| e as isize - c.position_bits() as isize),
+    );
+
+    for (index, token) in expand(&spec).iter().enumerate() {
+        let at = c.position_bits();
+        let value: String = match token.as_str() {
+            "B" => format!("{}", c.read_b()?),
+            "BB" => format!("{}", c.read_bb()?),
+            "3B" => format!("{}", c.read_3b()?),
+            "BS" => format!("{}", c.read_bs()?),
+            "BSU" => format!("{}", c.read_bs_u()?),
+            "BL" => format!("{}", c.read_bl()?),
+            "BLU" => format!("{}", c.read_bl_u()?),
+            "BLL" => format!("{}", c.read_bll()?),
+            "BD" => format!("{}", c.read_bd()?),
+            "RC" => format!("{}", c.read_rc()?),
+            "RS" => format!("{}", c.read_rs()?),
+            "RL" => format!("{}", c.read_rl()?),
+            "RD" => format!("{}", c.read_rd()?),
+            "CMC" => {
+                let index_ = c.read_bs()?;
+                let mut extra = String::new();
+                if version.is_r2004_plus() {
+                    let rgb = c.read_bl()?;
+                    let flag = c.read_rc()?;
+                    extra = format!(" rgb {rgb:#010X} flag {flag}");
+                    if flag & 1 != 0 {
+                        let _ = read_tv(&mut c, &mut strings, version)?;
+                    }
+                    if flag & 2 != 0 {
+                        let _ = read_tv(&mut c, &mut strings, version)?;
+                    }
+                }
+                format!("{index_}{extra}")
+            }
+            "TV" => format!("{:?}", read_tv(&mut c, &mut strings, version)?),
+            other => panic!("unknown field token {other}"),
+        };
+        let now = c.position_bits();
+        println!(
+            "  [{index:>3}] {token:<4} @{at:<5} w{:<3} = {value}",
+            now - at
+        );
+    }
+
+    let at = c.position_bits();
+    match data_end {
+        Some(end) => println!(
+            "ended at {at}, boundary {end}, delta {}",
+            at as isize - end as isize
+        ),
+        None => println!("ended at {at}, boundary unknown"),
+    }
+    if let Some(end) = data_end {
+        println!("remaining bits from {at} to {end}:");
+        let mut line = String::new();
+        for bit in at..end {
+            let byte = object.raw.get(bit / 8).copied().unwrap_or(0);
+            line.push(if (byte >> (7 - (bit % 8))) & 1 != 0 {
+                '1'
+            } else {
+                '0'
+            });
+            if line.len() == 64 {
+                println!("  @{:<6} {line}", bit + 1 - 64);
+                line.clear();
+            }
+        }
+        if !line.is_empty() {
+            println!("  @{:<6} {line}", end - line.len());
+        }
+    }
+    if let Some(reader) = strings.as_mut() {
+        let mut rest = Vec::new();
+        while !reader.is_exhausted() {
+            match reader.read_tv() {
+                Ok(s) => rest.push(s),
+                Err(_) => break,
+            }
+        }
+        println!("unread strings: {rest:?}");
+    }
+    Ok(())
+}

--- a/src/entities/dispatch.rs
+++ b/src/entities/dispatch.rs
@@ -112,6 +112,7 @@ pub enum DecodedEntity {
     Placeholder(crate::objects::placeholder::Placeholder),
     Group(crate::objects::acad_group::AcadGroup),
     Scale(crate::objects::acad_scale::AcadScale),
+    VisualStyle(crate::objects::acad_visual_style::AcadVisualStyle),
     ImageDef(crate::entities::imagedef::ImageDef),
     /// One of the ten `*_CONTROL` table owners; `kind` says which.
     Control {
@@ -209,7 +210,7 @@ impl DecodedEntity {
             // DICTIONARYVAR and SCALE are custom classes — their codes
             // vary per file via AcDb:Classes. Return 0 so callers know
             // to consult the class map.
-            Self::DictionaryVar(_) | Self::Scale(_) | Self::ImageDef(_) => 0,
+            Self::DictionaryVar(_) | Self::Scale(_) | Self::ImageDef(_) | Self::VisualStyle(_) => 0,
             Self::Control { kind, .. } => control_type_code(*kind),
             Self::Unhandled { type_code, .. } | Self::Error { type_code, .. } => *type_code,
         }
@@ -584,6 +585,10 @@ fn dispatch_object_class(
             crate::objects::acad_scale::decode_object(payload, body_start, inline_end, version)
                 .map(DecodedEntity::Scale)
         }
+        "VISUALSTYLE" | "ACDBVISUALSTYLE" => crate::objects::acad_visual_style::decode_object(
+            payload, body_start, inline_end, version,
+        )
+        .map(DecodedEntity::VisualStyle),
         "DICTIONARYVAR" | "ACDBDICTIONARYVAR" => {
             crate::objects::dictionary_var::decode_object(payload, body_start, inline_end, version)
                 .map(DecodedEntity::DictionaryVar)
@@ -605,6 +610,13 @@ fn dispatch_object_class(
     };
     Some(match result {
         Ok(decoded) => decoded,
+        // "this release's layout is not determined" is not a decode
+        // failure — the record is simply one this crate does not handle
+        // yet, so it belongs in the Unhandled bucket rather than being
+        // reported as a broken record.
+        Err(crate::error::Error::Unsupported { .. }) => {
+            DecodedEntity::Unhandled { type_code, kind }
+        }
         Err(e) => DecodedEntity::Error {
             type_code,
             kind,

--- a/src/objects/acad_material.rs
+++ b/src/objects/acad_material.rs
@@ -1,125 +1,114 @@
-//! ACAD_MATERIAL object (spec §19.6.9 — L6-16) — rendering material
-//! definition. R2007+ only.
+//! ACAD_MATERIAL object — rendering material definition.
 //!
-//! MATERIAL records describe how a surface is shaded during a
-//! rendered-viewport plot: diffuse/ambient/specular terms, bump
-//! mapping amplitude, refraction index, self-illumination, etc.
-//! The full stream runs to ~65 fields including per-channel texture
-//! sub-records; this decoder reads the **first ~25 most-rendering-
-//! relevant fields** and stops.
+//! # What this module does and does not claim
 //!
-//! # Field cutoff
+//! It reads a MATERIAL record's **strings** — the material name, its
+//! description, and the further string-stream entries R2018 records
+//! carry — and reports the **measured bit budget** of the record's data
+//! fields. It does not decode those data fields, because their layout
+//! is not determined, and it is therefore deliberately **not wired into
+//! the object dispatcher**: a MATERIAL record still counts as
+//! `Unhandled`, never as decoded.
 //!
-//! The cutoff is deliberate: once `luminance_mode` is consumed, the
-//! remaining fields are all texture sub-records (diffuse map, bump
-//! map, reflection map, opacity map, specular map, refraction map,
-//! normal map, …) each of which is itself a multi-field struct with
-//! version-gated extensions. A proper decoder for those belongs in
-//! a dedicated `MaterialTextures` module; mixing them into the
-//! base-property decoder would triple the surface area for a first
-//! cut. The fields captured here are sufficient to drive a flat
-//! shading preview or a DXF export of the material's base colour
-//! properties.
+//! # There is no spec prescription for this object
 //!
-//! # Stream shape (subset decoded)
+//! The ODA *Open Design Specification for .dwg files* v5.4.1 lists
+//! `MATERIAL` in §20.3's table of non-fixed object types, but §20.4 —
+//! the object-prescription chapter — has no entry for it; it runs from
+//! `20.4.1 Common Entity Data` to `20.4.104 XRECORD` and stops. (An
+//! earlier revision of this module cited "§19.6.9 (L6-16)"; no such
+//! section exists.)
 //!
-//! ```text
-//! TV   name
-//! TV   description
-//! BL   ambient_color_method       -- 0=ByObject, 1=Override
-//! BS   ambient_color              -- ACI index (simplified CMC)
-//! BD   ambient_color_factor
-//! BL   diffuse_color_method
-//! BS   diffuse_color
-//! BD   diffuse_color_factor
-//! BD   specular_color_factor
-//! BD   specular_gloss_factor
-//! BD   reflection_factor
-//! BD   opacity_factor
-//! BD   bump_amount
-//! BD   refraction_factor
-//! BD   translucence
-//! BL   self_illumination
-//! BD   luminance
-//! BL   luminance_mode
-//! ```
+//! # Why the previous field list was withdrawn
 //!
-//! Returns [`Error::Unsupported`] for pre-R2007 versions.
+//! That revision read `BL ambient_color_method, BS ambient_color,
+//! BD ambient_color_factor, …` off the front of the record. Measured
+//! against `arc_2004.dwg` handle 17 — the `ByLayer` material, whose two
+//! `TV`s occupy bits 0..76 of the body — that list decodes
+//! `ambient_color_method = 542113793` and `ambient_color = 17728`,
+//! followed by eight consecutive `BD = 1.0`. Those are not colour
+//! methods and colour indices; the list was wrong from its first field.
+//!
+//! # What the bytes do say — measured
+//!
+//! | File | Records | Data-field budget | Strings |
+//! |---|---|---|---|
+//! | `arc_2004.dwg` | 3 (`ByLayer`, `ByBlock`, `Global`) | 1340 / 1340 / 1332 bits, inclusive of the two inline `TV`s (1264 bits after them, identical in all three) | 2, inline |
+//! | `arc_2010.dwg` | 3 | 1284 bits, bit-identical in all three | 2 |
+//! | `arc_2013.dwg` | 3 | 1284 bits, bit-identical in all three and to R2010 | 2 |
+//! | `sample_AC1032.dwg` | 3 | 516 / 516 / 1028 bits | 7 |
+//!
+//! Inside the R2010/R2013 body, twelve `BD` slots decode to exactly
+//! `1/48` (`0.0208333…`, the imperial default map scale) at data-stream
+//! bits 46, 120, 250, 324, 510, 584, 706, 780, 900, 974, 1096 and 1170
+//! — six pairs, one per texture map, each pair 74 bits apart. The
+//! `sample_AC1032.dwg` `Global` record shows the same shape with four
+//! pairs, and each of its pairs is bracketed by `CMC` words
+//! `0xC1000000` and `0xC2040300`. Its seven string-stream entries — the
+//! name plus six empties — corroborate six map slots.
+//!
+//! That is enough to say where the per-map blocks are and not enough to
+//! say what is inside them, and the gap between the last `1/48` pair and
+//! the record's boundary differs from block to block (64, 120, 56, 54,
+//! 56 and 48 bits on R2010), so no single repeating block layout has
+//! been pinned. Per this crate's honesty rule a record counts as decoded
+//! only when its fields end exactly on the string-stream start bit, so
+//! MATERIAL stays undecoded until that layout is measured rather than
+//! guessed.
 
-use crate::bitcursor::BitCursor;
-use crate::error::{Error, Result};
-use crate::tables::read_tv;
+use crate::error::Result;
+use crate::objects::modern;
 use crate::version::Version;
 
-#[derive(Debug, Clone, PartialEq)]
+/// The parts of an ACAD_MATERIAL record this crate can prove.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AcadMaterial {
+    /// Material name — `ByLayer`, `ByBlock` and `Global` in every
+    /// corpus file. Taken from the R2007+ string stream.
     pub name: String,
+    /// Material description; empty in every corpus record.
     pub description: String,
-    pub ambient_color_method: i32,
-    pub ambient_color: i16,
-    pub ambient_color_factor: f64,
-    pub diffuse_color_method: i32,
-    pub diffuse_color: i16,
-    pub diffuse_color_factor: f64,
-    pub specular_color_factor: f64,
-    pub specular_gloss_factor: f64,
-    pub reflection_factor: f64,
-    pub opacity_factor: f64,
-    pub bump_amount: f64,
-    pub refraction_factor: f64,
-    pub translucence: f64,
-    pub self_illumination: i32,
-    pub luminance: f64,
-    pub luminance_mode: i32,
+    /// Further string-stream entries. R2018 records carry six empty
+    /// slots here, one per texture map.
+    pub extra_strings: Vec<String>,
+    /// Bits between the end of the common object data and the record's
+    /// data-stream boundary — the budget a future field list has to
+    /// fill exactly. `None` on R13/R14, which carry no boundary.
+    pub data_field_bits: Option<usize>,
 }
 
-/// Decodes the `AcadMaterial` payload that follows the common object header.
-pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<AcadMaterial> {
-    if !version.is_r2007_plus() {
-        return Err(Error::Unsupported {
-            feature: format!(
-                "ACAD_MATERIAL requires R2007 or newer; got {}",
-                version.release()
-            ),
-        });
+/// Read the strings and the measured data-field budget of one
+/// ACAD_MATERIAL record.
+///
+/// This does **not** decode the record's data fields and does not
+/// satisfy the crate-internal `ObjectStream::finish` boundary check, so
+/// it is not dispatched; see the module docs for what is and is not known.
+pub fn read_strings(
+    payload: &[u8],
+    body_start: usize,
+    inline_data_end: Option<usize>,
+    version: Version,
+) -> Result<AcadMaterial> {
+    let mut split = modern::open(payload, body_start, inline_data_end, version)?;
+    let name = modern::read_tv(&mut split.data, &mut split.strings, version)?;
+    let description = modern::read_tv(&mut split.data, &mut split.strings, version)?;
+    let data_field_bits = split
+        .data_end()
+        .map(|end| end.saturating_sub(split.data.position_bits()));
+    let mut extra_strings = Vec::new();
+    if let Some(strings) = split.strings.as_mut() {
+        while !strings.is_exhausted() {
+            match strings.read_tv() {
+                Ok(text) => extra_strings.push(text),
+                Err(_) => break,
+            }
+        }
     }
-    let name = read_tv(c, version)?;
-    let description = read_tv(c, version)?;
-    let ambient_color_method = c.read_bl()?;
-    let ambient_color = c.read_bs()?;
-    let ambient_color_factor = c.read_bd()?;
-    let diffuse_color_method = c.read_bl()?;
-    let diffuse_color = c.read_bs()?;
-    let diffuse_color_factor = c.read_bd()?;
-    let specular_color_factor = c.read_bd()?;
-    let specular_gloss_factor = c.read_bd()?;
-    let reflection_factor = c.read_bd()?;
-    let opacity_factor = c.read_bd()?;
-    let bump_amount = c.read_bd()?;
-    let refraction_factor = c.read_bd()?;
-    let translucence = c.read_bd()?;
-    let self_illumination = c.read_bl()?;
-    let luminance = c.read_bd()?;
-    let luminance_mode = c.read_bl()?;
     Ok(AcadMaterial {
         name,
         description,
-        ambient_color_method,
-        ambient_color,
-        ambient_color_factor,
-        diffuse_color_method,
-        diffuse_color,
-        diffuse_color_factor,
-        specular_color_factor,
-        specular_gloss_factor,
-        reflection_factor,
-        opacity_factor,
-        bump_amount,
-        refraction_factor,
-        translucence,
-        self_illumination,
-        luminance,
-        luminance_mode,
+        extra_strings,
+        data_field_bits,
     })
 }
 
@@ -128,56 +117,44 @@ mod tests {
     use super::*;
     use crate::bitwriter::BitWriter;
 
-    fn encode_tv_utf16(w: &mut BitWriter, s: &str) {
-        let units: Vec<u16> = s.encode_utf16().collect();
-        w.write_bs_u(units.len() as u16);
-        for u in units {
-            w.write_rc((u & 0xFF) as u8);
-            w.write_rc((u >> 8) as u8);
+    #[test]
+    fn r2018_split_stream_material_reads_its_names_from_the_string_stream() {
+        let mut body = modern::tests::r2018_object_prefix(1);
+        // Stand-in for the undecoded data fields.
+        for _ in 0..40 {
+            body.write_b(false);
         }
+        let bits = crate::string_stream::tests::bits_of(&body);
+        let payload =
+            crate::string_stream::tests::build_payload(&bits, &["Global", "", "", "", "", "", ""]);
+        let material = read_strings(&payload, 8, None, Version::R2018).unwrap();
+        assert_eq!(material.name, "Global");
+        assert_eq!(material.description, "");
+        assert_eq!(material.extra_strings.len(), 5);
+        assert_eq!(material.data_field_bits, Some(40));
     }
 
     #[test]
-    fn rejects_pre_r2007() {
-        let bytes = [0u8; 16];
-        let mut c = BitCursor::new(&bytes);
-        let err = decode(&mut c, Version::R2000).unwrap_err();
-        assert!(
-            matches!(&err, Error::Unsupported { feature } if feature.contains("ACAD_MATERIAL"))
-        );
-    }
-
-    #[test]
-    fn roundtrip_plastic_material_r2010() {
+    fn inline_layout_reads_its_names_from_the_data_cursor() {
         let mut w = BitWriter::new();
-        // R2010 is in the is_r2007_plus / uses_utf16_text family.
-        encode_tv_utf16(&mut w, "Plastic - Red");
-        encode_tv_utf16(&mut w, "Smooth red plastic");
-        w.write_bl(1); // ambient_color_method (1 = Override)
-        w.write_bs(1); // ambient_color (ACI red)
-        w.write_bd(1.0); // ambient_color_factor
-        w.write_bl(1); // diffuse_color_method
-        w.write_bs(1); // diffuse_color
-        w.write_bd(1.0); // diffuse_color_factor
-        w.write_bd(0.5); // specular_color_factor
-        w.write_bd(0.85); // specular_gloss_factor
-        w.write_bd(0.0); // reflection_factor
-        w.write_bd(1.0); // opacity_factor (fully opaque)
-        w.write_bd(0.0); // bump_amount
-        w.write_bd(1.5); // refraction_factor
-        w.write_bd(0.0); // translucence
-        w.write_bl(0); // self_illumination
-        w.write_bd(0.0); // luminance
-        w.write_bl(0); // luminance_mode
+        w.write_bs_u(0); // EED terminator
+        w.write_bl(1); // num_reactors
+        w.write_b(true); // no xdictionary (R2004+)
+        w.write_bs_u(8);
+        for b in b"ByLayer\0" {
+            w.write_rc(*b);
+        }
+        w.write_bs_u(0); // empty description
+        let after_names = w.position_bits();
+        for _ in 0..24 {
+            w.write_b(false);
+        }
+        let end = w.position_bits();
         let bytes = w.into_bytes();
-        let mut c = BitCursor::new(&bytes);
-        let m = decode(&mut c, Version::R2010).unwrap();
-        assert_eq!(m.name, "Plastic - Red");
-        assert_eq!(m.description, "Smooth red plastic");
-        assert_eq!(m.ambient_color_method, 1);
-        assert_eq!(m.diffuse_color, 1);
-        assert!((m.specular_gloss_factor - 0.85).abs() < 1e-12);
-        assert!((m.opacity_factor - 1.0).abs() < 1e-12);
-        assert!((m.refraction_factor - 1.5).abs() < 1e-12);
+        let material = read_strings(&bytes, 0, Some(end), Version::R2004).unwrap();
+        assert_eq!(material.name, "ByLayer");
+        assert_eq!(material.description, "");
+        assert!(material.extra_strings.is_empty());
+        assert_eq!(material.data_field_bits, Some(end - after_names));
     }
 }

--- a/src/objects/acad_visual_style.rs
+++ b/src/objects/acad_visual_style.rs
@@ -1,111 +1,472 @@
-//! ACAD_VISUALSTYLE object (spec §19.6.10 — L6-17) — named display
-//! style (face lighting model, edge rendering, silhouette, etc.).
-//! R2007+ only.
+//! ACAD_VISUALSTYLE object — named display style (face lighting model,
+//! edge rendering, silhouette, shadows). R2010+ only.
 //!
-//! Visual styles are the R2007+ replacement for the earlier
-//! "shademode" enumeration. Each style packages face-shading
-//! parameters (lighting model, opacity, monochrome colour), edge
-//! rendering parameters (intersection / obscured / silhouette
-//! colours, edge model), and shadow flags. The full on-wire stream
-//! includes upwards of 50 fields; this decoder reads a **documented
-//! subset** — the most commonly-used face + edge base properties —
-//! and stops.
+//! # There is no spec prescription for this object
 //!
-//! # Field cutoff
+//! The ODA *Open Design Specification for .dwg files* v5.4.1 lists
+//! `VISUALSTYLE` in §20.3's table of non-fixed object types but §20.4
+//! carries **no prescription** for it — the object-prescription chapter
+//! runs from `20.4.1 Common Entity Data` to `20.4.104 XRECORD` and stops.
+//! (An earlier revision of this module cited "§19.6.10 (L6-17)"; no such
+//! section exists.) Everything below was therefore derived by measuring
+//! real records against the boundary the format itself provides.
 //!
-//! After `edge_silhouette_color` the stream continues with
-//! halo-gap, crease/intersection/obscured line style, jitter, wiggle,
-//! silhouette line width, halo intensity, and display settings —
-//! each of which is usable only in conjunction with sibling fields
-//! not surfaced here. A full decoder belongs in a dedicated
-//! extension; this subset is sufficient for matching a visual style
-//! by name and extracting the handful of properties that most
-//! consumers actually use (base face colour mode, silhouette
-//! colour, edge model).
-//!
-//! # Stream shape (subset decoded)
+//! # The wire shape — measured
 //!
 //! ```text
-//! TV   description
-//! BS   face_lighting_model
-//! BS   face_lighting_quality
-//! BS   face_color_mode
-//! BD   face_opacity
-//! BD   face_specular
-//! BS   face_mono_color
-//! RC   face_modifier
-//! BS   edge_model
-//! BL   edge_style_apply_flags
-//! BS   edge_intersection_color
-//! BS   edge_obscured_color
-//! BS   edge_color
-//! BS   edge_silhouette_color
+//! TV   description                  -- from the string stream on R2007+
+//! BS   internal_style_type          -- 0..27, one per built-in style
+//! BS   format_version               -- 2 in every record measured
+//! B    is_internal_use_only
+//! then one (value, BS flag) pair per property, in this order:
+//!   BS  face_lighting_model          BS  face_lighting_quality
+//!   BS  face_color_mode              BS  face_modifier
+//!   BD  face_opacity                 BD  face_specular
+//!   CMC face_mono_color              BS  edge_model
+//!   BS  edge_style                   CMC edge_intersection_color
+//!   CMC edge_obscured_color          BS  edge_obscured_linetype
+//!   BS  edge_intersection_linetype   BD  edge_crease_angle
+//!   BS  edge_modifier                CMC edge_color
+//!   BD  edge_opacity                 BS  edge_width
+//!   BS  edge_overhang                BS  edge_jitter
+//!   CMC edge_silhouette_color        BS  edge_silhouette_width
+//!   BS  edge_halo_gap                BS  edge_isoline_count
+//!   B   edge_hide_precision          BS  edge_style_apply
+//!   BD  display_brightness           BS  display_shadow_type
+//! R2013+ only: 30 further (value, flag) pairs, widths measured, names
+//! not determined — see [`AcadVisualStyle::extended`].
 //! ```
 //!
-//! Returns [`Error::Unsupported`] for pre-R2007 versions.
+//! `CMC` is the full colour form the crate-internal
+//! `tables::modern::read_cmc_full` already reads for VIEW / VPORT:
+//! `BS` index, `BL` true-colour word, `RC` colour byte. The true-colour words in these records carry the
+//! usual method byte in the top octet — `0xC2RRGGBB` for an RGB colour,
+//! `0xC3000000 | aci` for an index, `0xC0`/`0xC8` for ByLayer / none.
+//!
+//! # Why the `(value, flag)` pairing is not a guess
+//!
+//! Every record's data fields have to end exactly on the first bit of
+//! its string stream — the boundary the crate-internal
+//! `objects::modern::ObjectStream::finish` enforces for every
+//! dispatched object decoder.
+//! Searching for one token sequence that lands **all 24 VISUALSTYLE
+//! records of a file** on that boundary — with every `BD` a plausible
+//! double, every `CMC` true-colour word a real colour method, and every
+//! flag a `BS` in `0..=7` — returns exactly **one** answer on
+//! `arc_2010.dwg`, the 28-property list above. The same search on
+//! `arc_2013.dwg` returns exactly one answer too: the identical 28
+//! properties followed by 30 more.
+//!
+//! The pairing also explains the corpus's bit budgets. A flag of `1`
+//! costs 10 bits (`BS` byte form), a flag of `0` costs 2, so records
+//! differ by multiples of 8: the 24 records of `arc_2010.dwg` measure
+//! 574 / 774 / 782 / 790 / 798 / 806 / 854 / 862 bits, and the three
+//! internal styles (`JitterOff`, `OverhangOff`, `EdgeColorOff`) that
+//! carry `0` in *every* flag are exactly the 574-bit ones.
+//!
+//! Corroboration from the decoded values themselves:
+//!
+//! - `face_opacity` decodes to `0.6` in every style but `X-Ray`, which
+//!   decodes `0.5` — the one built-in style that is semi-transparent;
+//! - `face_mono_color` decodes `0xC2FFFFFF` (white) everywhere except
+//!   `ColorChange`, which decodes `0xC2808080`;
+//! - `internal_style_type` decodes `0` for `Flat`, `1` for
+//!   `FlatWithEdges`, `2` for `Gouraud`, `3` for `GouraudWithEdges`,
+//!   `4` for `2dWireframe` … `27` for `Shaded` — a dense enumeration in
+//!   the order AutoCAD ships the styles;
+//! - `is_internal_use_only` — the lone `B` of the fixed head — decodes
+//!   `false` for exactly ten of the 24 records: `2dWireframe`,
+//!   `Wireframe`, `Hidden`, `Conceptual`, `Realistic`, `Shades of
+//!   Gray`, `Sketchy`, `X-Ray`, `Shaded with edges`, `Shaded`. Those
+//!   are precisely the ten styles AutoCAD's Visual Styles Manager
+//!   lists; the fourteen it hides (`Flat`, `Gouraud`, `Basic`, `Dim`,
+//!   `Brighten`, `Thicken`, `Linepattern`, `Facepattern`,
+//!   `ColorChange`, `JitterOff`, …) all decode `true`. A field list
+//!   off by one bit cannot reproduce that partition;
+//! - `edge_crease_angle` decodes `40` on `Hidden`, `Sketchy` and
+//!   `Shades of Gray`, `179` on `Conceptual` and `1` elsewhere —
+//!   degrees, in the styles where a crease angle is meaningful;
+//! - the sole `B`-typed property of the pair list falls where the
+//!   conventional `AcDbVisualStyle` property order puts its sole
+//!   boolean.
+//!
+//! # Naming
+//!
+//! The field **types, widths and order** above are measured. The
+//! **names** follow the conventional `AcDbVisualStyle` property
+//! ordering; the face group is corroborated by the decoded values as
+//! described above, the edge and display groups are positional and are
+//! not independently corroborated by this crate. Treat them as labels
+//! for slots whose layout is proven, not as verified semantics.
+//!
+//! # Versions
+//!
+//! | Release | Status |
+//! |---|---|
+//! | R2010 | 28 properties — closes on all 24 records of `arc_2010.dwg` |
+//! | R2013 / R2018 | 58 properties — closes on all 24 records of `arc_2013.dwg` and all 24 of `sample_AC1032.dwg` |
+//! | R2004 / R2007 | layout differs and is **not** determined; [`Error::Unsupported`] |
+//!
+//! `arc_2004.dwg` stores the same styles without the per-property flags
+//! and with a different property count; no token sequence over
+//! `BS/BD/CMC/B` lands its 24 records on their `RL` object-data-size
+//! boundary, so this module declines that band rather than guessing.
 
 use crate::bitcursor::BitCursor;
 use crate::error::{Error, Result};
-use crate::tables::read_tv;
+use crate::objects::modern;
 use crate::version::Version;
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct AcadVisualStyle {
-    pub description: String,
-    pub face_lighting_model: i16,
-    pub face_lighting_quality: i16,
-    pub face_color_mode: i16,
-    pub face_opacity: f64,
-    pub face_specular: f64,
-    pub face_mono_color: i16,
-    pub face_modifier: u8,
-    pub edge_model: i16,
-    pub edge_style_apply_flags: i32,
-    pub edge_intersection_color: i16,
-    pub edge_obscured_color: i16,
-    pub edge_color: i16,
-    pub edge_silhouette_color: i16,
+/// One `CMC` colour: `BS` index, `BL` true-colour word, `RC` colour byte.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct VisualStyleColor {
+    /// Colour index word.
+    pub index: u16,
+    /// True-colour word; the top octet is the colour method
+    /// (`0xC2` RGB, `0xC3` ACI index, `0xC0` ByLayer, `0xC8` none).
+    pub rgb: u32,
+    /// Trailing colour byte; `1` and `2` would introduce name strings.
+    pub color_byte: u8,
 }
 
-/// Decodes the `AcadVisualStyle` payload that follows the common object header.
-pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<AcadVisualStyle> {
-    if !version.is_r2007_plus() {
+impl VisualStyleColor {
+    /// The colour method octet — the top byte of the true-colour word.
+    pub fn method(&self) -> u8 {
+        (self.rgb >> 24) as u8
+    }
+
+    /// The 24-bit payload of the true-colour word: an RGB triple when
+    /// [`method`](Self::method) is `0xC2`, an ACI index when it is `0xC3`.
+    pub fn payload(&self) -> u32 {
+        self.rgb & 0x00FF_FFFF
+    }
+}
+
+/// One R2013+ tail property: a value of measured width, plus its flag.
+#[derive(Debug, Clone, PartialEq)]
+pub enum VisualStyleValue {
+    /// A `BS` slot.
+    Short(i16),
+    /// A `BD` slot.
+    Double(f64),
+    /// A `B` slot.
+    Bool(bool),
+    /// A `CMC` slot.
+    Color(VisualStyleColor),
+}
+
+/// A `(value, flag)` property pair.
+#[derive(Debug, Clone, PartialEq)]
+pub struct VisualStyleProperty {
+    /// The property's value.
+    pub value: VisualStyleValue,
+    /// The trailing `BS` flag; `0` on the styles AutoCAD marks internal.
+    pub flag: i16,
+}
+
+/// A decoded ACAD_VISUALSTYLE record.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AcadVisualStyle {
+    /// Style name / description, from the R2007+ string stream.
+    pub description: String,
+    /// Dense per-style enumeration, `0` (`Flat`) … `27` (`Shaded`).
+    pub internal_style_type: i16,
+    /// `2` in every record measured.
+    pub format_version: i16,
+    /// Set on the styles AutoCAD does not offer in the UI.
+    pub is_internal_use_only: bool,
+    /// Face property: lighting model.
+    pub face_lighting_model: i16,
+    /// Face property: lighting quality.
+    pub face_lighting_quality: i16,
+    /// Face property: colour mode.
+    pub face_color_mode: i16,
+    /// Face property: modifier bits.
+    pub face_modifier: i16,
+    /// Face property: opacity, `0.5` on `X-Ray` and `0.6` elsewhere.
+    pub face_opacity: f64,
+    /// Face property: specular / highlight level.
+    pub face_specular: f64,
+    /// Face property: monochrome colour.
+    pub face_mono_color: VisualStyleColor,
+    /// Edge property (positional name): edge model.
+    pub edge_model: i16,
+    /// Edge property (positional name): edge style bits.
+    pub edge_style: i16,
+    /// Edge property (positional name): intersection colour.
+    pub edge_intersection_color: VisualStyleColor,
+    /// Edge property (positional name): obscured colour.
+    pub edge_obscured_color: VisualStyleColor,
+    /// Edge property (positional name): obscured linetype.
+    pub edge_obscured_linetype: i16,
+    /// Edge property (positional name): intersection linetype.
+    pub edge_intersection_linetype: i16,
+    /// Edge property (positional name): crease angle.
+    pub edge_crease_angle: f64,
+    /// Edge property (positional name): modifier bits.
+    pub edge_modifier: i16,
+    /// Edge property (positional name): edge colour.
+    pub edge_color: VisualStyleColor,
+    /// Edge property (positional name): edge opacity.
+    pub edge_opacity: f64,
+    /// Edge property (positional name): edge width.
+    pub edge_width: i16,
+    /// Edge property (positional name): overhang.
+    pub edge_overhang: i16,
+    /// Edge property (positional name): jitter.
+    pub edge_jitter: i16,
+    /// Edge property (positional name): silhouette colour.
+    pub edge_silhouette_color: VisualStyleColor,
+    /// Edge property (positional name): silhouette width.
+    pub edge_silhouette_width: i16,
+    /// Edge property (positional name): halo gap.
+    pub edge_halo_gap: i16,
+    /// Edge property (positional name): isoline count.
+    pub edge_isoline_count: i16,
+    /// The single `B`-typed property of the list.
+    pub edge_hide_precision: bool,
+    /// Edge property (positional name): style-apply bits.
+    pub edge_style_apply: i16,
+    /// Display property (positional name): brightness.
+    pub display_brightness: f64,
+    /// Display property (positional name): shadow type.
+    pub display_shadow_type: i16,
+    /// The `BS` flag of each property above, in wire order.
+    pub property_flags: Vec<i16>,
+    /// R2013+ tail: 30 further `(value, flag)` pairs. Their widths are
+    /// measured — the record does not close on its string stream
+    /// without them — but their names are not determined, so they are
+    /// surfaced positionally rather than mislabelled.
+    pub extended: Vec<VisualStyleProperty>,
+    /// String-stream entries the field list does not place. Every
+    /// corpus record carries exactly one (`strokes_ogs.tif`); which
+    /// property slot owns it is not determined, because a `TV` costs no
+    /// data-stream bits and so leaves no measurable trace.
+    pub trailing_strings: Vec<String>,
+}
+
+/// Reads the `(value, flag)` pairs of one record, collecting the flags.
+struct PropertyReader<'a, 'b> {
+    cursor: &'b mut BitCursor<'a>,
+    flags: Vec<i16>,
+}
+
+impl PropertyReader<'_, '_> {
+    fn flag(&mut self) -> Result<i16> {
+        let flag = self.cursor.read_bs()?;
+        self.flags.push(flag);
+        Ok(flag)
+    }
+
+    fn short(&mut self) -> Result<i16> {
+        let v = self.cursor.read_bs()?;
+        self.flag()?;
+        Ok(v)
+    }
+
+    fn double(&mut self) -> Result<f64> {
+        let v = self.cursor.read_bd()?;
+        self.flag()?;
+        Ok(v)
+    }
+
+    fn boolean(&mut self) -> Result<bool> {
+        let v = self.cursor.read_b()?;
+        self.flag()?;
+        Ok(v)
+    }
+
+    fn color(&mut self) -> Result<VisualStyleColor> {
+        let (index, rgb, color_byte) = crate::tables::modern::read_cmc_full(self.cursor)?;
+        self.flag()?;
+        Ok(VisualStyleColor {
+            index,
+            rgb,
+            color_byte,
+        })
+    }
+
+    fn property(&mut self, kind: TailKind) -> Result<VisualStyleProperty> {
+        let value = match kind {
+            TailKind::Short => VisualStyleValue::Short(self.cursor.read_bs()?),
+            TailKind::Double => VisualStyleValue::Double(self.cursor.read_bd()?),
+            TailKind::Bool => VisualStyleValue::Bool(self.cursor.read_b()?),
+            TailKind::Color => {
+                let (index, rgb, color_byte) = crate::tables::modern::read_cmc_full(self.cursor)?;
+                VisualStyleValue::Color(VisualStyleColor {
+                    index,
+                    rgb,
+                    color_byte,
+                })
+            }
+        };
+        let flag = self.flag()?;
+        Ok(VisualStyleProperty { value, flag })
+    }
+}
+
+/// Token type of one R2013+ tail property.
+#[derive(Debug, Clone, Copy)]
+enum TailKind {
+    Short,
+    Double,
+    Bool,
+    Color,
+}
+
+/// The 30 R2013+ tail property widths, measured on `arc_2013.dwg` and
+/// `sample_AC1032.dwg`. This is the only token sequence over
+/// `BS`/`BD`/`B`/`CMC` that lands all 24 records of either file exactly
+/// on their string-stream start.
+const R2013_TAIL: [TailKind; 30] = [
+    TailKind::Bool,
+    TailKind::Bool,
+    TailKind::Bool,
+    TailKind::Bool,
+    TailKind::Bool,
+    TailKind::Bool,
+    TailKind::Bool,
+    TailKind::Bool,
+    TailKind::Bool,
+    TailKind::Short,
+    TailKind::Short,
+    TailKind::Double,
+    TailKind::Short,
+    TailKind::Color,
+    TailKind::Short,
+    TailKind::Short,
+    TailKind::Color,
+    TailKind::Bool,
+    TailKind::Short,
+    TailKind::Short,
+    TailKind::Short,
+    TailKind::Bool,
+    TailKind::Short,
+    TailKind::Color,
+    TailKind::Bool,
+    TailKind::Bool,
+    TailKind::Short,
+    TailKind::Bool,
+    TailKind::Double,
+    TailKind::Double,
+];
+
+/// Decode an ACAD_VISUALSTYLE straight from its raw object payload,
+/// taking its `TV` fields from the R2007+ string stream and checking
+/// that the data fields end exactly on the data-stream boundary.
+///
+/// Returns [`Error::Unsupported`] for R2007 and earlier, whose layout
+/// this crate has not matched against real bytes.
+pub fn decode_object(
+    payload: &[u8],
+    body_start: usize,
+    inline_data_end: Option<usize>,
+    version: Version,
+) -> Result<AcadVisualStyle> {
+    if !version.is_r2010_plus() {
         return Err(Error::Unsupported {
             feature: format!(
-                "ACAD_VISUALSTYLE requires R2007 or newer; got {}",
+                "ACAD_VISUALSTYLE layout is only determined for R2010 or newer; got {}",
                 version.release()
             ),
         });
     }
-    let description = read_tv(c, version)?;
-    let face_lighting_model = c.read_bs()?;
-    let face_lighting_quality = c.read_bs()?;
-    let face_color_mode = c.read_bs()?;
-    let face_opacity = c.read_bd()?;
-    let face_specular = c.read_bd()?;
-    let face_mono_color = c.read_bs()?;
-    let face_modifier = c.read_rc()?;
-    let edge_model = c.read_bs()?;
-    let edge_style_apply_flags = c.read_bl()?;
-    let edge_intersection_color = c.read_bs()?;
-    let edge_obscured_color = c.read_bs()?;
-    let edge_color = c.read_bs()?;
-    let edge_silhouette_color = c.read_bs()?;
+    let mut split = modern::open(payload, body_start, inline_data_end, version)?;
+    let description = modern::read_tv(&mut split.data, &mut split.strings, version)?;
+    let internal_style_type = split.data.read_bs()?;
+    let format_version = split.data.read_bs()?;
+    let is_internal_use_only = split.data.read_b()?;
+
+    let mut reader = PropertyReader {
+        cursor: &mut split.data,
+        flags: Vec::with_capacity(58),
+    };
+    let face_lighting_model = reader.short()?;
+    let face_lighting_quality = reader.short()?;
+    let face_color_mode = reader.short()?;
+    let face_modifier = reader.short()?;
+    let face_opacity = reader.double()?;
+    let face_specular = reader.double()?;
+    let face_mono_color = reader.color()?;
+    let edge_model = reader.short()?;
+    let edge_style = reader.short()?;
+    let edge_intersection_color = reader.color()?;
+    let edge_obscured_color = reader.color()?;
+    let edge_obscured_linetype = reader.short()?;
+    let edge_intersection_linetype = reader.short()?;
+    let edge_crease_angle = reader.double()?;
+    let edge_modifier = reader.short()?;
+    let edge_color = reader.color()?;
+    let edge_opacity = reader.double()?;
+    let edge_width = reader.short()?;
+    let edge_overhang = reader.short()?;
+    let edge_jitter = reader.short()?;
+    let edge_silhouette_color = reader.color()?;
+    let edge_silhouette_width = reader.short()?;
+    let edge_halo_gap = reader.short()?;
+    let edge_isoline_count = reader.short()?;
+    let edge_hide_precision = reader.boolean()?;
+    let edge_style_apply = reader.short()?;
+    let display_brightness = reader.double()?;
+    let display_shadow_type = reader.short()?;
+
+    let mut extended = Vec::new();
+    if matches!(version, Version::R2013 | Version::R2018) {
+        extended.reserve(R2013_TAIL.len());
+        for kind in R2013_TAIL {
+            extended.push(reader.property(kind)?);
+        }
+    }
+    let property_flags = reader.flags;
+
+    split.finish("VISUALSTYLE")?;
+
+    let mut trailing_strings = Vec::new();
+    if let Some(strings) = split.strings.as_mut() {
+        while !strings.is_exhausted() {
+            match strings.read_tv() {
+                Ok(text) => trailing_strings.push(text),
+                Err(_) => break,
+            }
+        }
+    }
+
     Ok(AcadVisualStyle {
         description,
+        internal_style_type,
+        format_version,
+        is_internal_use_only,
         face_lighting_model,
         face_lighting_quality,
         face_color_mode,
+        face_modifier,
         face_opacity,
         face_specular,
         face_mono_color,
-        face_modifier,
         edge_model,
-        edge_style_apply_flags,
+        edge_style,
         edge_intersection_color,
         edge_obscured_color,
+        edge_obscured_linetype,
+        edge_intersection_linetype,
+        edge_crease_angle,
+        edge_modifier,
         edge_color,
+        edge_opacity,
+        edge_width,
+        edge_overhang,
+        edge_jitter,
         edge_silhouette_color,
+        edge_silhouette_width,
+        edge_halo_gap,
+        edge_isoline_count,
+        edge_hide_precision,
+        edge_style_apply,
+        display_brightness,
+        display_shadow_type,
+        property_flags,
+        extended,
+        trailing_strings,
     })
 }
 
@@ -114,51 +475,171 @@ mod tests {
     use super::*;
     use crate::bitwriter::BitWriter;
 
-    fn encode_tv_utf16(w: &mut BitWriter, s: &str) {
-        let units: Vec<u16> = s.encode_utf16().collect();
-        w.write_bs_u(units.len() as u16);
-        for u in units {
-            w.write_rc((u & 0xFF) as u8);
-            w.write_rc((u >> 8) as u8);
+    /// Write one `(value, flag)` pair's flag.
+    fn flag(w: &mut BitWriter, v: i16) {
+        w.write_bs(v);
+    }
+
+    fn cmc(w: &mut BitWriter, index: u16, rgb: u32, color_byte: u8) {
+        w.write_bs_u(index);
+        w.write_bl_u(rgb);
+        w.write_rc(color_byte);
+    }
+
+    /// Build the 28-property R2010 body every release shares.
+    fn write_common_properties(w: &mut BitWriter) {
+        w.write_bs(2); // face_lighting_model
+        flag(w, 1);
+        w.write_bs(1); // face_lighting_quality
+        flag(w, 1);
+        w.write_bs(1); // face_color_mode
+        flag(w, 1);
+        w.write_bs(2); // face_modifier
+        flag(w, 1);
+        w.write_bd(0.6); // face_opacity
+        flag(w, 1);
+        w.write_bd(30.0); // face_specular
+        flag(w, 1);
+        cmc(w, 0, 0xC2FF_FFFF, 0); // face_mono_color
+        flag(w, 1);
+        w.write_bs(0); // edge_model
+        flag(w, 1);
+        w.write_bs(0); // edge_style
+        flag(w, 1);
+        cmc(w, 0, 0xC300_0007, 0); // edge_intersection_color
+        flag(w, 1);
+        cmc(w, 0, 0xC800_0000, 0); // edge_obscured_color
+        flag(w, 1);
+        w.write_bs(1); // edge_obscured_linetype
+        flag(w, 1);
+        w.write_bs(1); // edge_intersection_linetype
+        flag(w, 1);
+        w.write_bd(1.0); // edge_crease_angle
+        flag(w, 1);
+        w.write_bs(8); // edge_modifier
+        flag(w, 1);
+        cmc(w, 0, 0xC300_0007, 0); // edge_color
+        flag(w, 1);
+        w.write_bd(1.0); // edge_opacity
+        flag(w, 1);
+        w.write_bs(1); // edge_width
+        flag(w, 1);
+        w.write_bs(6); // edge_overhang
+        flag(w, 1);
+        w.write_bs(2); // edge_jitter
+        flag(w, 1);
+        cmc(w, 0, 0xC300_0007, 0); // edge_silhouette_color
+        flag(w, 1);
+        w.write_bs(5); // edge_silhouette_width
+        flag(w, 1);
+        w.write_bs(0); // edge_halo_gap
+        flag(w, 1);
+        w.write_bs(0); // edge_isoline_count
+        flag(w, 1);
+        w.write_b(false); // edge_hide_precision
+        flag(w, 1);
+        w.write_bs(13); // edge_style_apply
+        flag(w, 1);
+        w.write_bd(0.0); // display_brightness
+        flag(w, 1);
+        w.write_bs(0); // display_shadow_type
+        flag(w, 1);
+    }
+
+    fn write_r2013_tail(w: &mut BitWriter) {
+        for kind in R2013_TAIL {
+            match kind {
+                TailKind::Short => w.write_bs(50),
+                TailKind::Double => w.write_bd(1.0),
+                TailKind::Bool => w.write_b(true),
+                TailKind::Color => cmc(w, 0, 0xC200_0000, 0),
+            }
+            flag(w, 1);
         }
     }
 
+    /// The common object data an R2010 non-entity object leads with:
+    /// empty EED chain, `BL` reactor count, no xdictionary. R2010
+    /// predates the R2013+ AcDs binary-data bit.
+    fn r2010_object_prefix(num_reactors: i32) -> BitWriter {
+        let mut w = BitWriter::new();
+        w.write_bs_u(0);
+        w.write_bl(num_reactors);
+        w.write_b(true);
+        w
+    }
+
+    fn build(version: Version) -> Vec<u8> {
+        let mut body = if matches!(version, Version::R2013 | Version::R2018) {
+            modern::tests::r2018_object_prefix(1)
+        } else {
+            r2010_object_prefix(1)
+        };
+        body.write_bs(0); // internal_style_type
+        body.write_bs(2); // format_version
+        body.write_b(true); // is_internal_use_only
+        write_common_properties(&mut body);
+        if matches!(version, Version::R2013 | Version::R2018) {
+            write_r2013_tail(&mut body);
+        }
+        let bits = crate::string_stream::tests::bits_of(&body);
+        crate::string_stream::tests::build_payload(&bits, &["Flat", "strokes_ogs.tif"])
+    }
+
     #[test]
-    fn rejects_pre_r2007() {
-        let bytes = [0u8; 32];
-        let mut c = BitCursor::new(&bytes);
-        let err = decode(&mut c, Version::R2000).unwrap_err();
+    fn rejects_pre_r2010() {
+        let payload = build(Version::R2018);
+        let err = decode_object(&payload, 8, None, Version::R2004).unwrap_err();
         assert!(
             matches!(&err, Error::Unsupported { feature } if feature.contains("ACAD_VISUALSTYLE"))
         );
     }
 
     #[test]
-    fn roundtrip_shaded_visual_style_r2013() {
-        let mut w = BitWriter::new();
-        encode_tv_utf16(&mut w, "Shaded with edges");
-        w.write_bs(1); // face_lighting_model (1 = Phong)
-        w.write_bs(1); // face_lighting_quality (1 = Smooth)
-        w.write_bs(2); // face_color_mode (2 = Desaturate)
-        w.write_bd(1.0); // face_opacity
-        w.write_bd(0.5); // face_specular
-        w.write_bs(7); // face_mono_color (ACI white)
-        w.write_rc(0); // face_modifier
-        w.write_bs(1); // edge_model (1 = isolines)
-        w.write_bl(0x00FF); // edge_style_apply_flags
-        w.write_bs(7); // edge_intersection_color
-        w.write_bs(8); // edge_obscured_color
-        w.write_bs(256); // edge_color (ByLayer sentinel)
-        w.write_bs(3); // edge_silhouette_color
-        let bytes = w.into_bytes();
-        let mut c = BitCursor::new(&bytes);
-        let v = decode(&mut c, Version::R2013).unwrap();
-        assert_eq!(v.description, "Shaded with edges");
-        assert_eq!(v.face_lighting_model, 1);
-        assert_eq!(v.face_color_mode, 2);
-        assert!((v.face_opacity - 1.0).abs() < 1e-12);
-        assert!((v.face_specular - 0.5).abs() < 1e-12);
-        assert_eq!(v.edge_style_apply_flags, 0x00FF);
-        assert_eq!(v.edge_silhouette_color, 3);
+    fn r2018_split_stream_visual_style_closes_on_its_string_stream() {
+        let payload = build(Version::R2018);
+        let style = decode_object(&payload, 8, None, Version::R2018).unwrap();
+        assert_eq!(style.description, "Flat");
+        assert_eq!(style.internal_style_type, 0);
+        assert_eq!(style.format_version, 2);
+        assert!(style.is_internal_use_only);
+        assert_eq!(style.face_lighting_model, 2);
+        assert!((style.face_opacity - 0.6).abs() < 1e-12);
+        assert!((style.face_specular - 30.0).abs() < 1e-12);
+        assert_eq!(style.face_mono_color.method(), 0xC2);
+        assert_eq!(style.face_mono_color.payload(), 0x00FF_FFFF);
+        assert_eq!(style.edge_intersection_color.method(), 0xC3);
+        assert_eq!(style.edge_intersection_color.payload(), 7);
+        assert!(!style.edge_hide_precision);
+        assert_eq!(style.display_shadow_type, 0);
+        assert_eq!(style.property_flags.len(), 58);
+        assert_eq!(style.extended.len(), 30);
+        assert_eq!(style.trailing_strings, vec!["strokes_ogs.tif".to_string()]);
+    }
+
+    #[test]
+    fn r2010_visual_style_has_no_r2013_tail() {
+        let payload = build(Version::R2010);
+        let style = decode_object(&payload, 8, None, Version::R2010).unwrap();
+        assert_eq!(style.description, "Flat");
+        assert_eq!(style.property_flags.len(), 28);
+        assert!(style.extended.is_empty());
+    }
+
+    /// The R2013 tail is not optional: reading an R2013 record with the
+    /// R2010 field list leaves 30 properties unread, and the boundary
+    /// check has to reject that rather than return a plausible struct.
+    #[test]
+    fn r2013_body_rejected_by_the_r2010_field_list() {
+        let payload = build(Version::R2018);
+        assert!(decode_object(&payload, 8, None, Version::R2010).is_err());
+    }
+
+    /// …and the converse: an R2010-length body must not satisfy the
+    /// R2013 field list.
+    #[test]
+    fn r2010_body_rejected_by_the_r2013_field_list() {
+        let payload = build(Version::R2010);
+        assert!(decode_object(&payload, 8, None, Version::R2018).is_err());
     }
 }

--- a/src/objects/mod.rs
+++ b/src/objects/mod.rs
@@ -14,12 +14,12 @@
 //! |--------------------------|---------------------------|------------------|
 //! | ACAD_GROUP               | [`acad_group`]            | §19.6.7 (L6-11)  |
 //! | ACAD_LAYOUT              | [`acad_layout`]           | §19.6.12 (L6-12) |
-//! | ACAD_MATERIAL            | [`acad_material`]         | §19.6.9 (L6-16)  |
+//! | ACAD_MATERIAL            | [`acad_material`]         | none — measured  |
 //! | ACAD_MLINESTYLE          | [`acad_mlinestyle`]       | §19.6.4 (L6-13)  |
 //! | ACAD_PLOTSETTINGS        | [`acad_plot_settings`]    | §19.6.6 (L6-14)  |
 //! | ACAD_PROPERTYSET_DATA    | [`acad_property_set_data`]| §19.6.11 (L7-07) |
 //! | ACAD_SCALE               | [`acad_scale`]            | §19.6.8 (L6-15)  |
-//! | ACAD_VISUALSTYLE         | [`acad_visual_style`]     | §19.6.10 (L6-17) |
+//! | ACAD_VISUALSTYLE         | [`acad_visual_style`]     | none — measured  |
 //! | class-map extension      | [`class_map_extension`]   | §5.7 (L7-03)     |
 //! | *_CONTROL                | [`control`]               | §19.5.1..§19.5.10|
 //! | custom-dict entries      | [`custom_dict_entry`]     | §19.5.19 (L7-06) |
@@ -34,13 +34,14 @@
 //! # Reachability and the R2007+ split stream
 //!
 //! The decoders the dispatcher routes to — DICTIONARY, DICTIONARYVAR,
-//! XRECORD, ACDB_PLACEHOLDER, the `*_CONTROL` family, ACAD_GROUP and
-//! ACAD_SCALE — all go through the crate-private `objects::modern`, so
+//! XRECORD, ACDB_PLACEHOLDER, the `*_CONTROL` family, ACAD_GROUP,
+//! ACAD_SCALE and ACAD_VISUALSTYLE — all go through the crate-private
+//! `objects::modern`, so
 //! their `TV` fields come
 //! from the object's string stream on R2007+ and each one checks that
 //! its data fields end exactly on the data-stream boundary.
 //!
-//! The remaining modules ([`acad_material`], [`acad_visual_style`],
+//! The remaining modules ([`acad_material`],
 //! [`acad_property_set_data`], [`acad_layout`], [`acad_plot_settings`],
 //! [`acad_mlinestyle`]) decode a documented *prefix* of their record's
 //! fields, or a field list this crate has not yet matched against real
@@ -48,6 +49,13 @@
 //! deliberately not dispatched — a partial decoder that cannot
 //! self-validate would inflate the coverage ratio without proving
 //! anything. They remain callable directly.
+//!
+//! Two of the table's "Spec" cells read *none — measured*: the ODA
+//! v5.4.1 object-prescription chapter §20.4 stops at XRECORD and
+//! carries no entry for VISUALSTYLE or MATERIAL. Both modules document
+//! what their own byte measurements establish, and
+//! [`acad_material`] restricts itself to the strings and the budget
+//! precisely because its data-field layout is not among them.
 
 pub mod acad_group;
 pub mod acad_layout;

--- a/src/objects/modern.rs
+++ b/src/objects/modern.rs
@@ -120,6 +120,15 @@ pub(crate) fn read_tv(
 }
 
 impl ObjectStream<'_> {
+    /// The bit at which the data fields must end, when it is knowable.
+    ///
+    /// Decoders that close their field list use
+    /// [`finish`](Self::finish); this is for the ones that only measure
+    /// the budget a future field list will have to fill.
+    pub(crate) fn data_end(&self) -> Option<usize> {
+        self.data_end
+    }
+
     /// Verify the data cursor consumed exactly the data stream, no more
     /// and no less. `what` names the record for the error message.
     ///


### PR DESCRIPTION
## Summary

`VISUALSTYLE` was the largest single undispatched class on the corpus (240 records) and `MATERIAL` the third (30). Both had "partial prefix" decoders that could not satisfy the `objects::modern::ObjectStream::finish` boundary check, so both stayed `Unhandled`.

**The first thing this PR establishes is that the ODA spec does not describe either object.** §20.4 — the object-prescription chapter — runs from `20.4.1 Common Entity Data` to `20.4.104 XRECORD` and stops. `VISUALSTYLE` and `MATERIAL` appear only in §20.3's list of non-fixed class names. The two modules cited `§19.6.10 (L6-17)` and `§19.6.9 (L6-16)`; **no such sections exist**, and those citations are withdrawn.

So the field lists here were derived from bytes, against the one thing the format itself guarantees: a record's data fields must end **exactly** on the first bit of its string stream.

### VISUALSTYLE — decoded and dispatched on R2010, R2013 and R2018

Search for a token sequence over `B / BS / BL / BD / CMC` that lands **all 24** VISUALSTYLE records of a file on that bit, requiring every `BD` to be a plausible double, every `CMC` true-colour word to carry a real colour-method octet (`0xC0`…`0xC8`), and every alternating slot to be a `BS` flag in `0..=7`:

- `arc_2010.dwg` → **exactly one** answer: fixed head (`TV` description, `BS` internal style type, `BS` 2, `B` internal-use flag) then **28 `(value, flag)` pairs**;
- `arc_2013.dwg` → **exactly one** answer: the same 28 pairs plus **30 more**;
- that R2013 sequence also closes on all 24 records of `sample_AC1032.dwg` with zero delta.

The `(value, flag)` pairing is what explains the corpus's bit budgets. A flag of `1` costs 10 bits (`BS` byte form) and a flag of `0` costs 2, so the records of one file differ only in multiples of 8 — `arc_2010.dwg` measures 574 / 774 / 782 / 790 / 798 / 806 / 854 / 862 bits — and the three internal styles that carry `0` in *every* flag (`JitterOff`, `OverhangOff`, `EdgeColorOff`) are exactly the 574-bit ones.

Corroboration from the decoded values, none of which is used by the search:

| Check | Result |
|---|---|
| `is_internal_use_only` (the lone `B` of the head) | `false` on exactly ten records — `2dWireframe`, `Wireframe`, `Hidden`, `Conceptual`, `Realistic`, `Shades of Gray`, `Sketchy`, `X-Ray`, `Shaded with edges`, `Shaded` — which is precisely the set AutoCAD's Visual Styles Manager lists; `true` on the fourteen it hides |
| `face_opacity` | `0.6` on every style but `X-Ray`, which is `0.5` |
| `face_mono_color` | `0xC2FFFFFF` everywhere but `ColorChange`, which is `0xC2808080` |
| `edge_crease_angle` | `179` on `Conceptual`, `40` on `Hidden` / `Sketchy` / `Shades of Gray`, `1` elsewhere |
| `internal_style_type` | dense `0..=27` in ship order (`Flat`=0 … `Shaded`=27) |
| `description` | real text on every record — `"Flat"`, `"Shaded with edges"`, `"Shades of Gray"`, … — from the string stream |

Descriptions and the per-record second string (`strokes_ogs.tif`) come from the R2007+ string stream; the previous decoder read `TV` from the data cursor, i.e. the wrong stream, on every R2007+ file.

**R2004 / R2007 decline rather than guess.** Those records store the same styles without the per-property flags and with a different property count (measured: 492–580 data bits vs R2010's 574–862), and no sequence over the same token set lands their 24 records on the `RL` object-data-size boundary. `decode_object` returns `Error::Unsupported` there. The dispatcher now maps an `Unsupported` from an object-class decoder to `Unhandled` rather than `Error` — "this release's layout is not determined" is not a broken record.

### MATERIAL — field list withdrawn, strings and budget kept

The previous prefix (`BL ambient_color_method, BS ambient_color, BD ambient_color_factor, …`) was wrong from its first field. On `arc_2004.dwg` handle 17 — the `ByLayer` material, whose two `TV`s occupy body bits 0..76 — it decodes `ambient_color_method = 542113793` and `ambient_color = 17728`, then eight consecutive `BD = 1.0`.

`objects::acad_material::read_strings` now returns only what the bytes prove:

| File | Records | Data-field budget | Strings |
|---|---|---|---|
| `arc_2004.dwg` | `ByLayer` / `ByBlock` / `Global` | 1264 bits after the two inline `TV`s, identical in all three | 2, inline |
| `arc_2010.dwg` | same three | 1284 bits, bit-identical in all three | 2 |
| `arc_2013.dwg` | same three | 1284 bits, bit-identical to R2010 | 2 |
| `sample_AC1032.dwg` | same three | 516 / 516 / 1028 bits | 7 |

Documented but **not** implemented, per the honesty rule: twelve `BD` slots decode to exactly `1/48` (`0.0208333…`) at data-stream bits 46, 120, 250, 324, 510, 584, 706, 780, 900, 974, 1096, 1170 — six pairs, one per texture map, 74 bits apart; the R2018 `Global` record shows four such pairs each bracketed by `CMC` words `0xC1000000` / `0xC2040300`; and its seven string-stream entries (name + six empties) corroborate six map slots. The gaps between pairs are 204 / 260 / 196 / 194 / 196 bits, so no single repeating block layout is pinned. **MATERIAL therefore stays undispatched and its 30 records stay `Unhandled`.**

## Measured coverage

`cargo run --release --example coverage_report -- <19-file samples dir>`, before = `0914187` (post-#41):

| Corpus slice | Before | After |
|---|---|---|
| R2004 (AC1018) × 3 | 489 / 108 / 0 / 81.9 % | 489 / 108 / 0 / 81.9 % |
| R2010 (AC1024) × 3 | 438 / 105 / 0 / 80.7 % | **510 / 33 / 0 / 93.9 %** |
| R2013 (AC1027) × 3 | 291 / 105 / 0 / 73.5 % | **363 / 33 / 0 / 91.7 %** |
| R2018 (AC1032) × 1 | 533 / 166 / 46 / 71.5 % | **557 / 142 / 46 / 74.8 %** |
| **Aggregate** | **1751 / 484 / 46 / 76.8 %** | **1919 / 316 / 46 / 84.1 %** |

168 of the 240 VISUALSTYLE records now decode; the 72 on the three R2004 files are the remainder. Error count is unchanged at 46.

Top remaining unhandled classes after this PR: VISUALSTYLE-on-R2004 (72), LAYOUT (31), MATERIAL (30), ACDBDETAILVIEWSTYLE (11), ACDBSECTIONVIEWSTYLE (11), MLEADERSTYLE (11), MLINESTYLE (10), TABLESTYLE (10).

## Tests

Five BitWriter-built unit tests in `objects::acad_visual_style`, two in `objects::acad_material`:

- an R2018 record with both strings and the 30-property tail closes on its string stream and decodes its description, colours and flags;
- an R2010 record has no tail and 28 flags;
- an R2013-length body fed to the R2010 field list is **rejected**, and an R2010-length body fed to the R2013 field list is **rejected** — the tail is not optional in either direction;
- pre-R2010 returns `Unsupported`;
- MATERIAL reads its names from the string stream on R2018 (five extra empty map slots) and from the data cursor on R2004, with the budget matching in both.

Full suite: 696 lib + 100 integration, all green.

## New tooling

`examples/probe_field_list.rs` — measures one candidate field list against one real record and prints each field's offset, width and value plus the delta from the boundary. `delta 0` is the only result that means the list is right.

```sh
cargo run --release --example probe_field_list -- samples/arc_2010.dwg 42 BS,BS,B,BS,BS,BD,BD
```

`examples/dump_decoded_entities.rs` gained a VISUALSTYLE arm.

## Spec sections

- ODA v5.4.1 §20.3 — non-fixed object type table (the only place VISUALSTYLE and MATERIAL appear).
- ODA v5.4.1 §20.4 — object prescriptions; **verified to contain no entry for either object**.
- ODA v5.4.1 §19.1 / §19.4.2 — object prologue, string stream, common object data (the boundary this PR relies on).
- ODA v5.4.1 §2.11 — the `CMC` colour form, as already read by `tables::modern::read_cmc_full` for VIEW / VPORT.

## Source provenance

**Clean-room declaration.** I certify that:

1. All code and tests in this PR were written from scratch by me.
2. I consulted only sources listed as allowed in `CLEANROOM.md`. In particular I did not consult Autodesk SDK source, ODA SDK (Drawings SDK / Teigha) source, LibreDWG source, decompilations of Autodesk or ODA binaries, or any copyleft-licensed DWG implementation code.
3. Citations are in the diff as module comments and in `ARCHITECTURE.md` §7d.1.
4. I have never had access to any forbidden source in a commercial or NDA'd context.

Two disclosures beyond the boilerplate, both about *naming* rather than layout:

- Every field **type, width and order** in this PR came from first-party byte measurement of the publicly-redistributable `nextgis/dwg_samples` files, using the boundary check as the arbiter. No external implementation was read.
- The **names** attached to the VISUALSTYLE property slots follow the conventional `AcDbVisualStyle` property ordering as published in Autodesk's public DXF Reference (official public documentation, not SDK source, and not a leaked or unofficial document). This was recall, not a consulted file, and it was used only to label slots whose layout the bytes had already fixed. The module doc says so explicitly: the face-group names are independently corroborated by the decoded values, the edge and display group names are positional and are **not** corroborated by this crate. If a reviewer would rather those slots stayed unnamed, say so and I will demote them to a positional `Vec` like the R2013 tail already is.

## Not closing #38

`Closes #38` is deliberately omitted. The issue covers VISUALSTYLE, MATERIAL and PROPERTYSET_DATA; only VISUALSTYLE fully decodes, and only on R2010+. Remaining: VISUALSTYLE on R2004/R2007 (72 records), MATERIAL's per-map block layout (30 records), PROPERTYSET_DATA (0 records on this corpus).

https://claude.ai/code/session_01BaHKf1Rw5aJBGK5y3xmx7C

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new binary decoder and dispatcher behavior change (`Unsupported` → `Unhandled`); `AcadMaterial` API shrinks and no longer pretends to decode data fields.
> 
> **Overview**
> Adds a **boundary-validated** `ACAD_VISUALSTYLE` decoder for R2010, R2013, and R2018: field order was derived by searching token sequences that land every record on the string-stream start bit (28 `(value, flag)` pairs on R2010, plus 30 more on R2013+). Records wire through `objects::modern`, expose a new `DecodedEntity::VisualStyle`, and route from custom-class dispatch for `VISUALSTYLE` / `ACDBVISUALSTYLE`. R2004/R2007 return `Error::Unsupported`; the dispatcher now maps that to **`Unhandled`** instead of **`Error`** so undetermined layouts are not counted as broken records.
> 
> **ACAD_MATERIAL** drops the incorrect prefix decoder and only exposes **`read_strings`** (name, description, extra string-stream slots, measured `data_field_bits`). MATERIAL stays **undispatched**; corpus coverage rises mainly from VISUALSTYLE (aggregate **76.8% → 84.1%** on the 19-file set).
> 
> New **`examples/probe_field_list.rs`** probes candidate field lists against one object handle; **`dump_decoded_entities`** prints VISUALSTYLE fields. Docs (`ARCHITECTURE.md` §7d.1, changelog, README/STATUS) and withdrawn bogus ODA §19.6 citations for VISUALSTYLE/MATERIAL are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c50fab6a7b96779a8868139f2aaccde0cfec4b22. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->