### PR TITLE
fix(handle-map): the handle delta is an unsigned MC and both accumulators restart per handle section

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -214,15 +214,33 @@ pairs:
 
 ```
  AcDb:Handles section bytes:
-   [count][handle₁][offset₁][handle₂ delta][offset₂ delta]...
-            └─────────┐                 ┌────┘
-                      ▼                 ▼
-                 handle values     signed MC deltas from previous
+   [BE u16 size][pairs ...][CRC]  [BE u16 size][pairs ...][CRC]  [0x0000]
+   └──── handle section 1 ─────┘  └──── handle section 2 ─────┘  terminator
+        pair = (unsigned MC handle delta, signed MC offset delta)
 ```
 
 `HandleMap::parse` walks this index, applies the deltas to recover
 absolute handles and offsets, and returns a sorted list. The walker
 then seeks to each offset, reads the object's size + type code + body.
+
+Two encoding rules govern the pair run, both established by the
+`sample_AC1032.dwg` audit in #43/#44:
+
+- The **handle delta is an unsigned modular char**; only the **offset
+  delta is signed**. Handles grow monotonically inside a handle
+  section, so the encoder spends all seven low bits of the terminating
+  byte on magnitude; byte offsets genuinely move backward when deleted
+  objects' space is reused, so those keep the 0x40 negation bit.
+- **Both accumulators restart at zero on every handle section.** The
+  first pair of each section is absolute, not relative to the previous
+  section's last entry.
+
+The object stream checks the map against itself: every record repeats
+its own handle, so "does the record at the offset this map produced
+carry the handle this map produced?" is a free oracle.
+`ObjectWalkSummary::handle_mismatches` reports each disagreement, and
+`examples/probe_class_census.rs` cross-checks the walk against the
+`num_objects` instance counts in `AcDb:Classes`.
 
 For R2010+, a 2-bit "object type tag" preceeds the 16-bit type code
 to compress common type numbers into 1 byte — see `object_type.rs`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,76 @@ once the public API stabilizes at 0.1.0.
 
 ## [Unreleased]
 
+### Fixed — the `AcDb:Handles` delta run: unsigned handle deltas, per-section restart (2026-08-30, closes #43, closes #44, closes #51)
+
+- **The handle delta is an UNSIGNED modular char; only the offset delta
+  is signed.** Reading it as a signed MC steals bit `0x40` of the
+  terminating byte as a negation flag, so every single-byte delta in
+  `0x40..=0x7F` decoded as a small negative number and the multi-byte
+  form split its limbs one bit short. On `sample_AC1032.dwg` the first
+  divergence is handle-map entry 272, from which point every recovered
+  handle ran 108 low: the map claimed `0x438` at offset 148,422 where
+  the record at that offset carries `0x4A4`.
+- **Both accumulators restart at zero on every handle section.** The
+  first `(handle, offset)` pair of a section is absolute. Carrying the
+  running totals across the boundary threw the whole of this file's
+  second handle section — entries 656..841, 186 of 842 — into a
+  fabricated address space: entry 656 was read as handle `0x1343` at
+  offset 197,439 when the bytes say handle `0xB23` at offset 99,522,
+  and the drift produced the phantom offset 1,289,590 that #44 reported
+  as a 96,739-byte shortfall against the section.
+- **The section assembly was never wrong.** `AcDb:AcDbObjects` on that
+  file is 41 pages of exactly `0x7400` decompressed bytes each
+  (1,217,536 total) truncated to the declared 1,192,851; the trailing
+  24,685 bytes are the last page's zero padding, which is why its
+  compressed payload is only 3,317 bytes. After the fix the map's
+  highest offset is 1,192,823 — 28 bytes inside the section — and all
+  six previously out-of-range entries land in real records.
+- **Verified against the file itself.** Every record repeats its own
+  handle, so the object stream is a self-checking oracle for the map.
+  Agreement on `sample_AC1032.dwg` goes from 272 / 842 to **842 / 842**,
+  walker skips from 97 to 0, and the 842 walked records cover 1,191,935
+  of the section's 1,192,851 bytes with 916 unclaimed (longest run: 4
+  bytes) — so no unreferenced records are hiding outside the map.
+  `ObjectWalkSummary::handle_mismatches` now reports the check on every
+  walk, and `DwgFile::all_objects_lossy` exposes it.
+- **`BitCursor::read_handle` rejects a counter above 8** (#51) with the
+  new `Error::HandleCounterTooLarge`. The nibble can hold 0..=15 but a
+  handle value is at most a `u64`, so a wider counter proves the cursor
+  is not on a handle field — it previously shifted the excess out and
+  produced a plausible handle from garbage. On the pre-fix address
+  space this gate alone caught 43 phantom records on
+  `sample_AC1032.dwg`. It surfaces as a walker skip, never as a decoder
+  error, so coverage ratios stay comparable.
+- The three phantom `CUSTOM(727)` records (#44) are gone, along with
+  `CUSTOM(517)` at 212,392 and `CUSTOM(564)` at 229,599.
+- Class-table census on `sample_AC1032.dwg` (#43), declared
+  `num_objects` vs walked, before → after: MATERIAL 3 → 11 of 11,
+  MULTILEADER 10 → 15 of 15, ACAD_EVALUATION_GRAPH 1 → 3 of 3,
+  TABLECONTENT 1 → 2, TABLEGEOMETRY 1 → 2, and PDFDEFINITION,
+  PDFUNDERLAY, SPATIAL_FILTER, ACSH_BOX_CLASS, ACDBASSOCPERSSUBENTMANAGER,
+  ACDBPERSSUBENTMANAGER, ACSH_HISTORY_CLASS all 0 → their full declared
+  count. 41 of 43 classes now reach their declared instance count;
+  TABLECONTENT and TABLEGEOMETRY each declare 5 and reach 2, with no
+  unclaimed stream bytes to hold the difference.
+- **Coverage** (`examples/coverage_report.rs` over the local 19-file
+  corpus): R2018 `sample_AC1032.dwg` 561 / 145 / 39 / 75.3 % →
+  **712 / 91 / 39 / 84.6 %**; aggregate 1923 / 319 / 39 / 84.3 % →
+  **2074 / 265 / 39 / 87.2 %**. R2004 (81.9 %), R2010 (93.9 %) and
+  R2013 (91.7 %) are unchanged — those samples carry a single handle
+  section, so neither bug could fire.
+- Writer side moves with the reader: `write_handle_map` emits unsigned
+  handle deltas, restarts its baselines per section, and opens a new
+  section when a caller's handles move backward (which an unsigned
+  delta cannot encode).
+- New probes: `examples/probe_section_pages.rs` (per-page section
+  assembly audit — page-map row, data-page header, produced bytes,
+  cumulative offsets, handle-map address-space cross-check) and
+  `examples/probe_class_census.rs` (declared-vs-walked per class plus
+  object-stream byte coverage). `coverage_report` gains a `wskip`
+  column and a walker-diagnostic histogram kept separate from the
+  dispatch error counts.
+
 ### Fixed — the R2010+ entity graphics-preview block is sized by a `BLL` (2026-08-30, closes #42)
 
 - **The common entity preamble's graphics-preview size is an `RL` up to

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ local `samples/` set:
 | R2004 (AC1018)      | 3 | 489 | 108 | 0 | **81.9 %** |
 | R2010 (AC1024)      | 3 | 510 | 33 | 0 | **93.9 %** |
 | R2013 (AC1027)      | 3 | 363 | 33 | 0 | **91.7 %** |
-| R2018 (AC1032)      | 1 | 561 | 145 | 39 | **75.3 %** |
-| **Aggregate** | **19** | **1923** | **319** | **39** | **84.3 %** |
+| R2018 (AC1032)      | 1 | 712 | 91 | 39 | **84.6 %** |
+| **Aggregate** | **19** | **2074** | **265** | **39** | **87.2 %** |
 
 Per-entity-type error concentration in the measured corpus:
 
@@ -87,7 +87,7 @@ real-file decode gap is the 0.2.0 milestone.
 | HandleMap + ClassMap parsing | ✓ shipped | — |
 | Header variables | ✓ shipped | Strict + lossy variants |
 | Object-stream walker (R2004+) | ✓ shipped | R14 / R2000 / R2007 pending (#104) |
-| Per-entity field decoders | ⚠ alpha | Broad synthetic coverage; real-file aggregate currently ~84.3% (#103) |
+| Per-entity field decoders | ⚠ alpha | Broad synthetic coverage; real-file aggregate currently ~87.2% (#103) |
 | Entity graph (owner / reactors / blocks / layers) | ⚠ partial | Resolver APIs exist; trailing-handle/block traversal gaps remain |
 | Symbol tables (LAYER / LTYPE / STYLE / DIMSTYLE / …) | ⚠ partial | R2007+ BLOCK_HEADER and simple LTYPE names decode; broader content fields pending |
 | SVG / PDF export | ⚠ alpha | SVG writer + paged-SVG PDF path; output quality depends on decoded geometry |
@@ -271,8 +271,8 @@ $ cargo deny check                                                # no advisorie
 
 Tests exercise the container layer end-to-end across all 19 corpus files and verify
 bit-level round-trip properties for every primitive. They do **not** verify that every
-entity decoder succeeds on every real-world drawing — that's what the 84.3 %
-aggregate / 75.3 % AC1032 coverage numbers above measure. Both classes of
+entity decoder succeeds on every real-world drawing — that's what the 87.2 %
+aggregate / 84.6 % AC1032 coverage numbers above measure. Both classes of
 testing are needed.
 
 ## Safety

--- a/STATUS.md
+++ b/STATUS.md
@@ -6,18 +6,22 @@ scrolling the changelog.
 
 ## Summary
 
-- **Lib tests:** 691 passing in default/debug and release-all-features
+- **Lib tests:** 703 passing in default/debug and release-all-features
   profiles, clippy + fmt clean.
 - **WASM tests:** 40 passing in `wasm/` sub-crate.
 - **Integration tests:** DXF round-trip (7), glTF smoke (3), SVG
   goldens (3), fuzz-corpus regression (6), write-path (5),
   entity-regression (18), real-DWG value regression (8).
-- **Current real-file decode coverage:** 1,923 decoded / 319 skipped /
-  39 errored / 84.3% on the local 19-file `samples/` corpus. The
-  R2018 `sample_AC1032.dwg` sample is 561 / 145 / 39 / 75.3%, and it
+- **Current real-file decode coverage:** 2,074 decoded / 265 skipped /
+  39 errored / 87.2% on the local 19-file `samples/` corpus. The
+  R2018 `sample_AC1032.dwg` sample is 712 / 91 / 39 / 84.6%, and it
   is the only file with any errors — the R2004, R2010 and R2013
   samples all decode with zero. Per version: R2004 81.9%,
   R2010 93.9%, R2013 91.7%.
+- **Handle-map completeness:** every one of the 842 `AcDb:Handles`
+  entries on `sample_AC1032.dwg` resolves to a record whose own handle
+  field matches the map, and the walked records cover 1,191,935 of the
+  section's 1,192,851 bytes (916 unclaimed, longest run 4 bytes).
 - **Fuzz targets:** 9 (lz77 / bitcursor / dwg-file-open / section-map /
   object-walker / classmap / handlemap / header-vars / rs-fec).
   Seed corpus: 30 hand-crafted inputs across all targets.
@@ -201,8 +205,8 @@ scrolling the changelog.
 These have genuine open scope requiring focused work, not stubs.
 
 - **Current real-file decode baseline:** the 2026-08-30
-  `examples/coverage_report.rs ../../samples` run reports 1923 decoded,
-  319 skipped, 39 errored, 84.3% aggregate coverage. This is the
+  `examples/coverage_report.rs ../../samples` run reports 2074 decoded,
+  265 skipped, 39 errored, 87.2% aggregate coverage. This is the
   practical product-readiness blocker even though synthetic decoder
   tests are broad.
 

--- a/examples/coverage_report.rs
+++ b/examples/coverage_report.rs
@@ -47,12 +47,19 @@ fn main() -> ExitCode {
     let mut totals = DispatchSummary::default();
     let mut type_histo: BTreeMap<String, usize> = BTreeMap::new();
     let mut unhandled_histo: BTreeMap<String, usize> = BTreeMap::new();
+    // Walker diagnostics are tracked separately from dispatch counts:
+    // a handle-map entry the walker could not turn into a record never
+    // reaches a decoder, so folding it into `err` would make coverage
+    // ratios incomparable across releases.
+    let mut walk_skips: BTreeMap<String, usize> = BTreeMap::new();
+    let mut total_walk_skips = 0usize;
+    let mut total_handle_mismatches = 0usize;
 
     println!(
-        "{:<32} {:<12} {:>6} {:>6} {:>6} {:>7}",
-        "file", "version", "deco", "skip", "err", "ratio%"
+        "{:<32} {:<12} {:>6} {:>6} {:>6} {:>6} {:>7}",
+        "file", "version", "deco", "skip", "err", "wskip", "ratio%"
     );
-    println!("{}", "-".repeat(80));
+    println!("{}", "-".repeat(87));
 
     for path in &files {
         let filename = path
@@ -75,7 +82,7 @@ fn main() -> ExitCode {
             }
             None => {
                 println!(
-                    "{:<32} {:<12} n/a    n/a    n/a       (no-handle-map)",
+                    "{:<32} {:<12} n/a    n/a    n/a    n/a       (no-handle-map)",
                     filename,
                     format!("{version}")
                 );
@@ -83,13 +90,28 @@ fn main() -> ExitCode {
             }
         };
 
+        // Walker-level diagnostic pass: how many handle-map entries did
+        // not resolve to a record at all?
+        let file_walk_skips = match file.all_objects_lossy() {
+            Some(Ok((_, walk))) => {
+                for entry in &walk.skipped {
+                    *walk_skips.entry(classify_skip(&entry.reason)).or_default() += 1;
+                }
+                total_handle_mismatches += walk.handle_mismatches.len();
+                walk.skipped.len()
+            }
+            _ => 0,
+        };
+        total_walk_skips += file_walk_skips;
+
         println!(
-            "{:<32} {:<12} {:>6} {:>6} {:>6} {:>7.1}",
+            "{:<32} {:<12} {:>6} {:>6} {:>6} {:>6} {:>7.1}",
             filename,
             format!("{version}"),
             summary.decoded,
             summary.unhandled,
             summary.errored,
+            file_walk_skips,
             summary.decoded_ratio() * 100.0
         );
 
@@ -125,16 +147,32 @@ fn main() -> ExitCode {
         totals.errored += summary.errored;
     }
 
-    println!("{}", "-".repeat(80));
+    println!("{}", "-".repeat(87));
     println!(
-        "{:<32} {:<12} {:>6} {:>6} {:>6} {:>7.1}",
+        "{:<32} {:<12} {:>6} {:>6} {:>6} {:>6} {:>7.1}",
         "TOTAL",
         "",
         totals.decoded,
         totals.unhandled,
         totals.errored,
+        total_walk_skips,
         totals.decoded_ratio() * 100.0
     );
+    println!();
+    println!(
+        "Handle-map self-check: {total_handle_mismatches} record(s) carry a handle \
+         that disagrees with the map."
+    );
+    if walk_skips.is_empty() {
+        println!("Walker diagnostics: every handle-map entry resolved to a record.");
+    } else {
+        println!("Walker diagnostics (handle-map entries that yielded no record):");
+        let mut rows: Vec<(&String, &usize)> = walk_skips.iter().collect();
+        rows.sort_by_key(|(label, cnt)| (std::cmp::Reverse(**cnt), (*label).clone()));
+        for (label, cnt) in rows {
+            println!("  {label:<44} → {cnt}");
+        }
+    }
     println!();
     if !type_histo.is_empty() {
         println!("Error histogram by kind (top 10):");
@@ -155,4 +193,24 @@ fn main() -> ExitCode {
     }
 
     ExitCode::SUCCESS
+}
+
+/// Collapse a per-record skip reason into a stable bucket so the
+/// diagnostic histogram stays readable. Offsets and handle values are
+/// dropped; the failure mode is what matters.
+fn classify_skip(reason: &str) -> String {
+    if reason.contains("past end of object stream") {
+        "offset past end of object stream".to_string()
+    } else if reason.contains("handle counter") {
+        "handle counter above 8 (not a handle field)".to_string()
+    } else if reason.contains("returned None") {
+        "no record at offset (zero-length or truncated)".to_string()
+    } else {
+        reason
+            .split(':')
+            .next()
+            .unwrap_or(reason)
+            .trim()
+            .to_string()
+    }
 }

--- a/examples/probe_class_census.rs
+++ b/examples/probe_class_census.rs
@@ -1,0 +1,159 @@
+//! Declared-vs-walked object census per custom class.
+//!
+//! `AcDb:Classes` records a `num_objects` count for every custom class
+//! in the drawing (DXF group 91), which makes the class table a cheap
+//! oracle for handle-map / walker completeness: if the walk reaches
+//! fewer objects of a class than the file declares, the walker is
+//! missing records.
+//!
+//! ```bash
+//! cargo run --release --example probe_class_census -- file.dwg
+//! ```
+//!
+//! Exit code is non-zero when any class is under-walked, so the probe
+//! doubles as a regression gate.
+
+use dwg::error::Result;
+use dwg::{DwgFile, ObjectType};
+use std::collections::BTreeMap;
+use std::env;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let Some(path) = env::args().nth(1) else {
+        eprintln!("usage: probe_class_census <file.dwg>");
+        return ExitCode::FAILURE;
+    };
+    match run(&path) {
+        Ok(true) => ExitCode::SUCCESS,
+        Ok(false) => ExitCode::FAILURE,
+        Err(e) => {
+            eprintln!("probe failed: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run(path: &str) -> Result<bool> {
+    let file = DwgFile::open(path)?;
+    println!("file    : {path}");
+    println!("version : {}", file.version());
+
+    let Some(classes) = file.class_map().transpose()? else {
+        println!("no AcDb:Classes section — nothing to census");
+        return Ok(true);
+    };
+    let Some((objects, walk)) = file.all_objects_lossy().transpose()? else {
+        println!("no handle-map-driven walk available for this file");
+        return Ok(true);
+    };
+
+    let mut walked: BTreeMap<u16, usize> = BTreeMap::new();
+    // Some classes listed in AcDb:Classes were promoted to fixed object
+    // types in later releases (LAYOUT, ACDBPLACEHOLDER, ...). The file
+    // still registers the class and still counts its instances, but it
+    // writes those instances with the fixed type code, so crediting the
+    // custom class number alone under-counts them. Index the fixed-code
+    // records by normalized type name and credit both.
+    let mut walked_fixed: BTreeMap<String, usize> = BTreeMap::new();
+    for obj in &objects {
+        match obj.kind {
+            ObjectType::Custom(code) => *walked.entry(code).or_default() += 1,
+            kind => {
+                *walked_fixed
+                    .entry(normalize(&kind.to_string()))
+                    .or_default() += 1
+            }
+        }
+    }
+
+    println!("handle-map records walked : {}", objects.len());
+    println!("walker skips              : {}", walk.skipped.len());
+    println!(
+        "handle self-check misses  : {}",
+        walk.handle_mismatches.len()
+    );
+
+    // Byte-coverage of the object stream. If the class table declares
+    // instances the walk never reaches, the first question is whether
+    // unreferenced records are sitting in stream bytes no handle-map
+    // entry addresses; a near-total coverage figure with only
+    // inter-record padding left over answers "no".
+    if let Some(Ok(stream)) = file.read_section("AcDb:AcDbObjects") {
+        let mut spans: Vec<(usize, usize)> = objects
+            .iter()
+            .map(|o| {
+                // MS is 2 bytes per 15-bit module.
+                let ms_len = if o.size_bytes < 0x8000 { 2 } else { 4 };
+                (
+                    o.stream_offset,
+                    o.stream_offset + ms_len + o.size_bytes as usize + 2,
+                )
+            })
+            .collect();
+        spans.sort_unstable();
+        let covered: usize = spans.iter().map(|(s, e)| e - s).sum();
+        let mut unclaimed = 0usize;
+        let mut largest = 0usize;
+        let mut end = 0usize;
+        for (s, e) in &spans {
+            if *s > end {
+                unclaimed += s - end;
+                largest = largest.max(s - end);
+            }
+            end = end.max(*e);
+        }
+        unclaimed += stream.len().saturating_sub(end);
+        largest = largest.max(stream.len().saturating_sub(end));
+        println!(
+            "object stream coverage    : {covered} of {} bytes; {unclaimed} unclaimed \
+             (largest run {largest})",
+            stream.len()
+        );
+    }
+    println!();
+    println!(
+        "{:<38} {:>6} {:>9} {:>7} {:>7} {:>7}",
+        "class", "code", "declared", "walked", "fixed", "delta"
+    );
+    println!("{}", "-".repeat(80));
+
+    let mut complete = true;
+    for def in &classes.classes {
+        let declared = def.num_objects as usize;
+        let seen = walked.get(&def.class_number).copied().unwrap_or(0);
+        let fixed = walked_fixed
+            .get(&normalize(&def.dxf_class_name))
+            .copied()
+            .unwrap_or(0);
+        if declared == 0 && seen == 0 && fixed == 0 {
+            continue;
+        }
+        let delta = (seen + fixed) as i64 - declared as i64;
+        if delta < 0 {
+            complete = false;
+        }
+        println!(
+            "{:<38} {:>6} {:>9} {:>7} {:>7} {:>+7}",
+            def.dxf_class_name, def.class_number, declared, seen, fixed, delta
+        );
+    }
+
+    println!();
+    if complete {
+        println!("RESULT: every class reached its declared num_objects.");
+    } else {
+        println!("RESULT: at least one class is under-walked (negative delta above).");
+    }
+    Ok(complete)
+}
+
+/// Fold a class name and a built-in type name into a comparable key:
+/// the class table writes `ACDBPLACEHOLDER` where the built-in type
+/// table writes `ACDB_PLACEHOLDER`.
+fn normalize(name: &str) -> String {
+    name.chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .flat_map(|c| c.to_uppercase())
+        .collect()
+}

--- a/examples/probe_section_pages.rs
+++ b/examples/probe_section_pages.rs
@@ -1,0 +1,204 @@
+//! Per-page audit of an R2004-family section's page assembly.
+//!
+//! Prints, for one named section (default `AcDb:AcDbObjects`), the
+//! section description fields, then one row per page entry showing the
+//! section-info page reference, the matching global page-map row, the
+//! decrypted 0x20-byte data-page header (spec §4.6), the number of
+//! bytes LZ77 actually produced, and the running high-water mark of
+//! decompressed coverage.
+//!
+//! It also reads `AcDb:Handles` and reports the highest offset the
+//! handle map addresses, so a mismatch between "what the map points at"
+//! and "what the section assembles to" is visible in one place.
+//!
+//! ```bash
+//! cargo run --release --example probe_section_pages -- file.dwg [SectionName]
+//! ```
+
+use dwg::error::Result;
+use dwg::section_map::{self, DataPageHeader};
+use dwg::{DwgFile, HandleMap};
+use std::env;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let mut args = env::args().skip(1);
+    let Some(path) = args.next() else {
+        eprintln!("usage: probe_section_pages <file.dwg> [SectionName]");
+        return ExitCode::FAILURE;
+    };
+    let want = args
+        .next()
+        .unwrap_or_else(|| "AcDb:AcDbObjects".to_string());
+    match run(&path, &want) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("probe failed: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run(path: &str, want: &str) -> Result<()> {
+    let file = DwgFile::open(path)?;
+    let bytes = file.raw_bytes();
+    println!("file      : {path}");
+    println!("version   : {}", file.version());
+    println!("file bytes: {}", bytes.len());
+
+    let Some(header) = file.r2004_header() else {
+        println!("not an R2004-family file — nothing to probe");
+        return Ok(());
+    };
+
+    let page_map = section_map::parse_page_map(bytes, header)?;
+    let descriptions = section_map::parse_section_info(bytes, header, &page_map)?;
+    println!(
+        "page map  : {} entries ({} gaps)",
+        page_map.len(),
+        page_map.iter().filter(|p| p.is_gap).count()
+    );
+    println!("sections  : {}", descriptions.len());
+    println!();
+
+    println!(
+        "{:<26} {:>12} {:>7} {:>10} {:>5} {:>5} {:>5}",
+        "section", "size", "pages", "maxdecomp", "unk", "comp", "encr"
+    );
+    for d in &descriptions {
+        println!(
+            "{:<26} {:>12} {:>7} {:>10} {:>5} {:>5} {:>5}",
+            d.name,
+            d.size,
+            d.page_count,
+            d.max_decomp_page_size,
+            d.unknown,
+            d.compressed,
+            d.encrypted
+        );
+    }
+    println!();
+
+    let Some(desc) = descriptions.iter().find(|d| d.name == want) else {
+        println!("section {want:?} not present");
+        return Ok(());
+    };
+
+    println!("=== {} ===", desc.name);
+    println!("declared decompressed size : {}", desc.size);
+    println!("declared page count        : {}", desc.page_count);
+    println!("page refs present          : {}", desc.pages.len());
+    println!("max_decomp_page_size       : {}", desc.max_decomp_page_size);
+    println!("compressed flag            : {}", desc.compressed);
+    println!("encrypted flag             : {}", desc.encrypted);
+    println!("unknown field              : {}", desc.unknown);
+    println!();
+
+    println!(
+        "{:>4} {:>6} {:>10} {:>12} {:>12} {:>10} {:>10} {:>10} {:>12} {:>10}",
+        "idx",
+        "page#",
+        "map size",
+        "file off",
+        "ref start",
+        "ref dsize",
+        "hdr dsize",
+        "hdr psize",
+        "hdr start",
+        "produced"
+    );
+
+    let mut sorted: Vec<_> = desc.pages.iter().enumerate().collect();
+    sorted.sort_by_key(|(_, p)| p.start_offset);
+    let mut high_water: u64 = 0;
+    let mut gaps: Vec<(u64, u64)> = Vec::new();
+    let mut total_produced: u64 = 0;
+
+    for (idx, page_ref) in &sorted {
+        let page = page_map
+            .iter()
+            .find(|p| !p.is_gap && p.number == page_ref.page_number as i32);
+        let (map_size, file_off) = match page {
+            Some(p) => (p.size, p.file_offset),
+            None => {
+                println!(
+                    "{:>4} {:>6} {:>10} {:>12} {:>12} {:>10} {:>10} {:>10} {:>12} {:>10}",
+                    idx,
+                    page_ref.page_number,
+                    "MISSING",
+                    "-",
+                    page_ref.start_offset,
+                    page_ref.data_size,
+                    "-",
+                    "-",
+                    "-",
+                    "-"
+                );
+                continue;
+            }
+        };
+        let hdr = DataPageHeader::parse(bytes, file_off)?;
+        let payload_start = (file_off + 0x20) as usize;
+        let payload_end = payload_start + hdr.data_size as usize;
+        let produced = if payload_end > bytes.len() {
+            None
+        } else {
+            let payload = &bytes[payload_start..payload_end];
+            match desc.compressed {
+                1 => Some(payload.len()),
+                _ => dwg::lz77::decompress(payload, Some(desc.max_decomp_page_size as usize))
+                    .map(|v| v.len())
+                    .ok(),
+            }
+        };
+        println!(
+            "{:>4} {:>6} {:>10} {:>12} {:>12} {:>10} {:>10} {:>10} {:>12} {:>10}",
+            idx,
+            page_ref.page_number,
+            map_size,
+            file_off,
+            page_ref.start_offset,
+            page_ref.data_size,
+            hdr.data_size,
+            hdr.page_size,
+            hdr.start_offset,
+            produced
+                .map(|p| p.to_string())
+                .unwrap_or_else(|| "ERR".to_string())
+        );
+        if let Some(p) = produced {
+            total_produced += p as u64;
+            if page_ref.start_offset > high_water {
+                gaps.push((high_water, page_ref.start_offset));
+            }
+            let end = page_ref.start_offset + p as u64;
+            if end > high_water {
+                high_water = end;
+            }
+        }
+    }
+
+    println!();
+    println!("sum of produced page bytes : {total_produced}");
+    println!("assembled high-water mark  : {high_water}");
+    println!("declared section size      : {}", desc.size);
+    if !gaps.is_empty() {
+        println!("coverage gaps              : {gaps:?}");
+    }
+
+    // Cross-check against the handle map's address space.
+    if let Some(Ok(hbytes)) = file.read_section("AcDb:Handles") {
+        let map = HandleMap::parse(&hbytes)?;
+        let max = map.iter().map(|e| e.offset).max().unwrap_or(0);
+        let past = map.iter().filter(|e| e.offset >= desc.size).count();
+        println!();
+        println!("handle map entries         : {}", map.len());
+        println!("handle map max offset      : {max}");
+        println!("entries at/past decl size  : {past}");
+        if max >= desc.size {
+            println!("SHORTFALL                  : {}", max - desc.size + 1);
+        }
+    }
+
+    Ok(())
+}

--- a/src/bitcursor.rs
+++ b/src/bitcursor.rs
@@ -421,9 +421,21 @@ impl<'a> BitCursor<'a> {
     // ================================================================
 
     /// Reads an `H` (handle reference): a code/counter byte followed by `counter` big-endian value bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::HandleCounterTooLarge`] when the counter nibble
+    /// is above 8. The nibble can hold 0..=15, but a handle value is at
+    /// most a `u64`, so a wider counter is not a large handle — it is
+    /// proof that the cursor is not sitting on a handle field. Reading
+    /// it anyway shifted the excess bytes out silently and produced a
+    /// plausible-looking handle from garbage.
     pub fn read_handle(&mut self) -> Result<Handle> {
         let code = self.read_bits(4)? as u8;
         let counter = self.read_bits(4)? as u8;
+        if counter > 8 {
+            return Err(Error::HandleCounterTooLarge { code, counter });
+        }
         let mut value: u64 = 0;
         for _ in 0..counter {
             value = (value << 8) | self.read_rc()? as u64;
@@ -471,6 +483,39 @@ impl Handle {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bitwriter::BitWriter;
+
+    #[test]
+    fn read_handle_accepts_a_full_eight_byte_counter() {
+        let mut w = BitWriter::new();
+        w.write_handle(4, u64::MAX);
+        let bytes = w.into_bytes();
+        let h = BitCursor::new(&bytes).read_handle().unwrap();
+        assert_eq!(h.code, 4);
+        assert_eq!(h.counter, 8);
+        assert_eq!(h.value, u64::MAX);
+    }
+
+    #[test]
+    fn read_handle_rejects_a_counter_above_eight() {
+        // Code 2, counter 11 — the signature the sample_AC1032.dwg
+        // phantom records carried (#44/#51). Eleven value bytes cannot
+        // fit a u64, so the cursor is provably not on a handle field.
+        let mut w = BitWriter::new();
+        w.write_rc(0x2B);
+        for b in 0..11u8 {
+            w.write_rc(b);
+        }
+        let bytes = w.into_bytes();
+        let err = BitCursor::new(&bytes).read_handle().unwrap_err();
+        match err {
+            Error::HandleCounterTooLarge { code, counter } => {
+                assert_eq!(code, 2);
+                assert_eq!(counter, 11);
+            }
+            other => panic!("expected HandleCounterTooLarge, got {other:?}"),
+        }
+    }
 
     /// Helper: pack a sequence of `(value, bit_count)` pairs MSB-first into a
     /// byte vector. Pads the final byte with zeros. Used to construct bit

--- a/src/entities/dispatch.rs
+++ b/src/entities/dispatch.rs
@@ -1153,13 +1153,17 @@ mod tests {
         }
 
         // Without the RL the handle is misread and the walk overruns.
+        // The counter-nibble gate (#51) now rejects the misread handle
+        // one field earlier than the entity body used to; either way
+        // the misaligned read must not yield a LINE.
         let mut misaligned = BitCursor::new(&raw.raw);
         misaligned.read_bs_u().unwrap();
-        misaligned.read_handle().unwrap();
-        assert!(
+        let misaligned_result = misaligned.read_handle().and_then(|_| {
             crate::common_entity::read_common_entity_data(&mut misaligned, Version::R2004)
                 .and_then(|_| line::decode(&mut misaligned))
-                .is_err(),
+        });
+        assert!(
+            misaligned_result.is_err(),
             "skipping the RL obj_size must not decode as a valid LINE"
         );
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -153,4 +153,21 @@ pub enum Error {
         /// Byte offset into the decompressed `AcDb:AcDbObjects` stream.
         offset: u64,
     },
+
+    /// A handle reference (spec §2.13) declared more than 8 value
+    /// bytes. The counter nibble can encode 0..=15, but a handle value
+    /// is at most a `u64`, so anything above 8 cannot be a handle —
+    /// it means the cursor is not on a handle field at all. Treated as
+    /// a positional signal, not a value-range complaint: the walker
+    /// reports it as a skipped record rather than a decode failure.
+    #[error(
+        "handle counter {counter} exceeds 8 bytes (code {code}); a handle value \
+         cannot be wider than a u64, so the cursor is not on a handle field"
+    )]
+    HandleCounterTooLarge {
+        /// The 4-bit reference code that preceded the counter.
+        code: u8,
+        /// The 4-bit byte count read from the stream (9..=15 here).
+        counter: u8,
+    },
 }

--- a/src/handle_map.rs
+++ b/src/handle_map.rs
@@ -12,9 +12,31 @@
 //!   2 bytes  CRC-8 (spec §2.14.1) over the preceding bytes
 //! ```
 //!
-//! Handle numbers only grow (they're monotonic); byte offsets can jump
-//! backward because objects may be deleted and reused. Deltas are signed
-//! modular chars (0x40-is-sign).
+//! Two properties of the delta run are easy to get wrong and were both
+//! wrong here until the `sample_AC1032.dwg` audit in #43/#44:
+//!
+//! 1. **The handle delta is an UNSIGNED modular char; only the offset
+//!    delta is signed.** Handle numbers inside one handle section only
+//!    grow, so the encoder has no sign to spend — every one of the
+//!    terminating byte's low 7 bits is magnitude. Decoding the handle
+//!    delta as a *signed* MC steals bit 0x40 as a negation flag, which
+//!    silently halves any single-byte delta ≥ 0x40 and mis-splits the
+//!    multi-byte form. Byte offsets, by contrast, do jump backward
+//!    (objects get deleted and their space reused), so the offset delta
+//!    keeps the signed encoding.
+//! 2. **Both accumulators restart at zero on every handle section.**
+//!    The first pair of a section carries the absolute handle and the
+//!    absolute offset, not a delta from the previous section's last
+//!    entry. Carrying the running totals across the section boundary
+//!    throws every entry after the first section into a fabricated
+//!    address space.
+//!
+//! Both facts are verified against the file itself: each record in
+//! `AcDb:AcDbObjects` repeats its own handle, so "does the record at
+//! the offset this map produced carry the handle this map produced?"
+//! is a self-checking oracle. On `sample_AC1032.dwg` it agrees for
+//! 842 of 842 entries under these rules and for 272 of 842 without
+//! them.
 //!
 //! The section list terminates with a size-0 header.
 
@@ -56,8 +78,6 @@ impl HandleMap {
     pub fn parse(bytes: &[u8]) -> Result<Self> {
         let mut entries = Vec::new();
         let mut pos = 0usize;
-        let mut last_handle: i64 = 0;
-        let mut last_offset: i64 = 0;
         while pos < bytes.len() {
             if pos + 2 > bytes.len() {
                 break;
@@ -81,10 +101,14 @@ impl HandleMap {
             let payload_end = pos + section_size - 2;
             let payload = &bytes[pos..payload_end];
             pos += section_size;
-            // Walk the MC-delta pairs.
+            // Walk the MC-delta pairs. Both running totals restart at
+            // zero for every handle section — the section's first pair
+            // is absolute (see the module docs).
+            let mut last_handle: u64 = 0;
+            let mut last_offset: i64 = 0;
             let mut cur = BitCursor::new(payload);
             while cur.remaining_bits() >= 8 {
-                let h_delta = match read_signed_mc(&mut cur) {
+                let h_delta = match read_unsigned_mc(&mut cur) {
                     Ok(v) => v,
                     Err(_) => break,
                 };
@@ -101,7 +125,7 @@ impl HandleMap {
                     )));
                 }
                 entries.push(HandleEntry {
-                    handle: last_handle as u64,
+                    handle: last_handle,
                     offset: last_offset as u64,
                 });
             }
@@ -146,6 +170,20 @@ impl<'a> IntoIterator for &'a HandleMap {
 /// Maximum bytes per handle-section on the wire (spec §4.3 — the reader
 /// enforces ≤ 2032-byte section payloads + 2-byte CRC trailer).
 pub const MAX_HANDLE_SECTION_BYTES: usize = 2032;
+
+/// Write an UNSIGNED modular char — 7 magnitude bits per byte, 0x80 on
+/// every non-terminal byte. Inverse of [`read_unsigned_mc`].
+fn write_unsigned_mc(out: &mut Vec<u8>, mut v: u64) {
+    loop {
+        let limb = (v & 0x7F) as u8;
+        v >>= 7;
+        if v == 0 {
+            out.push(limb);
+            return;
+        }
+        out.push(0x80 | limb);
+    }
+}
 
 /// Write a SIGNED modular char using the same on-disk encoding
 /// [`read_signed_mc`] consumes. Multi-byte output with continuation bit
@@ -239,29 +277,35 @@ pub fn write_handle_map(
     use crate::crc::crc8;
 
     let mut out = Vec::new();
-    let mut last_handle: i64 = 0;
-    let mut last_offset: i64 = 0;
 
     let mut idx = 0;
     while idx < map.entries.len() {
         // Accumulate one section's pairs until adding the next pair would
         // exceed MAX_HANDLE_SECTION_BYTES - 2 (leaving room for the CRC).
+        // Both baselines start at zero: the reader restarts its
+        // accumulators on every section, so the first pair is absolute.
         let mut pairs = Vec::with_capacity(32);
-        let mut sec_last_handle = last_handle;
-        let mut sec_last_offset = last_offset;
+        let mut sec_last_handle: u64 = 0;
+        let mut sec_last_offset: i64 = 0;
         while idx < map.entries.len() {
             let e = map.entries[idx];
-            let h_delta = (e.handle as i64).wrapping_sub(sec_last_handle);
+            // The handle delta is unsigned on the wire, so a handle that
+            // moves backward cannot be encoded inside the current
+            // section. Close the section: the next one restarts from
+            // zero, where any absolute handle is representable.
+            let Some(h_delta) = e.handle.checked_sub(sec_last_handle) else {
+                break;
+            };
             let o_delta = (e.offset as i64).wrapping_sub(sec_last_offset);
             let mut pair_bytes = Vec::with_capacity(4);
-            write_signed_mc(&mut pair_bytes, h_delta);
+            write_unsigned_mc(&mut pair_bytes, h_delta);
             write_signed_mc(&mut pair_bytes, o_delta);
             // 2 bytes reserved for the trailing CRC.
             if pairs.len() + pair_bytes.len() + 2 > MAX_HANDLE_SECTION_BYTES {
                 break;
             }
             pairs.extend_from_slice(&pair_bytes);
-            sec_last_handle = e.handle as i64;
+            sec_last_handle = e.handle;
             sec_last_offset = e.offset as i64;
             idx += 1;
         }
@@ -272,12 +316,29 @@ pub fn write_handle_map(
         // CRC-8 over the pair bytes.
         let crc = crc8(0xC0C1, &pairs);
         out.extend_from_slice(&crc.to_le_bytes());
-        last_handle = sec_last_handle;
-        last_offset = sec_last_offset;
     }
     // Terminator: size = 0.
     out.extend_from_slice(&0u16.to_be_bytes());
     Ok(out)
+}
+
+/// Read an UNSIGNED modular char — every byte contributes 7 magnitude
+/// bits and the 0x80 bit is the only flag (spec §2.6). Used for the
+/// handle delta, which cannot be negative inside one handle section.
+fn read_unsigned_mc(r: &mut BitCursor<'_>) -> Result<u64> {
+    let mut value: u64 = 0;
+    let mut shift: u32 = 0;
+    loop {
+        let b = r.read_rc()? as u64;
+        value |= (b & 0x7F) << shift;
+        shift += 7;
+        if (b & 0x80) == 0 {
+            return Ok(value);
+        }
+        if shift >= 64 {
+            return Ok(value);
+        }
+    }
 }
 
 /// Read a SIGNED modular char — the 0x40 bit on the terminating byte
@@ -378,6 +439,79 @@ mod tests {
         );
     }
 
+    #[test]
+    fn handle_delta_is_unsigned_so_bit_0x40_is_magnitude_not_sign() {
+        // One pair: handle delta byte 0x56, offset delta byte 0x04.
+        //
+        // Read as an UNSIGNED modular char, 0x56 is 86. Read as a
+        // SIGNED one it would be -(0x56 & 0x3F) = -22 — the decode bug
+        // this test pins. 86 is the correct value: handle numbers only
+        // grow inside a handle section, so the encoder spends all seven
+        // low bits on magnitude.
+        let payload: Vec<u8> = vec![0x56, 0x04];
+        let mut data = Vec::new();
+        data.extend_from_slice(&((payload.len() + 2) as u16).to_be_bytes());
+        data.extend_from_slice(&payload);
+        data.extend_from_slice(&[0x00, 0x00]); // CRC placeholder
+        data.extend_from_slice(&[0x00, 0x00]); // terminator
+        let map = HandleMap::parse(&data).unwrap();
+        assert_eq!(map.entries.len(), 1);
+        assert_eq!(map.entries[0].handle, 86);
+        assert_eq!(map.entries[0].offset, 4);
+    }
+
+    #[test]
+    fn multi_byte_handle_delta_carries_seven_bits_in_its_terminator() {
+        // 0xC1 0x02 = continuation limb 0x41 (65) + terminator 0x02.
+        // Unsigned: 65 | (2 << 7) = 321. The signed reading would mask
+        // the terminator to six bits — same value here — but would also
+        // treat a terminator with 0x40 set as a sign; the companion
+        // pair below (0x81 0x41) proves the difference: unsigned gives
+        // 1 | (0x41 << 7) = 8321, signed would give -1.
+        let payload: Vec<u8> = vec![0xC1, 0x02, 0x01, 0x81, 0x41, 0x01];
+        let mut data = Vec::new();
+        data.extend_from_slice(&((payload.len() + 2) as u16).to_be_bytes());
+        data.extend_from_slice(&payload);
+        data.extend_from_slice(&[0x00, 0x00]);
+        data.extend_from_slice(&[0x00, 0x00]);
+        let map = HandleMap::parse(&data).unwrap();
+        assert_eq!(map.entries.len(), 2);
+        assert_eq!(map.entries[0].handle, 321);
+        assert_eq!(map.entries[1].handle, 321 + 8321);
+    }
+
+    #[test]
+    fn accumulators_restart_on_every_handle_section() {
+        // Section 1: (handle 5, offset 100). Section 2 opens with the
+        // pair (7, 40) — which is the ABSOLUTE handle 7 at ABSOLUTE
+        // offset 40, not handle 12 at offset 140. Handle 7 < 12 also
+        // makes the two readings distinguishable in one assertion.
+        let mut data = Vec::new();
+        let s1: Vec<u8> = vec![0x05, 0xE4, 0x00]; // h=+5, o=+100 (two-byte MC)
+        data.extend_from_slice(&((s1.len() + 2) as u16).to_be_bytes());
+        data.extend_from_slice(&s1);
+        data.extend_from_slice(&[0x00, 0x00]);
+        let s2: Vec<u8> = vec![0x07, 0x28]; // h=7, o=40
+        data.extend_from_slice(&((s2.len() + 2) as u16).to_be_bytes());
+        data.extend_from_slice(&s2);
+        data.extend_from_slice(&[0x00, 0x00]);
+        data.extend_from_slice(&[0x00, 0x00]); // terminator
+        let map = HandleMap::parse(&data).unwrap();
+        assert_eq!(
+            map.entries,
+            vec![
+                HandleEntry {
+                    handle: 5,
+                    offset: 100
+                },
+                HandleEntry {
+                    handle: 7,
+                    offset: 40
+                },
+            ]
+        );
+    }
+
     // -------- L12-08: writer tests --------
 
     #[test]
@@ -450,6 +584,66 @@ mod tests {
         let bytes = write_handle_map(&map, &mut w, Version::R2018).unwrap();
         let parsed = HandleMap::parse(&bytes).unwrap();
         assert_eq!(parsed.entries, map.entries);
+    }
+
+    #[test]
+    fn write_handle_map_roundtrips_deltas_that_set_bit_0x40() {
+        // Handle deltas of 64..=127 are exactly the range the signed-MC
+        // misreading corrupted; make the writer/reader pair prove them.
+        let entries: Vec<HandleEntry> = (0u64..64)
+            .map(|i| HandleEntry {
+                handle: 1 + i * 86,
+                offset: 4 + i * 70,
+            })
+            .collect();
+        let map = HandleMap {
+            entries: entries.clone(),
+        };
+        let mut w = BitWriter::new();
+        let bytes = write_handle_map(&map, &mut w, Version::R2018).unwrap();
+        assert_eq!(HandleMap::parse(&bytes).unwrap().entries, entries);
+    }
+
+    #[test]
+    fn write_handle_map_splits_a_section_when_the_handle_moves_backward() {
+        // The handle delta is unsigned on the wire, so a backward jump
+        // has to open a new section (whose accumulators restart at 0).
+        let entries = vec![
+            HandleEntry {
+                handle: 500,
+                offset: 10,
+            },
+            HandleEntry {
+                handle: 900,
+                offset: 20,
+            },
+            HandleEntry {
+                handle: 7,
+                offset: 30,
+            },
+            HandleEntry {
+                handle: 9,
+                offset: 40,
+            },
+        ];
+        let map = HandleMap {
+            entries: entries.clone(),
+        };
+        let mut w = BitWriter::new();
+        let bytes = write_handle_map(&map, &mut w, Version::R2018).unwrap();
+        // Two data sections plus the 2-byte terminator.
+        let mut sections = 0;
+        let mut pos = 0usize;
+        while pos + 2 <= bytes.len() {
+            let size = u16::from_be_bytes([bytes[pos], bytes[pos + 1]]) as usize;
+            if size == 0 {
+                break;
+            }
+            sections += 1;
+            pos += 2 + size;
+        }
+        assert_eq!(sections, 2);
+        assert_eq!(HandleMap::parse(&bytes).unwrap().entries, entries);
     }
 
     #[test]

--- a/src/object.rs
+++ b/src/object.rs
@@ -96,6 +96,8 @@ pub struct ObjectWalker<'a> {
     /// (decoded + skipped + errored). Compared against
     /// `limits.max_handles` on each `next_item` call.
     records_visited: usize,
+    /// Accumulator behind [`ObjectWalkSummary::handle_mismatches`].
+    handle_mismatches: Vec<(u64, u64, u64)>,
 }
 
 /// A single handle-driven walk step. In handle-driven mode the
@@ -145,6 +147,17 @@ pub struct ObjectWalkSummary {
     /// [`crate::reader::ParseDiagnostics`]; wiring the two together
     /// is deferred to a follow-up that can extend `src/api.rs`.
     pub unknown_types: Vec<(u16, u64)>,
+    /// Handle-driven mode only: records whose own handle field
+    /// disagreed with the handle the `AcDb:Handles` map paired with
+    /// that offset, as `(map_handle, record_handle, stream_offset)`.
+    ///
+    /// Every object repeats its handle inside its own record, so this
+    /// is a self-checking oracle for the handle map: a non-empty list
+    /// means the map's address space and the object stream disagree,
+    /// which is exactly the failure #43/#44 tracked. The record is
+    /// still yielded (with the map's handle, as before) — the
+    /// disagreement is reported, not enforced.
+    pub handle_mismatches: Vec<(u64, u64, u64)>,
 }
 
 impl ObjectWalkSummary {
@@ -194,6 +207,7 @@ impl<'a> ObjectWalker<'a> {
             handle_idx: 0,
             limits: WalkerLimits::default(),
             records_visited: 0,
+            handle_mismatches: Vec::new(),
         }
     }
 
@@ -214,6 +228,7 @@ impl<'a> ObjectWalker<'a> {
             handle_idx: 0,
             limits: WalkerLimits::default(),
             records_visited: 0,
+            handle_mismatches: Vec::new(),
         }
     }
 
@@ -323,6 +338,7 @@ impl<'a> ObjectWalker<'a> {
                 ObjectWalkItem::Skipped(entry) => summary.skipped.push(entry),
             }
         }
+        summary.handle_mismatches = std::mem::take(&mut self.handle_mismatches);
         (out, summary)
     }
 }
@@ -379,6 +395,13 @@ impl<'a> ObjectWalker<'a> {
             self.pos = pos;
             return match self.read_one_at_pos() {
                 Ok(Some(mut raw)) => {
+                    // Every record repeats its own handle; a mismatch
+                    // against the map means the map's address space is
+                    // wrong, not that this record is (#43/#44).
+                    if raw.handle.value != entry.handle {
+                        self.handle_mismatches
+                            .push((entry.handle, raw.handle.value, entry.offset));
+                    }
                     raw.handle.value = entry.handle;
                     Ok(Some(ObjectWalkItem::Object(raw)))
                 }
@@ -633,6 +656,7 @@ mod tests {
             skipped: Vec::new(),
             errored_count: 0,
             unknown_types: Vec::new(),
+            handle_mismatches: Vec::new(),
         };
         assert_eq!(s.confidence(), 1.0);
     }
@@ -652,6 +676,7 @@ mod tests {
             skipped,
             errored_count: 20,
             unknown_types: Vec::new(),
+            handle_mismatches: Vec::new(),
         };
         assert_eq!(s.confidence(), 0.5);
     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -510,6 +510,43 @@ impl DwgFile {
         )
     }
 
+    /// Same handle-driven walk as [`all_objects`](Self::all_objects),
+    /// but also returns the [`crate::object::ObjectWalkSummary`] listing
+    /// every handle-map entry the walker could not turn into a record.
+    ///
+    /// These skips are *walker* diagnostics, not decoder errors: they
+    /// mean the handle map pointed somewhere that does not hold an
+    /// object record (a truncated stream, an offset past the end, or a
+    /// handle field whose counter is impossible — see
+    /// [`crate::Error::HandleCounterTooLarge`]). They are deliberately
+    /// kept out of the per-entity dispatch counts so coverage numbers
+    /// stay comparable across releases.
+    pub fn all_objects_lossy(
+        &self,
+    ) -> Option<
+        Result<(
+            Vec<crate::object::RawObject>,
+            crate::object::ObjectWalkSummary,
+        )>,
+    > {
+        let _ = self.r2004.as_ref()?;
+        let hmap = match self.handle_map()? {
+            Ok(m) => m,
+            Err(e) => return Some(Err(e)),
+        };
+        let obj_bytes = match self.read_section("AcDb:AcDbObjects") {
+            Some(Ok(b)) => b,
+            Some(Err(e)) => return Some(Err(e)),
+            None => return None,
+        };
+        Some(Ok(crate::object::ObjectWalker::with_handle_map(
+            &obj_bytes,
+            self.version,
+            &hmap,
+        )
+        .collect_all_lossy()))
+    }
+
     /// End-to-end entity decode: walk every object via the handle map,
     /// then dispatch each one through the per-type decoder. Returns the
     /// list of [`crate::entities::DecodedEntity`] plus a

--- a/src/section_map.rs
+++ b/src/section_map.rs
@@ -46,6 +46,10 @@ pub struct SectionDescription {
     pub page_count: u32,
     /// Max decompressed size of a single page of this section (usually 0x7400).
     pub max_decomp_page_size: u32,
+    /// The undocumented u32 at offset 0x10 of the description record.
+    /// Surfaced for diagnostics (`examples/probe_section_pages.rs`);
+    /// the reader does not branch on it.
+    pub unknown: u32,
     /// Compression flag: 1 = uncompressed, 2 = LZ77.
     pub compressed: u32,
     /// ID used to cross-reference the Section Page Map.
@@ -379,7 +383,7 @@ fn decode_section_descriptions(data: &[u8]) -> Result<Vec<SectionDescription>> {
         let size = LittleEndian::read_u64(&data[cursor..cursor + 8]);
         let page_count = LittleEndian::read_u32(&data[cursor + 8..cursor + 12]);
         let max_decomp = LittleEndian::read_u32(&data[cursor + 12..cursor + 16]);
-        let _unknown = LittleEndian::read_u32(&data[cursor + 16..cursor + 20]);
+        let unknown = LittleEndian::read_u32(&data[cursor + 16..cursor + 20]);
         let compressed = LittleEndian::read_u32(&data[cursor + 20..cursor + 24]);
         let section_id = LittleEndian::read_u32(&data[cursor + 24..cursor + 28]);
         let encrypted = LittleEndian::read_u32(&data[cursor + 28..cursor + 32]);
@@ -412,6 +416,7 @@ fn decode_section_descriptions(data: &[u8]) -> Result<Vec<SectionDescription>> {
             size,
             page_count,
             max_decomp_page_size: max_decomp,
+            unknown,
             compressed,
             section_id,
             encrypted,

--- a/tests/canonical_corpus.rs
+++ b/tests/canonical_corpus.rs
@@ -164,3 +164,82 @@ fn fixture_sections_are_readable() {
         assert_eq!(map.len(), ENTITIES_PER_FIXTURE, "{name}: handle map size");
     }
 }
+
+/// Handle-map address-space gate (#43 / #44).
+///
+/// Every record in `AcDb:AcDbObjects` repeats its own handle, so the
+/// object stream can check the handle map against itself: the record at
+/// the offset the map produced must carry the handle the map produced.
+/// The R2018 sample audit found that invariant broken for 570 of 842
+/// entries because the handle delta was decoded as a *signed* modular
+/// char and the per-section accumulators were carried across handle
+/// sections. Pin it on every fixture so a regression in either the
+/// reader or the writer trips here.
+#[test]
+fn fixture_handle_maps_resolve_to_records_that_agree_with_them() {
+    for (name, _version) in FIXTURES {
+        let path = corpus_dir().join(name);
+        let file = DwgFile::open(&path).unwrap_or_else(|e| panic!("{name}: open failed: {e}"));
+        let (objects, walk) = file
+            .all_objects_lossy()
+            .unwrap_or_else(|| panic!("{name}: no handle-map-driven walk"))
+            .unwrap_or_else(|e| panic!("{name}: walk failed: {e}"));
+        let map = file
+            .handle_map()
+            .expect("handle map section present")
+            .expect("handle map parses");
+
+        assert!(
+            walk.skipped.is_empty(),
+            "{name}: {} handle-map entries yielded no record: {:?}",
+            walk.skipped.len(),
+            walk.skipped
+        );
+        assert!(
+            walk.handle_mismatches.is_empty(),
+            "{name}: {} records disagree with the handle map \
+             (map_handle, record_handle, offset): {:?}",
+            walk.handle_mismatches.len(),
+            walk.handle_mismatches
+        );
+        assert_eq!(
+            objects.len(),
+            map.len(),
+            "{name}: walked record count must equal the handle-map entry count"
+        );
+    }
+}
+
+/// Completeness oracle from the class table (#43): `AcDb:Classes`
+/// records how many instances of each custom class the drawing holds,
+/// so the walk must reach at least that many objects of each class.
+/// The synthetic fixtures carry no custom classes today; the assertion
+/// is written so it starts gating the moment `build_fixtures` declares
+/// one.
+#[test]
+fn fixture_walks_reach_every_declared_class_instance() {
+    for (name, _version) in FIXTURES {
+        let path = corpus_dir().join(name);
+        let file = DwgFile::open(&path).unwrap_or_else(|e| panic!("{name}: open failed: {e}"));
+        let Some(Ok(classes)) = file.class_map() else {
+            continue;
+        };
+        let objects = file
+            .all_objects()
+            .unwrap_or_else(|| panic!("{name}: no handle-map-driven walk"))
+            .unwrap_or_else(|e| panic!("{name}: walk failed: {e}"));
+        for def in &classes.classes {
+            let walked = objects
+                .iter()
+                .filter(|o| o.type_code == def.class_number)
+                .count();
+            assert!(
+                walked >= def.num_objects as usize,
+                "{name}: class {} ({}) declares {} instances, walk reached {walked}",
+                def.class_number,
+                def.dxf_class_name,
+                def.num_objects
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`AcDb:Handles` was decoded with two wrong rules. Their combination — not the
section assembly — is what #44 measured as a 96,739-byte address-space
shortfall against `AcDb:AcDbObjects`, and what #43 saw as classes the walker
never reached.

1. **The handle delta is an UNSIGNED modular char; only the offset delta is
   signed.** Handles grow monotonically inside a handle section, so the encoder
   spends all seven low bits of the terminating byte on magnitude. Reading it as
   a *signed* MC steals bit `0x40` as a negation flag, so every single-byte
   delta in `0x40..=0x7F` decoded small and negative and the multi-byte form
   split its limbs one bit short. Byte offsets genuinely move backward (deleted
   objects' space gets reused), so the offset delta keeps the signed encoding.
2. **Both accumulators restart at zero on every handle section.** The first
   `(handle, offset)` pair of a section is absolute, not a delta from the
   previous section's last entry.

## Evidence

**The section assembly was never wrong.** `examples/probe_section_pages.rs`
(new) walks `AcDb:AcDbObjects` page by page on `sample_AC1032.dwg`:

- 41 page refs, all present in the page map, `start_offset` stepping by exactly
  `0x7400` (29,696) from 0 to 1,187,840.
- every page's LZ77 payload produces exactly 29,696 bytes → 1,217,536 total.
- the description declares 1,192,851, so the last page contributes 5,011 real
  bytes and 24,685 bytes of padding — consistent with that page's compressed
  payload being only 3,317 bytes where every full page is ~29,817.
- `max_decomp_page_size` 29,696, `compressed` 2, `encrypted` 0, `unknown` 1,
  every `hdr.start_offset` equal to its `ref start`. Nothing is skipped or
  truncated.

**The map was wrong.** Every record in `AcDb:AcDbObjects` repeats its own
handle, so the object stream is a free oracle for the map: *does the record at
the offset this map produced carry the handle this map produced?* Decoding the
same 2,642 handle bytes four ways:

| handle delta | per-section restart | agree | disagree | no record |
|---|---|---|---|---|
| signed | no (shipped) | 272 | 457 | 113 |
| signed | yes | 445 | 397 | 0 |
| unsigned | no | 656 | 73 | 113 |
| **unsigned** | **yes** | **842** | **0** | **0** |

Byte-level witnesses on that file:

- Bug 1 first bites at entry 272: the map claimed `0x438` at offset 148,422;
  the record there carries `0x4A4`. Every later handle ran 108 low.
- Bug 2: handle section 1 ends at entry 655 (payload bytes 0..2030, consumed
  exactly). Section 2's first pair is `hd=2851, od=99522`. Carried across the
  boundary that reads as handle `0x1343` at offset 197,439, where no record
  starts. Read as absolute it is handle `0xB23` at offset 99,522 — and the
  record at 99,522 declares size 1,608 and handle **2851**. The next pair
  (`+1`, `+1613`) lands at 101,135 on a record declaring handle **2852**.
- The 1,289,590 phantom offset was pure accumulated drift. After the fix the
  map's highest offset is **1,192,823**, 28 bytes inside the declared section,
  and all six previously out-of-range entries resolve to real records.

**No records are hiding outside the map.** The 842 walked records cover
1,191,935 of the section's 1,192,851 bytes; 916 bytes are unclaimed and the
longest unclaimed run is 4 bytes (inter-record padding).

## Measured results

`cargo run --release --example coverage_report -- <19-file corpus>`, base
`f706937` vs this branch:

| Version | Files | Decoded | Skipped | Errored | Rate |
|---|---|---|---|---|---|
| R2004 (AC1018) | 3 | 489 → 489 | 108 → 108 | 0 → 0 | 81.9 % → 81.9 % |
| R2010 (AC1024) | 3 | 510 → 510 | 33 → 33 | 0 → 0 | 93.9 % → 93.9 % |
| R2013 (AC1027) | 3 | 363 → 363 | 33 → 33 | 0 → 0 | 91.7 % → 91.7 % |
| R2018 (AC1032) | 1 | 561 → **712** | 145 → **91** | 39 → 39 | 75.3 % → **84.6 %** |
| **Aggregate** | 19 | 1923 → **2074** | 319 → **265** | 39 → 39 | 84.3 % → **87.2 %** |

R2004/R2010/R2013 are unchanged because those samples carry a single handle
section and no delta ≥ `0x40` — neither bug could fire there. That is the
control.

Walker diagnostics on `sample_AC1032.dwg`: 97 handle-map entries yielded no
record before (91 "no record at offset", 6 "past end of stream"); **0** after.
Handle self-check mismatches: 430 before (measured with this PR's new
diagnostic against the old delta rules), **0** after.

### Declared vs walked per class (#43)

`examples/probe_class_census.rs` (new) against `AcDb:Classes`
`num_objects`. Only rows that changed or are still short:

| Class | Code | Declared | Walked before | Walked after |
|---|---|---|---|---|
| MATERIAL | 505 | 11 | 3 | **11** |
| MULTILEADER | 526 | 15 | 10 | **15** |
| ACAD_EVALUATION_GRAPH | 532 | 3 | 1 | **3** |
| ACSH_HISTORY_CLASS | 545 | 2 | 0 | **2** |
| PDFDEFINITION | 542 | 1 | 0 | **1** |
| PDFUNDERLAY | 543 | 1 | 0 | **1** |
| SPATIAL_FILTER | 544 | 1 | 0 | **1** |
| ACSH_BOX_CLASS | 546 | 1 | 0 | **1** |
| ACDBASSOCPERSSUBENTMANAGER | 548 | 1 | 0 | **1** |
| ACDBPERSSUBENTMANAGER | 549 | 1 | 0 | **1** |
| TABLECONTENT | 524 | 5 | 1 | 2 |
| TABLEGEOMETRY | 525 | 5 | 1 | 2 |

Pre-fix the census also *over*-counted several classes (ACDBDICTIONARYWDFLT
1/2, DICTIONARYVAR 11/12, MESH 2/3, BLOCKLINEARPARAMETER 1/2,
ACDB_BLOCKREPRESENTATION_DATA 2/3) because garbage offsets parsed into
plausible-looking records; those are gone too.

**41 of 43 classes now reach their declared instance count.** LAYOUT (4) and
ACDBPLACEHOLDER (1) are credited via their fixed type codes `0x52`/`0x50` —
both were promoted out of the custom-class range, so the drawing registers the
class but writes the instances with the fixed code. TABLECONTENT and
TABLEGEOMETRY each declare 5 and reach 2; with the object stream 99.92 %
covered and zero unclaimed runs longer than 4 bytes, those three instances
apiece are not present as standalone records in this drawing. That is a
class-table bookkeeping question, not a walker gap — follow-up below.

### #51 — `read_handle` rejects a counter above 8

`BitCursor::read_handle` now returns the new `Error::HandleCounterTooLarge`
when the counter nibble exceeds 8. The nibble holds 0..=15 but a handle value
is at most a `u64`, so a wider counter proves the cursor is not on a handle
field; the old code shifted the excess out and produced a plausible handle from
garbage (the `counter = 11` in #44). Measured against the *pre-fix* address
space, this gate alone caught **43** phantom records on `sample_AC1032.dwg`.
It surfaces as a walker skip, never as a dispatch error, so coverage ratios
stay comparable — `coverage_report` grows a separate `wskip` column and a
walker-diagnostic histogram.

The three phantom `CUSTOM(727)` records from #44 are gone, along with
`CUSTOM(517)` at 212,392 and `CUSTOM(564)` at 229,599.

## Changes

- `src/handle_map.rs` — `read_unsigned_mc` / `write_unsigned_mc`; accumulators
  scoped to the handle section on both read and write; the writer opens a new
  section when a caller's handles move backward (unencodable as an unsigned
  delta). Five new byte-built tests, including one that pins `0x56` as +86 and
  not −22, and one that pins the per-section restart.
- `src/bitcursor.rs` — the counter gate + two tests (a full 8-byte counter still
  round-trips; a `BitWriter`-built `code 2 / counter 11` is rejected).
- `src/object.rs` — `ObjectWalkSummary::handle_mismatches` records every record
  whose own handle disagrees with the map. Reported, not enforced.
- `src/reader.rs` — `DwgFile::all_objects_lossy()` exposes the walk summary.
- `src/section_map.rs` — `SectionDescription::unknown` surfaced for the probe.
- `tests/canonical_corpus.rs` — two new gates across all four fixtures: the
  handle map must resolve to records that agree with it (zero skips, zero
  mismatches, walked count == map length), and the walk must reach every
  declared class instance.
- `src/entities/dispatch.rs` — one negative-control test now expects the
  misaligned read to fail at `read_handle` rather than in the entity body.
- New probes `examples/probe_section_pages.rs` and
  `examples/probe_class_census.rs`; `examples/coverage_report.rs` gains the
  walker-diagnostic reporting.
- README / STATUS / CHANGELOG / ARCHITECTURE updated with the measured numbers
  and the corrected `AcDb:Handles` wire description.

No fixture bytes changed, so `tests/canonical_corpus.rs`'s existing field pins
are untouched: the writer moved in lockstep with the reader and the synthetic
maps are single-section with small deltas.

## Spec sections

§2.6 (modular chars), §2.13 (handle references), §4.5 / §4.6 (section info and
the 0x20 data-page header), §21 (object map / `AcDb:Handles`), §20 (object
stream records).

## Source provenance

Clean-room. Derived from the ODA DWG specification v5.4.1 and from measurements
of `sample_AC1032.dwg` itself using the probes in this repository. No
LibreDWG, ODA, Autodesk, or other third-party DWG source was read or consulted
for this change; `CLEANROOM.md` needs no new disclosure.

## Gate

`cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`,
`cargo test --release` (703 lib + all integration suites), `cargo deny check
all`, `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --all-features`, and
`cargo +1.85.0 test --no-run` all pass.

## Follow-up candidates

- TABLECONTENT / TABLEGEOMETRY each declare 5 instances on
  `sample_AC1032.dwg` and only 2 exist as standalone records. Decide whether
  `num_objects` is a live census or a registration-time counter, or whether the
  missing instances are embedded inside the two `ACAD_TABLE` entities.
- `probe_class_census` exits non-zero on any under-walked class; wiring it into
  CI once the two rows above are explained would make the class table a
  standing completeness gate.
- The 916 unclaimed object-stream bytes (842 runs, max 4 bytes each) are
  presumably record alignment padding; confirming that against the spec would
  turn "99.92 % covered" into "100 % accounted for".
- 39 dispatch errors remain on `sample_AC1032.dwg`, now concentrated in
  MULTILEADER (15) and HATCH (8) — both grew because the fix recovered records
  that previously never reached a decoder.

Closes #43
Closes #44
Closes #51

https://claude.ai/code/session_01BaHKf1Rw5aJBGK5y3xmx7C

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core R2004+ object enumeration (`HandleMap` read/write and the object walker), which affects every downstream decode path; behavior is heavily tested and corpus-gated, but regressions on multi-section handle maps would be high impact.
> 
> **Overview**
> Fixes **`AcDb:Handles`** decoding so handle deltas use **unsigned** modular chars (offset deltas stay signed) and **handle/offset accumulators reset at each handle section**. The writer mirrors the same rules, including splitting sections when handles would move backward.
> 
> Adds **`Error::HandleCounterTooLarge`** when `BitCursor::read_handle` sees a counter above 8, **`ObjectWalkSummary::handle_mismatches`**, and **`DwgFile::all_objects_lossy()`** so walks can be checked against each record’s embedded handle. Corpus integration tests and new probes (`probe_section_pages`, `probe_class_census`) gate completeness; **`coverage_report`** adds a separate **`wskip`** column for walker skips.
> 
> On **`sample_AC1032.dwg`**, handle-map self-check goes to **842/842**, walker skips drop to **0**, and measured decode coverage rises (**712 decoded**, **84.6%** file / **87.2%** aggregate). Closes **#43**, **#44**, **#51**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac5e7e059d9a62d0d5cb97de92ce02f7ca11b581. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->