### PR TITLE
feat(objects): decode MLINESTYLE from §20.4.73 and derive MLEADERSTYLE + the two view styles

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -443,8 +443,9 @@ boundary:
 A decoder that lands anywhere else returns `DecodedEntity::Error`, so a
 wrong field list can never inflate the coverage ratio. That is also why
 MATERIAL and PROPERTYSET_DATA — which read only what their bytes prove
-and stop — are deliberately **not** dispatched, along with MLINESTYLE,
-whose field list this crate has not yet matched against real bytes.
+and stop — are deliberately **not** dispatched, along with TABLESTYLE,
+whose block structure is measured (§7d.4) but whose token sequence a
+single record per file cannot pin.
 
 ### 7d.1 Deriving a field list the spec does not carry — VISUALSTYLE
 
@@ -537,6 +538,94 @@ that match their own name string (`215.9 × 279.4` mm for
 the sheet less its margins in inches, `(1,0,0)` / `(0,1,0)` UCS axes on
 all 31 records, and AutoCAD's `±1e20` uninitialised-extents sentinel on
 the empty layouts.
+
+### 7d.3 A second prescribed record — MLINESTYLE (§20.4.73)
+
+**§20.4.73 MLINESTYLE** prescribes the whole record: `TV` name, `TV`
+description, `BS` flags, `CMC` fill colour, `BD` start and end angles,
+`RC` line count, then per line a `BD` offset, a `CMC` colour and —
+"Before R2018" — a `BS` linetype index, which R2018 replaces with a
+handle. The module previously cited a "§19.6.4 (L6-13)" that does not
+exist and read `BS` where the spec prints `CMC` for both colour fields,
+which is 42 bits short per record on every real file; the citation is
+withdrawn.
+
+Read straight, the prescription closes all ten corpus records:
+
+| Release | Records | Budget | Delta |
+|---|---|---|---|
+| R2004 | 3 (`{arc,circle,line}_2004.dwg` handle 96) | 526 | 0 |
+| R2010 | 3 (`*_2010.dwg` handle 96) | 442 | 0 |
+| R2013 | 3 (`*_2013.dwg` handle 96) | 442 | 0 |
+| R2018 | 1 (`sample_AC1032.dwg` handle 24) | 406 | 0 |
+
+The R2013 → R2018 drop is exactly the two `BS ltindex` words R2018
+moves into the handle stream: both records carry two line elements,
+both write the index in the 16-bit `BS` form, and 442 − 2 × 18 = 406.
+Every record decodes `startang = endang = π/2`, a ByLayer fill colour,
+elements at `+0.5` and `−0.5`, and the `32767` no-linetype sentinel.
+
+### 7d.4 The joint-boundary search — MLEADERSTYLE and the view styles
+
+§20.4 has no entry for MLEADERSTYLE, ACDBDETAILVIEWSTYLE,
+ACDBSECTIONVIEWSTYLE or TABLESTYLE. The first three were derived the
+way VISUALSTYLE was, with one addition: because the corpus stores the
+same style in four release bands, a candidate token sequence has to
+close **every** band, and the pre-R2007 band is the strongest
+constraint of the four — there a `TV` is inline and costs real bits, so
+a string in the wrong slot moves everything after it by hundreds of
+bits. `ACDBSECTIONVIEWSTYLE`'s four strings cost 82, 146, 730 and 66
+bits on R2004; that is what fixes their positions, and what settles the
+order of `hatch_pattern_name` and the byte beside it, which are
+interchangeable on R2010+ where a `TV` is free.
+
+`H` fields are invisible to this search on every band the walker
+reaches: R2000+ puts the handle references past the object-data-size
+boundary, so a handle costs no data-stream bits and leaves no trace.
+The field lists in `objects::acad_mleader_style`,
+`objects::acad_detail_view_style` and `objects::acad_section_view_style`
+are therefore the data stream only.
+
+| Object | Records | R2004 | R2010 | R2013 | R2018 |
+|---|---|---|---|---|---|
+| MLEADERSTYLE | 11 | 744 | 692 | 693 | 693 / 749 |
+| ACDBDETAILVIEWSTYLE | 11 | 1209 | 667 | 667 | 677 / 605 |
+| ACDBSECTIONVIEWSTYLE | 11 | 2325 | 1301 | 1301 | 1263 / 1367 |
+
+Every one of those 33 records closes with delta 0. The version switches
+are measured: MLEADERSTYLE gains a leading `BS version` and three
+trailing attachment-direction words in R2010 and one further `B` in
+R2013; both view styles gain a second name `TV` and two `B`s in R2018,
+and only placing those two bits *after* the record's leading `BS` keeps
+`flags` reading the `32` (detail) / `44` (section) that R2004, R2010 and
+R2013 all carry — the other placement turns it into `72` and
+desynchronises the first `CMC` on both R2018 records.
+
+Corroboration is in the values. MLEADERSTYLE's `Standard` decodes
+AutoCAD's shipped defaults to the last digit — landing gap `0.09`,
+dogleg `0.36`, arrowhead `0.18`, text height `0.18`, break gap `0.125`,
+block scales `1, 1, 1`, ByBlock (`0xC1……`) for all three colours and
+`-2` for the leader lineweight. The view styles decode text heights of
+`5` on every `Metric50` record and `0.24` on every `Imperial24` one,
+lineweights of `25` and `50` (0.25 mm and 0.50 mm), ByLayer for every
+colour but the section hatch background, which is the `0xC8……` "no
+colour" method. ACDBSECTIONVIEWSTYLE ends in five consecutive
+full-width doubles that decode to 90°, 15°, 75°, −15° and 105° in
+radians — the cutting-plane angle set — and carries `I, O, Q, S, X, Z`,
+the identifier letters AutoCAD excludes, and `ANSI31` as the cut-surface
+pattern.
+
+**TABLESTYLE is declined.** Its R2013 record on `arc_2013.dwg` budgets
+6,844 bits and its structure is measurable —
+`examples/probe_token_scan.rs` shows a 52-bit header followed by four
+cell-style blocks (the string stream names them `Table`, `_TITLE`,
+`_HEADER`, `_DATA`) of 1738 / 1696 / 1696 / 1662 bits, each ending in
+six 168-bit border sub-records of the shape `CMC` + 36 bits + `BD` + 22
+bits — but the blocks' internal token sequence is not determined: each
+corpus file carries exactly one TABLESTYLE record, and one record with
+a 52-bit header admits thousands of parses over `B/BS/BL/BD/RC/CMC`.
+Measured budgets, for whoever picks this up: R2004 1849, R2010 6836,
+R2013 6844, R2018 5820. The records stay `Unhandled`.
 
 ## 7e. `AcDb:Classes` — where the class list actually starts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,63 @@ once the public API stabilizes at 0.1.0.
 
 ## [Unreleased]
 
+### Added — MLINESTYLE (§20.4.73) and three style classes the spec does not prescribe (2026-08-30, closes #55)
+
+`MLINESTYLE`, `MLEADERSTYLE`, `ACDBDETAILVIEWSTYLE` and
+`ACDBSECTIONVIEWSTYLE` now dispatch to typed decoders on every release
+band this crate walks. All 43 records of the local 19-file corpus close
+exactly on their own data-stream boundary — the first bit of the string
+stream on R2010+, the `RL` object-data-size on R2004 — so a wrong field
+list errors rather than returning a plausible struct.
+
+- **MLINESTYLE comes from the spec.** §20.4.73 prescribes the whole
+  record; the module previously cited a "§19.6.4 (L6-13)" that does not
+  exist and read `BS` where the spec prints `CMC` for both colour
+  fields. Read straight, it closes on all ten records: R2004 budget 526,
+  R2010 and R2013 442, R2018 406 — the R2018 drop being exactly the two
+  18-bit `BS ltindex` words that release moves into the handle stream.
+- **The other three have no §20.4 entry** and were derived by the
+  joint-boundary search over `B/BS/BL/BD/RC/CMC/TV`, with the pre-R2007
+  band — where a `TV` costs real data-stream bits — pinning the string
+  positions. 33 records, four release bands, delta 0 on every one.
+  Budgets: MLEADERSTYLE 744 / 692 / 693 / 693 · 749;
+  ACDBDETAILVIEWSTYLE 1209 / 667 / 667 / 677 · 605;
+  ACDBSECTIONVIEWSTYLE 2325 / 1301 / 1301 / 1263 · 1367.
+- **Values corroborate the layouts**: MLEADERSTYLE's `Standard` decodes
+  AutoCAD's shipped defaults (landing gap `0.09`, dogleg `0.36`,
+  arrowhead `0.18`, text height `0.18`, break gap `0.125`, block scales
+  `1,1,1`, ByBlock colours, lineweight `-2`); the view styles decode
+  `5` / `0.24` text heights for `Metric50` / `Imperial24`, lineweights
+  `25` and `50`, and ACDBSECTIONVIEWSTYLE ends in five doubles that are
+  90°, 15°, 75°, −15° and 105° in radians.
+- **TABLESTYLE is declined, not guessed.** Its structure is measured —
+  a 52-bit header plus four cell-style blocks of 1738 / 1696 / 1696 /
+  1662 bits, each ending in six 168-bit border sub-records — but one
+  record per corpus file cannot pin the token sequence inside a block.
+  Budgets recorded for a follow-up: R2004 1849, R2010 6836, R2013 6844,
+  R2018 5820. The records stay `Unhandled`.
+- New `objects::color::ObjectColor` gives the four decoders one `CMC`
+  reading that also honours the colour byte's two name-string bits.
+- New probe `examples/probe_token_scan.rs` reports the self-identifying
+  anchors (full-form `BD`s that decode to short decimals, `CMC`s whose
+  true-colour word carries a real method octet) a field list has to
+  reach exactly. `examples/probe_field_list.rs` and
+  `examples/probe_object_layout.rs` now consume the R2013+ AcDs
+  binary-data marker as 16 bits, matching `objects::modern`.
+
+Measured coverage on the local 19-file corpus, before → after:
+
+| Version | Decoded | Skipped | Errored | Ratio |
+|---|---|---|---|---|
+| R2004 (AC1018) | 498 → 510 | 99 → 87 | 0 | 83.4 % → **85.4 %** |
+| R2010 (AC1024) | 519 → 531 | 24 → 12 | 0 | 95.6 % → **97.8 %** |
+| R2013 (AC1027) | 372 → 384 | 24 → 12 | 0 | 93.9 % → **97.0 %** |
+| R2018 (AC1032) | 716 → 723 | 87 → 80 | 39 | 85.0 % → **85.9 %** |
+| **Aggregate** | **2105 → 2148** | **234 → 191** | **39** | 88.5 % → **90.3 %** |
+
+No new errors: every one of the 43 records moved from Unhandled to
+decoded.
+
 ### Fixed — the `AcDb:Handles` delta run: unsigned handle deltas, per-section restart (2026-08-30, closes #43, closes #44, closes #51)
 
 - **The handle delta is an UNSIGNED modular char; only the offset delta

--- a/CLEANROOM.md
+++ b/CLEANROOM.md
@@ -153,3 +153,34 @@ the modules; neither came from a third-party implementation.
 The "§19.6.12 (L6-12)" and "§19.6.6 (L6-14)" citations the two modules
 previously carried are withdrawn — the spec has no §19.6 chapter, and
 §20.4 carries no standalone PLOTSETTINGS entry.
+
+## 2026-08-30 — MLEADERSTYLE / view-style property names (Autodesk public documentation, recalled)
+
+The PR for #55 derives the field lists of `MLEADERSTYLE`,
+`ACDBDETAILVIEWSTYLE` and `ACDBSECTIONVIEWSTYLE` entirely from bytes:
+the one token sequence over `B/BS/BL/BD/RC/CMC/TV` that lands every one
+of the 33 corpus records — across R2004, R2010, R2013 and R2018 —
+exactly on its own data-stream boundary, with the pre-R2007 band, where
+a `TV` costs real bits, pinning the string positions. ODA spec v5.4.1
+§20.4 carries **no** prescription for any of the three; no citation is
+claimed for them.
+
+As with the VISUALSTYLE entry above, the **names** given to the slots
+are outside vocabulary, not outside structure. `MLEADERSTYLE`'s follow
+the conventional `AcDbMLeaderStyle` property ordering as recalled from
+Autodesk's public *DXF Reference*; the two view styles' follow the field
+vocabulary of AutoCAD's Detail View Style and Section View Style
+dialogs as recalled from Autodesk's public product documentation. Both
+are published documentation, not SDK or product source. No code,
+structure or layout was taken from either — they contributed vocabulary
+only, and the slots whose decoded values do not corroborate a name are
+labelled `unknown_*` / `flag_*` or documented as positional rather than
+given a plausible-sounding one.
+
+`MLINESTYLE` needed no outside vocabulary: **§20.4.73 MLINESTYLE** of
+the freely-redistributable ODA specification prescribes the whole
+record, and every field name and type in
+`src/objects/acad_mlinestyle.rs` comes from that table. The
+"§19.6.4 (L6-13)" citation that module previously carried is withdrawn
+— the spec has no §19.6 chapter — along with the `BS`-where-the-spec-
+prints-`CMC` reading that came with it.

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ local `samples/` set:
 | Version | Files tested | Decoded | Skipped | Errored | Success rate |
 |---------|--------------|---------|---------|---------|--------------|
 | R14 / R2000 / R2007 | 9 | n/a | n/a | n/a | not supported (no handle-map for this layout yet) |
-| R2004 (AC1018)      | 3 | 498 | 99 | 0 | **83.4 %** |
-| R2010 (AC1024)      | 3 | 519 | 24 | 0 | **95.6 %** |
-| R2013 (AC1027)      | 3 | 372 | 24 | 0 | **93.9 %** |
-| R2018 (AC1032)      | 1 | 716 | 87 | 39 | **85.0 %** |
-| **Aggregate** | **19** | **2105** | **234** | **39** | **88.5 %** |
+| R2004 (AC1018)      | 3 | 510 | 87 | 0 | **85.4 %** |
+| R2010 (AC1024)      | 3 | 531 | 12 | 0 | **97.8 %** |
+| R2013 (AC1027)      | 3 | 384 | 12 | 0 | **97.0 %** |
+| R2018 (AC1032)      | 1 | 723 | 80 | 39 | **85.9 %** |
+| **Aggregate** | **19** | **2148** | **191** | **39** | **90.3 %** |
 
 Per-entity-type error concentration in the measured corpus:
 
@@ -87,7 +87,7 @@ real-file decode gap is the 0.2.0 milestone.
 | HandleMap + ClassMap parsing | ✓ shipped | — |
 | Header variables | ✓ shipped | Strict + lossy variants |
 | Object-stream walker (R2004+) | ✓ shipped | R14 / R2000 / R2007 pending (#104) |
-| Per-entity field decoders | ⚠ alpha | Broad synthetic coverage; real-file aggregate currently ~88.5% (#103) |
+| Per-entity field decoders | ⚠ alpha | Broad synthetic coverage; real-file aggregate currently ~90.3% (#103) |
 | Entity graph (owner / reactors / blocks / layers) | ⚠ partial | Resolver APIs exist; trailing-handle/block traversal gaps remain |
 | Symbol tables (LAYER / LTYPE / STYLE / DIMSTYLE / …) | ⚠ partial | R2007+ BLOCK_HEADER and simple LTYPE names decode; broader content fields pending |
 | SVG / PDF export | ⚠ alpha | SVG writer + paged-SVG PDF path; output quality depends on decoded geometry |
@@ -271,8 +271,8 @@ $ cargo deny check                                                # no advisorie
 
 Tests exercise the container layer end-to-end across all 19 corpus files and verify
 bit-level round-trip properties for every primitive. They do **not** verify that every
-entity decoder succeeds on every real-world drawing — that's what the 88.5 %
-aggregate / 85.0 % AC1032 coverage numbers above measure. Both classes of
+entity decoder succeeds on every real-world drawing — that's what the 90.3 %
+aggregate / 85.9 % AC1032 coverage numbers above measure. Both classes of
 testing are needed.
 
 ## Safety

--- a/STATUS.md
+++ b/STATUS.md
@@ -6,18 +6,18 @@ scrolling the changelog.
 
 ## Summary
 
-- **Lib tests:** 703 passing in default/debug and release-all-features
+- **Lib tests:** 721 passing in default/debug and release-all-features
   profiles, clippy + fmt clean.
 - **WASM tests:** 40 passing in `wasm/` sub-crate.
 - **Integration tests:** DXF round-trip (7), glTF smoke (3), SVG
   goldens (3), fuzz-corpus regression (6), write-path (5),
   entity-regression (18), real-DWG value regression (8).
-- **Current real-file decode coverage:** 2,105 decoded / 234 skipped /
-  39 errored / 88.5% on the local 19-file `samples/` corpus. The
-  R2018 `sample_AC1032.dwg` sample is 716 / 87 / 39 / 85.0%, and it
+- **Current real-file decode coverage:** 2,148 decoded / 191 skipped /
+  39 errored / 90.3% on the local 19-file `samples/` corpus. The
+  R2018 `sample_AC1032.dwg` sample is 723 / 80 / 39 / 85.9%, and it
   is the only file with any errors — the R2004, R2010 and R2013
-  samples all decode with zero. Per version: R2004 81.9%,
-  R2010 93.9%, R2013 91.7%.
+  samples all decode with zero. Per version: R2004 85.4%,
+  R2010 97.8%, R2013 97.0%.
 - **Handle-map completeness:** every one of the 842 `AcDb:Handles`
   entries on `sample_AC1032.dwg` resolves to a record whose own handle
   field matches the map, and the walked records cover 1,191,935 of the
@@ -87,11 +87,15 @@ scrolling the changelog.
   HATCH / DIMENSION entities. Each modern
   decoder asserts its data fields end exactly on the string-stream
   start bit, so a wrong layout errors rather than returning garbage.
-- Named-object dictionary, ACAD_GROUP, ACAD_MLINESTYLE,
-  ACAD_SCALE, ACAD_VISUALSTYLE (R2010+, 58
-  properties on R2013/R2018), ACAD_PROPERTYSET_DATA, and LAYOUT +
-  PLOTSETTINGS (one §20.4.84 field list, closing on all 31 corpus
-  LAYOUT records across R2004, R2010, R2013 and R2018).
+- Named-object dictionary, ACAD_GROUP, ACAD_SCALE, ACAD_VISUALSTYLE
+  (R2010+, 58 properties on R2013/R2018), ACAD_PROPERTYSET_DATA, and
+  LAYOUT + PLOTSETTINGS (one §20.4.84 field list, closing on all 31
+  corpus LAYOUT records across R2004, R2010, R2013 and R2018).
+- MLINESTYLE from the §20.4.73 prescription, closing on all 10 corpus
+  records across R2004, R2010, R2013 and R2018, and MLEADERSTYLE,
+  ACDBDETAILVIEWSTYLE and ACDBSECTIONVIEWSTYLE from the joint-boundary
+  search — 33 further records, all four release bands, delta 0 on every
+  one (ARCHITECTURE.md §7d.3, §7d.4).
   ACAD_MATERIAL reads only its strings and its measured bit budget —
   its data-field layout is not determined.
 
@@ -207,8 +211,8 @@ scrolling the changelog.
 These have genuine open scope requiring focused work, not stubs.
 
 - **Current real-file decode baseline:** the 2026-08-30
-  `examples/coverage_report.rs ../../samples` run reports 2105 decoded,
-  234 skipped, 39 errored, 88.5% aggregate coverage. This is the
+  `examples/coverage_report.rs ../../samples` run reports 2148 decoded,
+  191 skipped, 39 errored, 90.3% aggregate coverage. This is the
   practical product-readiness blocker even though synthetic decoder
   tests are broad.
 
@@ -218,15 +222,17 @@ These have genuine open scope requiring focused work, not stubs.
   `TV` fields from the R2007+ string stream and checking their data
   fields end exactly on the record's data-stream boundary.
   VISUALSTYLE dispatches on R2010, R2013 and R2018 — 168 of its 240
-  corpus records — and LAYOUT (with its embedded PLOTSETTINGS block)
-  dispatches on all 31 of its corpus records. Still unreached, in
-  descending record count on the corpus (counts as of the 2026-08-30
-  run): VISUALSTYLE on R2004/R2007 (72 records), MATERIAL (30),
-  ACDBDETAILVIEWSTYLE (11), ACDBSECTIONVIEWSTYLE (11), MLEADERSTYLE
-  (11), MLINESTYLE (10), TABLESTYLE (10). MATERIAL and
-  PROPERTYSET_DATA decode only a documented prefix of their fields, so
-  they cannot satisfy the boundary check; MLINESTYLE has a field list
-  this crate has not yet matched against real bytes.
+  corpus records — LAYOUT (with its embedded PLOTSETTINGS block)
+  dispatches on all 31 of its corpus records, and MLINESTYLE (10),
+  MLEADERSTYLE (11), ACDBDETAILVIEWSTYLE (11) and
+  ACDBSECTIONVIEWSTYLE (11) dispatch on all of theirs. Still
+  unreached, in descending record count on the corpus (counts as of
+  the 2026-08-30 run): VISUALSTYLE on R2004/R2007 (72 records),
+  MATERIAL (38), TABLESTYLE (10). MATERIAL and PROPERTYSET_DATA decode
+  only a documented prefix of their fields, so they cannot satisfy the
+  boundary check; TABLESTYLE's block structure is measured
+  (ARCHITECTURE.md §7d.4) but a single record per corpus file cannot
+  pin the token sequence inside its cell-style blocks.
 
 - **R2018 entity preamble for custom-class entities** (surfaced by
   #37). With the class table resolving on `sample_AC1032.dwg`, its

--- a/examples/probe_field_list.rs
+++ b/examples/probe_field_list.rs
@@ -115,6 +115,8 @@ fn main() -> Result<()> {
         let _ = c.read_b()?;
     }
     if matches!(version, Version::R2013 | Version::R2018) && c.read_b()? {
+        // 16 bits, measured — see `crate::objects::modern`.
+        let _ = c.read_rc()?;
         let _ = c.read_rc()?;
     }
 

--- a/examples/probe_object_layout.rs
+++ b/examples/probe_object_layout.rs
@@ -107,6 +107,8 @@ fn main() -> Result<()> {
             if matches!(version, dwg::Version::R2013 | dwg::Version::R2018) {
                 let has_binary = c.read_b().ok()?;
                 if has_binary {
+                    // 16 bits, measured — see `crate::objects::modern`.
+                    c.read_rc().ok()?;
                     c.read_rc().ok()?;
                 }
             }

--- a/examples/probe_token_scan.rs
+++ b/examples/probe_token_scan.rs
@@ -1,0 +1,139 @@
+//! Where are the anchors in a record whose field list is unknown?
+//!
+//! # What this proves
+//!
+//! A field list derived from bytes alone needs anchor points: bit
+//! offsets that can only plausibly be one thing. Two token forms are
+//! self-identifying because they carry redundancy the surrounding bits
+//! do not:
+//!
+//! - a full-form `BD` (2-bit prefix `00` then eight IEEE-754 bytes)
+//!   whose value comes out as a short decimal — `0.09`, `0.18`, `1.5`,
+//!   `45` — rather than a denormal or a 1e+240;
+//! - a `CMC` whose true-colour `BL` word carries one of the colour
+//!   method octets in its top byte (`0xC0` ByLayer, `0xC1` ByBlock,
+//!   `0xC2` RGB, `0xC3` ACI index, `0xC8` none) and a colour byte
+//!   below 4.
+//!
+//! Neither pattern survives a one-bit misalignment, so every hit is a
+//! candidate field start, and the gaps between hits are what a
+//! candidate token sequence has to fill exactly. Combined with the
+//! data-stream boundary the record itself carries
+//! (`dwg::object::data_end_bit`), that is enough to derive a field list
+//! for an object the ODA specification does not prescribe.
+//!
+//! ```sh
+//! cargo run --release --example probe_token_scan -- samples/arc_2013.dwg 107
+//! ```
+//!
+//! The scan covers the record's whole data stream, so it reports hits
+//! that are coincidence as well as hits that are fields; a hit is
+//! evidence only once a token sequence reaches it exactly.
+
+use dwg::bitcursor::BitCursor;
+use dwg::error::Result;
+use dwg::{DwgFile, Version};
+
+/// Advance `c` to absolute bit `bit` (the cursor has no random access).
+fn skip_to(c: &mut BitCursor<'_>, bit: usize) -> Result<()> {
+    while c.position_bits() < bit {
+        let _ = c.read_b()?;
+    }
+    Ok(())
+}
+
+/// Is `v` the kind of double a CAD author would have typed?
+fn is_nice_double(v: f64) -> bool {
+    if !v.is_finite() {
+        return false;
+    }
+    if v == 0.0 {
+        return true;
+    }
+    let a = v.abs();
+    if !(1e-4..=1e7).contains(&a) {
+        return false;
+    }
+    // Round-trips through five decimals — excludes the 0.10000000149
+    // style noise a misaligned read produces.
+    (v * 1e5).round() / 1e5 == v || format!("{v:.6}").parse::<f64>() == Ok(v)
+}
+
+/// Colour method octets a real `CMC` true-colour word carries.
+fn is_color_method(rgb: u32) -> bool {
+    matches!(rgb >> 24, 0xC0 | 0xC1 | 0xC2 | 0xC3 | 0xC5 | 0xC8)
+}
+
+fn main() -> Result<()> {
+    let mut args = std::env::args().skip(1);
+    let path = args.next().expect("usage: <file.dwg> <handle>");
+    let handle: u64 = args
+        .next()
+        .expect("usage: <file.dwg> <handle>")
+        .parse()
+        .expect("handle must be decimal");
+
+    let file = DwgFile::open(&path)?;
+    let version = file.version();
+    let objects = file
+        .all_objects()
+        .expect("this version has no object-stream walk")?;
+    let object = objects
+        .iter()
+        .find(|o| o.handle.value == handle)
+        .unwrap_or_else(|| panic!("no object with handle {handle}"));
+
+    let body = dwg::object::body_cursor(object, version)?.position_bits();
+    let end = dwg::object::data_end_bit(object, version).expect("record has no data-stream end");
+    println!("{path}  ({version})  handle {handle}");
+    println!("body starts at bit {body}, data stream ends at {end}");
+
+    for at in body..end {
+        let mut c = BitCursor::new(&object.raw);
+        if skip_to(&mut c, at).is_err() {
+            break;
+        }
+        if let Ok(v) = c.read_bd() {
+            if c.position_bits() == at + 66 && is_nice_double(v) {
+                println!("  @{at:<6} BD  {v}");
+            }
+        }
+        let mut c = BitCursor::new(&object.raw);
+        if skip_to(&mut c, at).is_err() {
+            break;
+        }
+        let cmc = (|| -> Result<(u16, u32, u8)> {
+            let index = c.read_bs_u()?;
+            if !version.is_r2004_plus() {
+                return Ok((index, 0, 0));
+            }
+            let rgb = c.read_bl_u()?;
+            let flag = c.read_rc()?;
+            Ok((index, rgb, flag))
+        })();
+        if let Ok((index, rgb, flag)) = cmc {
+            if is_color_method(rgb) && flag < 4 && index < 8 {
+                println!(
+                    "  @{at:<6} CMC index {index} rgb {rgb:#010X} flag {flag} (w{})",
+                    c.position_bits() - at
+                );
+            }
+        }
+    }
+
+    if version.is_r2010_plus() {
+        let mut strings = Vec::new();
+        if let Some(stream) = dwg::string_stream::locate(&object.raw, version) {
+            let mut r = dwg::string_stream::StringReader::new(&object.raw, stream)?;
+            while !r.is_exhausted() {
+                match r.read_tv() {
+                    Ok(s) => strings.push(s),
+                    Err(_) => break,
+                }
+            }
+        }
+        println!("strings: {strings:?}");
+    }
+    let _ = Version::R2018;
+    Ok(())
+}

--- a/src/entities/dispatch.rs
+++ b/src/entities/dispatch.rs
@@ -115,6 +115,10 @@ pub enum DecodedEntity {
     VisualStyle(crate::objects::acad_visual_style::AcadVisualStyle),
     Layout(Box<crate::objects::acad_layout::AcadLayout>),
     PlotSettings(crate::objects::acad_plot_settings::AcadPlotSettings),
+    MLineStyle(crate::objects::acad_mlinestyle::AcadMlinestyle),
+    MLeaderStyle(Box<crate::objects::acad_mleader_style::AcadMLeaderStyle>),
+    DetailViewStyle(Box<crate::objects::acad_detail_view_style::AcadDetailViewStyle>),
+    SectionViewStyle(Box<crate::objects::acad_section_view_style::AcadSectionViewStyle>),
     ImageDef(crate::entities::imagedef::ImageDef),
     /// One of the ten `*_CONTROL` table owners; `kind` says which.
     Control {
@@ -210,6 +214,7 @@ impl DecodedEntity {
             Self::Placeholder(_) => OBJECT_TYPE_ACDB_PLACEHOLDER,
             Self::Group(_) => OBJECT_TYPE_GROUP,
             Self::Layout(_) => OBJECT_TYPE_LAYOUT,
+            Self::MLineStyle(_) => OBJECT_TYPE_MLINESTYLE,
             // DICTIONARYVAR and SCALE are custom classes — their codes
             // vary per file via AcDb:Classes. Return 0 so callers know
             // to consult the class map.
@@ -217,7 +222,10 @@ impl DecodedEntity {
             | Self::Scale(_)
             | Self::ImageDef(_)
             | Self::VisualStyle(_)
-            | Self::PlotSettings(_) => 0,
+            | Self::PlotSettings(_)
+            | Self::MLeaderStyle(_)
+            | Self::DetailViewStyle(_)
+            | Self::SectionViewStyle(_) => 0,
             Self::Control { kind, .. } => control_type_code(*kind),
             Self::Unhandled { type_code, .. } | Self::Error { type_code, .. } => *type_code,
         }
@@ -292,6 +300,7 @@ const OBJECT_TYPE_GROUP: u16 = 0x48; // 72
 const OBJECT_TYPE_XRECORD: u16 = 0x4F; // 79
 const OBJECT_TYPE_ACDB_PLACEHOLDER: u16 = 0x50; // 80
 const OBJECT_TYPE_LAYOUT: u16 = 0x52; // 82
+const OBJECT_TYPE_MLINESTYLE: u16 = 0x49; // 73
 
 const OBJECT_TYPE_CAMERA: u16 = 0x4F8; // 1272
 const OBJECT_TYPE_SUN: u16 = 0x4F9; // 1273
@@ -522,6 +531,7 @@ fn dispatch_object(
             | ObjectType::AcDbPlaceholder
             | ObjectType::Group
             | ObjectType::Layout
+            | ObjectType::MLineStyle
     ) || kind.is_control();
     if !has_decoder {
         return DecodedEntity::Unhandled { type_code, kind };
@@ -571,6 +581,11 @@ fn dispatch_object(
                 Err(e) => Err(e.to_string()),
             }
         }
+        ObjectType::MLineStyle => {
+            crate::objects::acad_mlinestyle::decode_object(payload, body_start, inline_end, version)
+                .map(DecodedEntity::MLineStyle)
+                .map_err(|e| e.to_string())
+        }
         k if k.is_control() => control::decode_object(payload, body_start, inline_end, version, k)
             .map(|control| DecodedEntity::Control { kind: k, control })
             .map_err(|e| e.to_string()),
@@ -617,6 +632,22 @@ fn dispatch_object_class(
             payload, body_start, inline_end, version,
         )
         .map(DecodedEntity::PlotSettings),
+        "MLEADERSTYLE" | "ACDBMLEADERSTYLE" => crate::objects::acad_mleader_style::decode_object(
+            payload, body_start, inline_end, version,
+        )
+        .map(|style| DecodedEntity::MLeaderStyle(Box::new(style))),
+        "ACDBDETAILVIEWSTYLE" | "DETAILVIEWSTYLE" => {
+            crate::objects::acad_detail_view_style::decode_object(
+                payload, body_start, inline_end, version,
+            )
+            .map(|style| DecodedEntity::DetailViewStyle(Box::new(style)))
+        }
+        "ACDBSECTIONVIEWSTYLE" | "SECTIONVIEWSTYLE" => {
+            crate::objects::acad_section_view_style::decode_object(
+                payload, body_start, inline_end, version,
+            )
+            .map(|style| DecodedEntity::SectionViewStyle(Box::new(style)))
+        }
         "DICTIONARYVAR" | "ACDBDICTIONARYVAR" => {
             crate::objects::dictionary_var::decode_object(payload, body_start, inline_end, version)
                 .map(DecodedEntity::DictionaryVar)
@@ -1066,8 +1097,8 @@ mod tests {
         let raw = RawObject {
             stream_offset: 0,
             size_bytes: 0,
-            type_code: 0x49,
-            kind: ObjectType::MLineStyle, // non-entity, no decoder
+            type_code: 0x51,
+            kind: ObjectType::VbaProject, // non-entity, no decoder
             handle: crate::bitcursor::Handle {
                 code: 0,
                 counter: 0,

--- a/src/objects/acad_detail_view_style.rs
+++ b/src/objects/acad_detail_view_style.rs
@@ -1,0 +1,358 @@
+//! ACDBDETAILVIEWSTYLE object — the style record behind a model
+//! documentation *detail view* (identifier symbol, detail boundary,
+//! connection line, view label).
+//!
+//! # There is no spec prescription for this object
+//!
+//! The ODA *Open Design Specification for .dwg files* v5.4.1 has **no
+//! §20.4 entry** for `ACDBDETAILVIEWSTYLE`; its object-prescription
+//! chapter runs from `20.4.1 Common Entity Data` to `20.4.104 XRECORD`
+//! and stops. The field list below was derived by measuring real
+//! records against the boundary the format itself provides.
+//!
+//! # The wire shape — measured
+//!
+//! ```text
+//! BS   unknown_head
+//! TV   name
+//! TV   name_alias                    -- R2018 only
+//! B    unknown_flag_a                -- R2018 only
+//! B    unknown_flag_b                -- R2018 only
+//! BS   flags                         -- 32 in every corpus record
+//! B    flag_c   B    flag_d   B    flag_e
+//! CMC  identifier_color              BD   identifier_height
+//! TV   identifier_symbol             BD   identifier_offset
+//! RC   identifier_placement
+//! CMC  arrow_symbol_color            BD   arrow_symbol_size
+//! BS   boundary_line_weight          CMC  boundary_line_color
+//! CMC  connection_line_color         BD   view_label_text_height
+//! BS   view_label_position           BD   view_label_offset
+//! BS   view_label_attachment         TV   view_label_pattern
+//! BS   connection_line_weight        CMC  view_label_color
+//! BS   model_edge_line_weight        CMC  model_edge_color
+//! RC   trailing_flags
+//! ```
+//!
+//! `H` fields (the text style, the arrow block, the linetypes) live in
+//! the handle stream and cost no data-stream bits, so they do not
+//! appear; this is the data stream only.
+//!
+//! # Why this is not a guess
+//!
+//! Every record's data fields have to end exactly on the first bit of
+//! its string stream (R2010+) or on its `RL` object-data-size (R2004) —
+//! the boundary `objects::modern::ObjectStream::finish` enforces. The
+//! list above closes **all eleven** ACDBDETAILVIEWSTYLE records of the
+//! corpus with delta 0:
+//!
+//! | Release | Records | Budget | Delta |
+//! |---|---|---|---|
+//! | R2004 | 3 (`{arc,circle,line}_2004.dwg` handle 107) | 1209 | 0 |
+//! | R2010 | 3 (`*_2010.dwg` handle 107) | 667 | 0 |
+//! | R2013 | 3 (`*_2013.dwg` handle 107) | 667 | 0 |
+//! | R2018 | 2 (`sample_AC1032.dwg` handles 428, 924) | 677 / 605 | 0 |
+//!
+//! The two R2018 records are the discriminating evidence. `Imperial24`
+//! (handle 428) and `Metric50` (handle 924) differ by 72 bits, and the
+//! field list accounts for the difference exactly: `Imperial24` writes
+//! `view_label_position` in the 10-bit `BS` byte form where `Metric50`
+//! writes the 2-bit zero form (+10), and writes a full 66-bit `BD` in
+//! the `identifier_offset` slot where `Metric50` writes the 2-bit zero
+//! form (+64), less the 2 bits the zero form still costs. Only one
+//! placement of the two extra R2018 head bits survives both records:
+//! putting them *after* the leading `BS` keeps `flags` reading `32` —
+//! the value R2004, R2010 and R2013 all carry — while putting them
+//! before it turns `flags` into `72` and desynchronises the first
+//! `CMC` on both records.
+//!
+//! Corroboration from the decoded values:
+//!
+//! - `identifier_height`, `arrow_symbol_size` and
+//!   `view_label_text_height` decode `5` on every `Metric50` record and
+//!   `0.24` on every `Imperial24` record — the shipped text heights of
+//!   AutoCAD's two view-style presets;
+//! - `view_label_offset` decodes `15` (metric) / `0.75` (imperial);
+//! - `boundary_line_weight`, `connection_line_weight` and
+//!   `model_edge_line_weight` all decode `25` — 0.25 mm in the DWG
+//!   hundredths-of-a-millimetre lineweight encoding;
+//! - all five `CMC` slots decode true-colour word `0xC0000000`, the
+//!   ByLayer method octet;
+//! - `view_label_pattern` decodes AutoCAD's field expression
+//!   `%<\AcVar ViewDetailId>% (%<\AcVar ViewScale \f "%sn">%)` on the
+//!   metric records, and the `ViewType`-prefixed imperial variant on
+//!   the others — and it decodes there *because* the field list places
+//!   an inline `TV` at exactly that offset on R2004, where the string
+//!   costs 458 data-stream bits.
+//!
+//! # Naming
+//!
+//! The field **types, widths and order** are measured. The **names**
+//! follow the vocabulary of AutoCAD's Detail View Style dialog
+//! (published product documentation — see `CLEANROOM.md`) applied in
+//! wire order. The identifier, arrow, lineweight and view-label slots
+//! are corroborated by the values above; the `unknown_*` and `flag_*`
+//! slots are positional labels for slots whose layout is proven and
+//! whose meaning is not. Treat them accordingly.
+
+use crate::error::Result;
+use crate::objects::color::{self, ObjectColor};
+use crate::objects::modern;
+use crate::version::Version;
+
+/// A decoded ACDBDETAILVIEWSTYLE record.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AcadDetailViewStyle {
+    /// Leading `BS`; `0` in every corpus record. Positional name.
+    pub unknown_head: i16,
+    /// Style name.
+    pub name: String,
+    /// Second name `TV`, R2018 only; repeats [`name`](Self::name) in
+    /// both corpus records.
+    pub name_alias: String,
+    /// R2018-only leading flag. Positional name.
+    pub unknown_flag_a: bool,
+    /// R2018-only leading flag. Positional name.
+    pub unknown_flag_b: bool,
+    /// Style flag word; `32` in every corpus record.
+    pub flags: i16,
+    /// Positional name.
+    pub flag_c: bool,
+    /// Positional name.
+    pub flag_d: bool,
+    /// Positional name.
+    pub flag_e: bool,
+    /// Identifier text colour.
+    pub identifier_color: ObjectColor,
+    /// Identifier text height.
+    pub identifier_height: f64,
+    /// Identifier symbol string; empty in every corpus record.
+    pub identifier_symbol: String,
+    /// Identifier offset from the boundary.
+    pub identifier_offset: f64,
+    /// Identifier placement selector.
+    pub identifier_placement: u8,
+    /// Arrow symbol colour.
+    pub arrow_symbol_color: ObjectColor,
+    /// Arrow symbol size.
+    pub arrow_symbol_size: f64,
+    /// Detail-boundary lineweight, hundredths of a millimetre.
+    pub boundary_line_weight: i16,
+    /// Detail-boundary colour.
+    pub boundary_line_color: ObjectColor,
+    /// Connection-line colour.
+    pub connection_line_color: ObjectColor,
+    /// View-label text height.
+    pub view_label_text_height: f64,
+    /// View-label position selector (positional name).
+    pub view_label_position: i16,
+    /// View-label offset.
+    pub view_label_offset: f64,
+    /// View-label attachment selector (positional name).
+    pub view_label_attachment: i16,
+    /// View-label field expression.
+    pub view_label_pattern: String,
+    /// Connection-line lineweight, hundredths of a millimetre.
+    pub connection_line_weight: i16,
+    /// View-label colour.
+    pub view_label_color: ObjectColor,
+    /// Model-edge lineweight, hundredths of a millimetre.
+    pub model_edge_line_weight: i16,
+    /// Model-edge colour.
+    pub model_edge_color: ObjectColor,
+    /// Trailing `RC`; `0` in every corpus record. Positional name.
+    pub trailing_flags: u8,
+}
+
+/// Decode an ACDBDETAILVIEWSTYLE straight from its raw object payload,
+/// taking its `TV` fields from the R2007+ string stream and checking
+/// that the data fields end exactly on the data-stream boundary.
+pub fn decode_object(
+    payload: &[u8],
+    body_start: usize,
+    inline_data_end: Option<usize>,
+    version: Version,
+) -> Result<AcadDetailViewStyle> {
+    let mut s = modern::open(payload, body_start, inline_data_end, version)?;
+    let r2018 = matches!(version, Version::R2018);
+    let unknown_head = s.data.read_bs()?;
+    let name = modern::read_tv(&mut s.data, &mut s.strings, version)?;
+    let (name_alias, unknown_flag_a, unknown_flag_b) = if r2018 {
+        (
+            modern::read_tv(&mut s.data, &mut s.strings, version)?,
+            s.data.read_b()?,
+            s.data.read_b()?,
+        )
+    } else {
+        (String::new(), false, false)
+    };
+    let flags = s.data.read_bs()?;
+    let flag_c = s.data.read_b()?;
+    let flag_d = s.data.read_b()?;
+    let flag_e = s.data.read_b()?;
+    let identifier_color = color::read(&mut s.data, &mut s.strings, version)?;
+    let identifier_height = s.data.read_bd()?;
+    let identifier_symbol = modern::read_tv(&mut s.data, &mut s.strings, version)?;
+    let identifier_offset = s.data.read_bd()?;
+    let identifier_placement = s.data.read_rc()?;
+    let arrow_symbol_color = color::read(&mut s.data, &mut s.strings, version)?;
+    let arrow_symbol_size = s.data.read_bd()?;
+    let boundary_line_weight = s.data.read_bs()?;
+    let boundary_line_color = color::read(&mut s.data, &mut s.strings, version)?;
+    let connection_line_color = color::read(&mut s.data, &mut s.strings, version)?;
+    let view_label_text_height = s.data.read_bd()?;
+    let view_label_position = s.data.read_bs()?;
+    let view_label_offset = s.data.read_bd()?;
+    let view_label_attachment = s.data.read_bs()?;
+    let view_label_pattern = modern::read_tv(&mut s.data, &mut s.strings, version)?;
+    let connection_line_weight = s.data.read_bs()?;
+    let view_label_color = color::read(&mut s.data, &mut s.strings, version)?;
+    let model_edge_line_weight = s.data.read_bs()?;
+    let model_edge_color = color::read(&mut s.data, &mut s.strings, version)?;
+    let trailing_flags = s.data.read_rc()?;
+    s.finish("ACDBDETAILVIEWSTYLE")?;
+    Ok(AcadDetailViewStyle {
+        unknown_head,
+        name,
+        name_alias,
+        unknown_flag_a,
+        unknown_flag_b,
+        flags,
+        flag_c,
+        flag_d,
+        flag_e,
+        identifier_color,
+        identifier_height,
+        identifier_symbol,
+        identifier_offset,
+        identifier_placement,
+        arrow_symbol_color,
+        arrow_symbol_size,
+        boundary_line_weight,
+        boundary_line_color,
+        connection_line_color,
+        view_label_text_height,
+        view_label_position,
+        view_label_offset,
+        view_label_attachment,
+        view_label_pattern,
+        connection_line_weight,
+        view_label_color,
+        model_edge_line_weight,
+        model_edge_color,
+        trailing_flags,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bitwriter::BitWriter;
+
+    const LABEL: &str = "%<\\AcVar ViewDetailId>%";
+
+    fn cmc(w: &mut BitWriter) {
+        w.write_bs_u(0);
+        w.write_bl_u(0xC000_0000);
+        w.write_rc(0);
+    }
+
+    /// Write the `Metric50` field list; `inline_strings` selects the
+    /// pre-R2007 layout, where the three `TV` slots consume data bits.
+    fn write_body(w: &mut BitWriter, version: Version, inline_strings: bool) {
+        let r2018 = matches!(version, Version::R2018);
+        w.write_bs(0);
+        if inline_strings {
+            modern::tests::write_inline_tv(w, "Metric50");
+        }
+        if r2018 {
+            w.write_b(false);
+            w.write_b(true);
+        }
+        w.write_bs(32);
+        w.write_b(false);
+        w.write_b(true);
+        w.write_b(true);
+        cmc(w);
+        w.write_bd(5.0);
+        if inline_strings {
+            modern::tests::write_inline_tv(w, "");
+        }
+        w.write_bd(0.36);
+        w.write_rc(1);
+        cmc(w);
+        w.write_bd(5.0);
+        w.write_bs(25);
+        cmc(w);
+        cmc(w);
+        w.write_bd(5.0);
+        w.write_bs(0);
+        w.write_bd(15.0);
+        w.write_bs(1);
+        if inline_strings {
+            modern::tests::write_inline_tv(w, LABEL);
+        }
+        w.write_bs(25);
+        cmc(w);
+        w.write_bs(25);
+        cmc(w);
+        w.write_rc(0);
+    }
+
+    fn build(version: Version) -> Vec<u8> {
+        let mut w = modern::tests::r2018_object_prefix(1);
+        write_body(&mut w, version, false);
+        let bits = crate::string_stream::tests::bits_of(&w);
+        let strings: Vec<&str> = if matches!(version, Version::R2018) {
+            vec!["Metric50", "Metric50", "", LABEL]
+        } else {
+            vec!["Metric50", "", LABEL]
+        };
+        crate::string_stream::tests::build_payload(&bits, &strings)
+    }
+
+    #[test]
+    fn r2018_detail_view_style_closes_on_its_string_stream() {
+        let payload = build(Version::R2018);
+        let s = decode_object(&payload, 8, None, Version::R2018).unwrap();
+        assert_eq!(s.name, "Metric50");
+        assert_eq!(s.name_alias, "Metric50");
+        assert_eq!(s.flags, 32);
+        assert_eq!(s.identifier_height, 5.0);
+        assert_eq!(s.arrow_symbol_size, 5.0);
+        assert_eq!(s.view_label_text_height, 5.0);
+        assert_eq!(s.view_label_offset, 15.0);
+        assert_eq!(s.boundary_line_weight, 25);
+        assert_eq!(s.connection_line_weight, 25);
+        assert_eq!(s.model_edge_line_weight, 25);
+        assert_eq!(s.identifier_color.method(), 0xC0);
+        assert_eq!(s.model_edge_color.method(), 0xC0);
+        assert_eq!(s.view_label_pattern, LABEL);
+        assert_eq!(s.trailing_flags, 0);
+    }
+
+    #[test]
+    fn r2013_detail_view_style_has_no_r2018_head() {
+        let payload = build(Version::R2013);
+        let s = decode_object(&payload, 8, None, Version::R2013).unwrap();
+        assert_eq!(s.name, "Metric50");
+        assert_eq!(s.name_alias, "");
+        assert!(!s.unknown_flag_a && !s.unknown_flag_b);
+        assert_eq!(s.flags, 32);
+        // The two extra R2018 head bits are not optional.
+        assert!(decode_object(&payload, 8, None, Version::R2018).is_err());
+    }
+
+    /// The R2004 layout: three inline `TV` fields, closing on the `RL`
+    /// object-data-size boundary.
+    #[test]
+    fn r2004_detail_view_style_reads_its_strings_inline() {
+        let mut w = modern::tests::r2004_object_prefix(1);
+        write_body(&mut w, Version::R2004, true);
+        let end = w.position_bits();
+        let bytes = w.into_bytes();
+        let s = decode_object(&bytes, 0, Some(end), Version::R2004).unwrap();
+        assert_eq!(s.name, "Metric50");
+        assert_eq!(s.view_label_pattern, LABEL);
+        assert_eq!(s.identifier_height, 5.0);
+    }
+}

--- a/src/objects/acad_mleader_style.rs
+++ b/src/objects/acad_mleader_style.rs
@@ -1,0 +1,441 @@
+//! MLEADERSTYLE object — the style record behind the MULTILEADER
+//! entity (leader geometry, landing, arrowhead, text and block content).
+//!
+//! # There is no spec prescription for this object
+//!
+//! The ODA *Open Design Specification for .dwg files* v5.4.1 lists
+//! `MLEADERSTYLE` among the classes a drawing registers in
+//! `AcDb:Classes`, but its object-prescription chapter §20.4 runs from
+//! `20.4.1 Common Entity Data` to `20.4.104 XRECORD` and carries **no
+//! entry** for it. Everything below was derived by measuring real
+//! records against the boundary the format itself provides.
+//!
+//! # The wire shape — measured
+//!
+//! ```text
+//! BS   version                       -- R2010+ only
+//! BS   content_type                  BS   draw_mleader_order_type
+//! BS   draw_leader_order_type        BS   max_leader_segment_points
+//! BD   first_segment_angle           BD   second_segment_angle
+//! BS   leader_line_type              CMC  leader_line_color
+//! BL   leader_lineweight             B    enable_landing
+//! BD   landing_gap                   B    enable_dogleg
+//! BD   dogleg_length                 TV   description
+//! BD   arrowhead_size                TV   default_mtext_contents
+//! BS   text_left_attachment          BS   text_right_attachment
+//! BS   text_angle_type               BS   text_alignment_type
+//! CMC  text_color                    BD   text_height
+//! B    enable_frame_text             B    text_align_always_left
+//! BD   align_space                   CMC  block_content_color
+//! BD   block_content_scale_x         BD   block_content_scale_y
+//! BD   block_content_scale_z         B    enable_block_content_scale
+//! BD   block_content_rotation        B    enable_block_content_rotation
+//! BS   block_content_connection      BD   scale
+//! B    overwrite_property_value      B    is_annotative
+//! BD   break_gap_size
+//! BS   text_attachment_direction     -- R2010+ only
+//! BS   bottom_text_attachment_dir    -- R2010+ only
+//! BS   top_text_attachment_dir       -- R2010+ only
+//! B    extended_flag                 -- R2013+ only
+//! ```
+//!
+//! `H` fields (leader linetype, arrow head, text style, block content)
+//! live in the handle stream and cost no data-stream bits, so they do
+//! not appear above; the field list is the data stream only.
+//!
+//! # Why this is not a guess
+//!
+//! Every record's data fields have to end exactly on the first bit of
+//! its string stream (R2010+) or on its `RL` object-data-size (R2004),
+//! the boundary `objects::modern::ObjectStream::finish` enforces. The
+//! list above closes **all eleven** MLEADERSTYLE records of the corpus
+//! with delta 0:
+//!
+//! | Release | Records | Budget | Delta |
+//! |---|---|---|---|
+//! | R2004 | 3 (`{arc,circle,line}_2004.dwg` handle 103) | 744 | 0 |
+//! | R2010 | 3 (`*_2010.dwg` handle 103) | 692 | 0 |
+//! | R2013 | 3 (`*_2013.dwg` handle 103) | 693 | 0 |
+//! | R2018 | 2 (`sample_AC1032.dwg` handles 216, 229) | 693 / 749 | 0 |
+//!
+//! The three version switches are measured, not assumed. R2004 is
+//! exactly one 10-bit `BS` shorter at the head and 22 bits shorter at
+//! the tail than R2010; R2010 is exactly one bit shorter than R2013,
+//! and the R2018 records reproduce the R2013 length.
+//!
+//! Corroboration from the decoded values of the `Standard` style — the
+//! only style all four releases carry:
+//!
+//! - `leader_line_color`, `text_color` and `block_content_color` all
+//!   decode as true-colour word `0xC1000000`, the ByBlock method octet;
+//! - `leader_lineweight` decodes `-2`, the ByBlock lineweight sentinel;
+//! - `landing_gap` decodes `0.09`, `dogleg_length` `0.36`,
+//!   `arrowhead_size` `0.18`, `text_height` `0.18`, `break_gap_size`
+//!   `0.125` — AutoCAD's shipped defaults for the `Standard` multileader
+//!   style, to the last digit;
+//! - the three block-content scales decode `1`, `1`, `1` and the
+//!   overall `scale` `1`;
+//! - `max_leader_segment_points` decodes `2` and both segment angle
+//!   constraints `0`.
+//!
+//! A field list off by one bit reproduces none of that.
+//!
+//! # Naming
+//!
+//! The field **types, widths and order** above are measured. The
+//! **names** follow the conventional `AcDbMLeaderStyle` property
+//! ordering as recalled from Autodesk's public *DXF Reference*
+//! (published documentation — see `CLEANROOM.md`); the values listed
+//! above corroborate the leader, landing, arrowhead, text-height and
+//! block-scale slots, while the attachment and flag slots are
+//! positional labels. Treat them as labels for slots whose layout is
+//! proven, not as verified semantics.
+//!
+//! # Versions
+//!
+//! R2004 through R2018 all decode. R13-R2000 are not reachable by this
+//! crate's object walker, and MLEADERSTYLE post-dates them.
+
+use crate::error::Result;
+use crate::objects::color::{self, ObjectColor};
+use crate::objects::modern;
+use crate::version::Version;
+
+/// A decoded MLEADERSTYLE record.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AcadMLeaderStyle {
+    /// Style-format version; `2` in every record measured. R2010+ only,
+    /// `0` on older releases which do not store it.
+    pub version: i16,
+    /// Content kind (`2` = mtext on the shipped `Standard` style).
+    pub content_type: i16,
+    /// Multileader draw-order selector.
+    pub draw_mleader_order_type: i16,
+    /// Leader draw-order selector.
+    pub draw_leader_order_type: i16,
+    /// Maximum number of leader segment points.
+    pub max_leader_segment_points: i32,
+    /// First segment angle constraint, radians.
+    pub first_segment_angle: f64,
+    /// Second segment angle constraint, radians.
+    pub second_segment_angle: f64,
+    /// Leader line kind (`1` = straight on the shipped style).
+    pub leader_line_type: i16,
+    /// Leader line colour.
+    pub leader_line_color: ObjectColor,
+    /// Leader lineweight; `-2` is ByBlock.
+    pub leader_lineweight: i32,
+    /// Whether the leader ends in a landing.
+    pub enable_landing: bool,
+    /// Gap between the landing and the content.
+    pub landing_gap: f64,
+    /// Whether the leader has a dogleg.
+    pub enable_dogleg: bool,
+    /// Dogleg length.
+    pub dogleg_length: f64,
+    /// Style description.
+    pub description: String,
+    /// Arrowhead size.
+    pub arrowhead_size: f64,
+    /// Default MTEXT contents for new multileaders.
+    pub default_mtext_contents: String,
+    /// Text attachment on the left (positional name).
+    pub text_left_attachment: i16,
+    /// Text attachment on the right (positional name).
+    pub text_right_attachment: i16,
+    /// Text angle selector (positional name).
+    pub text_angle_type: i16,
+    /// Text alignment selector (positional name).
+    pub text_alignment_type: i16,
+    /// Text colour.
+    pub text_color: ObjectColor,
+    /// Text height.
+    pub text_height: f64,
+    /// Whether the text is framed.
+    pub enable_frame_text: bool,
+    /// Whether text is always aligned left (positional name).
+    pub text_align_always_left: bool,
+    /// Alignment space.
+    pub align_space: f64,
+    /// Block-content colour.
+    pub block_content_color: ObjectColor,
+    /// Block-content scale, X.
+    pub block_content_scale_x: f64,
+    /// Block-content scale, Y.
+    pub block_content_scale_y: f64,
+    /// Block-content scale, Z.
+    pub block_content_scale_z: f64,
+    /// Whether the block-content scale is honoured.
+    pub enable_block_content_scale: bool,
+    /// Block-content rotation, radians.
+    pub block_content_rotation: f64,
+    /// Whether the block-content rotation is honoured.
+    pub enable_block_content_rotation: bool,
+    /// Block-content connection selector (positional name).
+    pub block_content_connection_type: i16,
+    /// Overall style scale.
+    pub scale: f64,
+    /// Overwrite-property flag (positional name).
+    pub overwrite_property_value: bool,
+    /// Annotative flag (positional name).
+    pub is_annotative: bool,
+    /// Break gap size.
+    pub break_gap_size: f64,
+    /// Text attachment direction (positional name). R2010+ only.
+    pub text_attachment_direction: i16,
+    /// Bottom text attachment direction (positional name). R2010+ only.
+    pub bottom_text_attachment_direction: i16,
+    /// Top text attachment direction (positional name). R2010+ only.
+    pub top_text_attachment_direction: i16,
+    /// The single further flag R2013 added at the tail; its meaning is
+    /// not determined. `false` on releases that do not store it.
+    pub extended_flag: bool,
+}
+
+/// Decode an MLEADERSTYLE straight from its raw object payload, taking
+/// its `TV` fields from the R2007+ string stream and checking that the
+/// data fields end exactly on the data-stream boundary.
+pub fn decode_object(
+    payload: &[u8],
+    body_start: usize,
+    inline_data_end: Option<usize>,
+    version: Version,
+) -> Result<AcadMLeaderStyle> {
+    let mut s = modern::open(payload, body_start, inline_data_end, version)?;
+    let has_version = version.is_r2010_plus();
+    let style_version = if has_version { s.data.read_bs()? } else { 0 };
+    let content_type = s.data.read_bs()?;
+    let draw_mleader_order_type = s.data.read_bs()?;
+    let draw_leader_order_type = s.data.read_bs()?;
+    let max_leader_segment_points = s.data.read_bl()?;
+    let first_segment_angle = s.data.read_bd()?;
+    let second_segment_angle = s.data.read_bd()?;
+    let leader_line_type = s.data.read_bs()?;
+    let leader_line_color = color::read(&mut s.data, &mut s.strings, version)?;
+    let leader_lineweight = s.data.read_bl()?;
+    let enable_landing = s.data.read_b()?;
+    let landing_gap = s.data.read_bd()?;
+    let enable_dogleg = s.data.read_b()?;
+    let dogleg_length = s.data.read_bd()?;
+    let description = modern::read_tv(&mut s.data, &mut s.strings, version)?;
+    let arrowhead_size = s.data.read_bd()?;
+    let default_mtext_contents = modern::read_tv(&mut s.data, &mut s.strings, version)?;
+    let text_left_attachment = s.data.read_bs()?;
+    let text_right_attachment = s.data.read_bs()?;
+    let text_angle_type = s.data.read_bs()?;
+    let text_alignment_type = s.data.read_bs()?;
+    let text_color = color::read(&mut s.data, &mut s.strings, version)?;
+    let text_height = s.data.read_bd()?;
+    let enable_frame_text = s.data.read_b()?;
+    let text_align_always_left = s.data.read_b()?;
+    let align_space = s.data.read_bd()?;
+    let block_content_color = color::read(&mut s.data, &mut s.strings, version)?;
+    let block_content_scale_x = s.data.read_bd()?;
+    let block_content_scale_y = s.data.read_bd()?;
+    let block_content_scale_z = s.data.read_bd()?;
+    let enable_block_content_scale = s.data.read_b()?;
+    let block_content_rotation = s.data.read_bd()?;
+    let enable_block_content_rotation = s.data.read_b()?;
+    let block_content_connection_type = s.data.read_bs()?;
+    let scale = s.data.read_bd()?;
+    let overwrite_property_value = s.data.read_b()?;
+    let is_annotative = s.data.read_b()?;
+    let break_gap_size = s.data.read_bd()?;
+    let (
+        text_attachment_direction,
+        bottom_text_attachment_direction,
+        top_text_attachment_direction,
+    ) = if has_version {
+        (s.data.read_bs()?, s.data.read_bs()?, s.data.read_bs()?)
+    } else {
+        (0, 0, 0)
+    };
+    let extended_flag = if matches!(version, Version::R2013 | Version::R2018) {
+        s.data.read_b()?
+    } else {
+        false
+    };
+    s.finish("MLEADERSTYLE")?;
+    Ok(AcadMLeaderStyle {
+        version: style_version,
+        content_type,
+        draw_mleader_order_type,
+        draw_leader_order_type,
+        max_leader_segment_points,
+        first_segment_angle,
+        second_segment_angle,
+        leader_line_type,
+        leader_line_color,
+        leader_lineweight,
+        enable_landing,
+        landing_gap,
+        enable_dogleg,
+        dogleg_length,
+        description,
+        arrowhead_size,
+        default_mtext_contents,
+        text_left_attachment,
+        text_right_attachment,
+        text_angle_type,
+        text_alignment_type,
+        text_color,
+        text_height,
+        enable_frame_text,
+        text_align_always_left,
+        align_space,
+        block_content_color,
+        block_content_scale_x,
+        block_content_scale_y,
+        block_content_scale_z,
+        enable_block_content_scale,
+        block_content_rotation,
+        enable_block_content_rotation,
+        block_content_connection_type,
+        scale,
+        overwrite_property_value,
+        is_annotative,
+        break_gap_size,
+        text_attachment_direction,
+        bottom_text_attachment_direction,
+        top_text_attachment_direction,
+        extended_flag,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bitwriter::BitWriter;
+
+    fn cmc(w: &mut BitWriter, rgb: u32) {
+        w.write_bs_u(0);
+        w.write_bl_u(rgb);
+        w.write_rc(0);
+    }
+
+    /// The `Standard` multileader style, with the values every corpus
+    /// record decodes.
+    fn build(version: Version) -> Vec<u8> {
+        // R2010 predates the R2013+ AcDs binary-data bit of the common
+        // object prefix, so it takes the shorter prefix.
+        let mut w = if matches!(version, Version::R2013 | Version::R2018) {
+            modern::tests::r2018_object_prefix(1)
+        } else {
+            modern::tests::r2004_object_prefix(1)
+        };
+        write_common_body(&mut w, version, false);
+        let bits = crate::string_stream::tests::bits_of(&w);
+        crate::string_stream::tests::build_payload(&bits, &["Standard", ""])
+    }
+
+    /// Write the field list itself. `inline_strings` selects the
+    /// pre-R2007 layout, where the two `TV` slots consume data bits.
+    fn write_common_body(w: &mut BitWriter, version: Version, inline_strings: bool) {
+        if version.is_r2010_plus() {
+            w.write_bs(2); // version
+        }
+        w.write_bs(2); // content_type
+        w.write_bs(1); // draw_mleader_order_type
+        w.write_bs(0); // draw_leader_order_type
+        w.write_bl(2); // max_leader_segment_points
+        w.write_bd(0.0);
+        w.write_bd(0.0);
+        w.write_bs(1); // leader_line_type
+        cmc(w, 0xC100_0000);
+        w.write_bl(-2); // leader_lineweight
+        w.write_b(true); // enable_landing
+        w.write_bd(0.09);
+        w.write_b(true); // enable_dogleg
+        w.write_bd(0.36);
+        if inline_strings {
+            modern::tests::write_inline_tv(w, "Standard");
+        }
+        w.write_bd(0.18); // arrowhead_size
+        if inline_strings {
+            modern::tests::write_inline_tv(w, "");
+        }
+        w.write_bs(1);
+        w.write_bs(6);
+        w.write_bs(1);
+        w.write_bs(0);
+        cmc(w, 0xC100_0000);
+        w.write_bd(0.18); // text_height
+        w.write_b(false);
+        w.write_b(false);
+        w.write_bd(0.18); // align_space
+        cmc(w, 0xC100_0000);
+        w.write_bd(1.0);
+        w.write_bd(1.0);
+        w.write_bd(1.0);
+        w.write_b(true);
+        w.write_bd(0.0);
+        w.write_b(true);
+        w.write_bs(0);
+        w.write_bd(1.0); // scale
+        w.write_b(false);
+        w.write_b(true);
+        w.write_bd(0.125); // break_gap_size
+        if version.is_r2010_plus() {
+            w.write_bs(0);
+            w.write_bs(9);
+            w.write_bs(9);
+        }
+        if matches!(version, Version::R2013 | Version::R2018) {
+            w.write_b(true);
+        }
+    }
+
+    #[test]
+    fn r2018_mleader_style_closes_on_its_string_stream() {
+        let payload = build(Version::R2018);
+        let s = decode_object(&payload, 8, None, Version::R2018).unwrap();
+        assert_eq!(s.version, 2);
+        assert_eq!(s.content_type, 2);
+        assert_eq!(s.max_leader_segment_points, 2);
+        assert_eq!(s.leader_line_color.method(), 0xC1);
+        assert_eq!(s.leader_lineweight, -2);
+        assert!(s.enable_landing && s.enable_dogleg);
+        assert!((s.landing_gap - 0.09).abs() < 1e-12);
+        assert!((s.dogleg_length - 0.36).abs() < 1e-12);
+        assert!((s.arrowhead_size - 0.18).abs() < 1e-12);
+        assert!((s.text_height - 0.18).abs() < 1e-12);
+        assert!((s.break_gap_size - 0.125).abs() < 1e-12);
+        assert_eq!(s.description, "Standard");
+        assert_eq!(s.default_mtext_contents, "");
+        assert_eq!(s.block_content_scale_x, 1.0);
+        assert_eq!(s.top_text_attachment_direction, 9);
+        assert!(s.extended_flag);
+    }
+
+    #[test]
+    fn r2010_mleader_style_has_no_r2013_tail_flag() {
+        let payload = build(Version::R2010);
+        let s = decode_object(&payload, 8, None, Version::R2010).unwrap();
+        assert_eq!(s.version, 2);
+        assert!(!s.extended_flag);
+        assert_eq!(s.bottom_text_attachment_direction, 9);
+    }
+
+    /// The R2004 layout: `TV` fields inline, no leading `version` word
+    /// and no attachment-direction tail, closing on the `RL`
+    /// object-data-size boundary.
+    #[test]
+    fn r2004_mleader_style_omits_the_r2010_fields() {
+        let mut w = modern::tests::r2004_object_prefix(1);
+        write_common_body(&mut w, Version::R2004, true);
+        let end = w.position_bits();
+        let bytes = w.into_bytes();
+        let s = decode_object(&bytes, 0, Some(end), Version::R2004).unwrap();
+        assert_eq!(s.version, 0);
+        assert_eq!(s.text_attachment_direction, 0);
+        assert_eq!(s.description, "Standard");
+        assert_eq!(s.leader_lineweight, -2);
+        assert!((s.break_gap_size - 0.125).abs() < 1e-12);
+    }
+
+    #[test]
+    fn r2013_body_rejected_by_the_r2010_field_list() {
+        let payload = build(Version::R2018);
+        assert!(decode_object(&payload, 8, None, Version::R2010).is_err());
+    }
+}

--- a/src/objects/acad_mlinestyle.rs
+++ b/src/objects/acad_mlinestyle.rs
@@ -1,82 +1,146 @@
-//! ACAD_MLINESTYLE object (spec §19.6.4 — L6-13) — multiline style
-//! definition (up to 16 parallel line elements).
+//! MLINESTYLE object (ODA *Open Design Specification for .dwg files*
+//! v5.4.1 §20.4.73) — multiline style definition.
 //!
 //! MLINESTYLE is the style record backing the MLINE entity: it
-//! describes how many parallel lines are drawn, each line's offset
-//! from the reference axis, colour, and linetype.
+//! describes how many parallel lines are drawn, each line's offset from
+//! the reference axis, its colour, and its linetype.
 //!
-//! # Stream shape
+//! # The spec prescribes the whole record (§20.4.73)
 //!
 //! ```text
-//! TV       name
-//! TV       description
-//! BS       flags
-//! BS       fill_color           -- ACI index (simplified CMC)
-//! BD       start_angle
-//! BD       end_angle
-//! RC       num_lines            -- capped at 16 (format-limit)
-//! // Per line (num_lines times):
-//! BD       offset
-//! BS       color                -- ACI index
-//! H        linetype_handle
+//! TV   name             -- name of this style
+//! TV   desc             -- description of this style
+//! BS   flags            -- DXF flag word (the spec tabulates the bit
+//!                          permutation between DWG and DXF)
+//! CMC  fillcolor        -- fill colour for this style
+//! BD   startang         -- start angle
+//! BD   endang           -- end angle
+//! RC   linesinstyle     -- number of lines in this style
+//! REPEAT linesinstyle times:
+//!   BD   offset         -- offset of this segment
+//!   CMC  color          -- colour of this segment
+//!   BS   ltindex        -- linetype index, before R2018
+//!   H    linetype       -- linetype handle, R2018+
+//! END REPEAT
 //! ```
 //!
-//! Note: the spec permits up to 16 lines per MLINESTYLE. A file
-//! claiming more than 16 is either adversarial or a format
-//! corruption; the decoder rejects it.
+//! An earlier revision of this module cited "§19.6.4 (L6-13)" — the
+//! spec has no §19.6 chapter — and read `BS` where §20.4.73 prints
+//! `CMC` for both colour fields, which is 42 bits short per record on
+//! every real file. The citation is withdrawn and the field list is the
+//! §20.4.73 one.
+//!
+//! # It closes on every corpus record
+//!
+//! `H` fields cost no data-stream bits on any release this crate walks
+//! (R2000+ moves the handle references past the `RL` object-data-size
+//! boundary), so the R2018 per-line handle is invisible to the data
+//! cursor while the pre-R2018 `BS ltindex` is not. With that one
+//! version switch the field list ends exactly on the data-stream
+//! boundary for all ten MLINESTYLE records of the corpus:
+//!
+//! | Release | Records | Budget | Delta |
+//! |---|---|---|---|
+//! | R2004 | 3 (`{arc,circle,line}_2004.dwg` handle 96) | 526 | 0 |
+//! | R2010 | 3 (`*_2010.dwg` handle 96) | 442 | 0 |
+//! | R2013 | 3 (`*_2013.dwg` handle 96) | 442 | 0 |
+//! | R2018 | 1 (`sample_AC1032.dwg` handle 24) | 406 | 0 |
+//!
+//! The R2013 → R2018 difference is exactly the two `BS ltindex` fields
+//! the R2018 record replaces with handles: both records carry two
+//! lines, both write `ltindex` in the 16-bit `BS` form (18 bits), and
+//! 442 − 2 × 18 = 406.
+//!
+//! Decoded values corroborate the reading: the `STANDARD` style of
+//! every file decodes `startang = endang = π/2`, `fillcolor` method
+//! `0xC0` (ByLayer), two lines at offsets `+0.5` and `−0.5`, each
+//! ByLayer, and `ltindex = 32767` — the "no linetype" sentinel.
 
-use crate::bitcursor::{BitCursor, Handle};
 use crate::error::{Error, Result};
-use crate::tables::read_tv;
+use crate::objects::color::{self, ObjectColor};
+use crate::objects::modern;
 use crate::version::Version;
 
 /// Format-limit cap on the number of lines a single MLINESTYLE may
-/// carry (spec §19.6.4).
+/// carry (§20.4.73 stores the count in one `RC`; AutoCAD's own limit is
+/// 16 elements per style).
 const MAX_MLINESTYLE_LINES: usize = 16;
 
-/// One of the parallel line elements in an MLINESTYLE.
+/// One of the parallel line elements of an MLINESTYLE (§20.4.73).
 #[derive(Debug, Clone, PartialEq)]
 pub struct MlineStyleLine {
+    /// Offset of this segment from the reference axis.
     pub offset: f64,
-    pub color: i16,
-    pub linetype_handle: Handle,
+    /// Colour of this segment.
+    pub color: ObjectColor,
+    /// Linetype index, before R2018. `32767` is the "none" sentinel.
+    /// R2018+ stores a linetype handle instead and leaves this `0`.
+    pub linetype_index: i16,
 }
 
-/// Decoded ACAD_MLINESTYLE body.
+/// A decoded MLINESTYLE record (§20.4.73).
 #[derive(Debug, Clone, PartialEq)]
 pub struct AcadMlinestyle {
+    /// Name of this style.
     pub name: String,
+    /// Description of this style.
     pub description: String,
+    /// DXF flag word.
     pub flags: i16,
-    pub fill_color: i16,
+    /// Fill colour for this style.
+    pub fill_color: ObjectColor,
+    /// Start angle, radians.
     pub start_angle: f64,
+    /// End angle, radians.
     pub end_angle: f64,
+    /// The style's parallel line elements, in wire order.
     pub lines: Vec<MlineStyleLine>,
 }
 
-/// Decodes the `AcadMlinestyle` payload that follows the common object header.
-pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<AcadMlinestyle> {
-    let name = read_tv(c, version)?;
-    let description = read_tv(c, version)?;
-    let flags = c.read_bs()?;
-    let fill_color = c.read_bs()?;
-    let start_angle = c.read_bd()?;
-    let end_angle = c.read_bd()?;
-    let num_lines = c.read_rc()? as usize;
+/// Decode an MLINESTYLE straight from its raw object payload (§20.4.73),
+/// taking its `TV` fields from the R2007+ string stream and checking
+/// that the data fields end exactly on the data-stream boundary.
+pub fn decode_object(
+    payload: &[u8],
+    body_start: usize,
+    inline_data_end: Option<usize>,
+    version: Version,
+) -> Result<AcadMlinestyle> {
+    let mut split = modern::open(payload, body_start, inline_data_end, version)?;
+    let style = read_fields(&mut split, version)?;
+    split.finish("MLINESTYLE")?;
+    Ok(style)
+}
+
+/// Read the §20.4.73 field list off an already-opened object stream.
+fn read_fields(split: &mut modern::ObjectStream<'_>, version: Version) -> Result<AcadMlinestyle> {
+    let name = modern::read_tv(&mut split.data, &mut split.strings, version)?;
+    let description = modern::read_tv(&mut split.data, &mut split.strings, version)?;
+    let flags = split.data.read_bs()?;
+    let fill_color = color::read(&mut split.data, &mut split.strings, version)?;
+    let start_angle = split.data.read_bd()?;
+    let end_angle = split.data.read_bd()?;
+    let num_lines = split.data.read_rc()? as usize;
     if num_lines > MAX_MLINESTYLE_LINES {
         return Err(Error::SectionMap(format!(
-            "ACAD_MLINESTYLE claims {num_lines} lines (max {MAX_MLINESTYLE_LINES} per spec §19.6.4)"
+            "MLINESTYLE claims {num_lines} lines (max {MAX_MLINESTYLE_LINES})"
         )));
     }
     let mut lines = Vec::with_capacity(num_lines);
     for _ in 0..num_lines {
-        let offset = c.read_bd()?;
-        let color = c.read_bs()?;
-        let linetype_handle = c.read_handle()?;
+        let offset = split.data.read_bd()?;
+        let color = color::read(&mut split.data, &mut split.strings, version)?;
+        // R2018 moved the per-line linetype to a handle, which lives in
+        // the handle stream and costs no data-stream bits.
+        let linetype_index = if matches!(version, Version::R2018) {
+            0
+        } else {
+            split.data.read_bs()?
+        };
         lines.push(MlineStyleLine {
             offset,
             color,
-            linetype_handle,
+            linetype_index,
         });
     }
     Ok(AcadMlinestyle {
@@ -95,56 +159,79 @@ mod tests {
     use super::*;
     use crate::bitwriter::BitWriter;
 
-    fn encode_tv_r2000(w: &mut BitWriter, s: &[u8]) {
-        w.write_bs_u(s.len() as u16);
-        for b in s {
-            w.write_rc(*b);
+    fn cmc(w: &mut BitWriter, index: u16, rgb: u32, color_byte: u8) {
+        w.write_bs_u(index);
+        w.write_bl_u(rgb);
+        w.write_rc(color_byte);
+    }
+
+    /// The `STANDARD` style every corpus file carries: two elements at
+    /// ±0.5, both ByLayer, both with the `32767` linetype sentinel.
+    fn build(version: Version) -> Vec<u8> {
+        let mut body = modern::tests::r2018_object_prefix(1);
+        body.write_bs(0); // flags
+        cmc(&mut body, 0, 0xC000_0000, 0); // fill colour, ByLayer
+        body.write_bd(std::f64::consts::FRAC_PI_2);
+        body.write_bd(std::f64::consts::FRAC_PI_2);
+        body.write_rc(2); // linesinstyle
+        for offset in [0.5, -0.5] {
+            body.write_bd(offset);
+            cmc(&mut body, 0, 0xC000_0000, 0);
+            if !matches!(version, Version::R2018) {
+                body.write_bs(32767);
+            }
         }
+        let bits = crate::string_stream::tests::bits_of(&body);
+        crate::string_stream::tests::build_payload(&bits, &["STANDARD", ""])
     }
 
     #[test]
-    fn roundtrip_standard_style() {
-        let mut w = BitWriter::new();
-        encode_tv_r2000(&mut w, b"STANDARD");
-        encode_tv_r2000(&mut w, b"");
-        w.write_bs(0); // flags
-        w.write_bs(256); // fill_color = BYLAYER-ish sentinel
-        w.write_bd(90.0); // start angle
-        w.write_bd(90.0); // end angle
-        w.write_rc(2); // 2 lines
-        // line 1: offset 0.5, color 1, linetype handle 5.1.0x10
-        w.write_bd(0.5);
-        w.write_bs(1);
-        w.write_handle(5, 0x10);
-        // line 2: offset -0.5, color 2, linetype handle 5.1.0x11
-        w.write_bd(-0.5);
-        w.write_bs(2);
-        w.write_handle(5, 0x11);
-        let bytes = w.into_bytes();
-        let mut c = BitCursor::new(&bytes);
-        let s = decode(&mut c, Version::R2000).unwrap();
-        assert_eq!(s.name, "STANDARD");
-        assert_eq!(s.lines.len(), 2);
-        assert_eq!(s.lines[0].offset, 0.5);
-        assert_eq!(s.lines[0].color, 1);
-        assert_eq!(s.lines[0].linetype_handle.value, 0x10);
-        assert_eq!(s.lines[1].offset, -0.5);
-        assert_eq!(s.fill_color, 256);
+    fn r2018_mlinestyle_closes_on_its_string_stream() {
+        let payload = build(Version::R2018);
+        let style = decode_object(&payload, 8, None, Version::R2018).unwrap();
+        assert_eq!(style.name, "STANDARD");
+        assert_eq!(style.description, "");
+        assert_eq!(style.flags, 0);
+        assert_eq!(style.fill_color.method(), 0xC0);
+        assert!((style.start_angle - std::f64::consts::FRAC_PI_2).abs() < 1e-12);
+        assert!((style.end_angle - std::f64::consts::FRAC_PI_2).abs() < 1e-12);
+        assert_eq!(style.lines.len(), 2);
+        assert_eq!(style.lines[0].offset, 0.5);
+        assert_eq!(style.lines[1].offset, -0.5);
+        assert_eq!(style.lines[0].color.method(), 0xC0);
+        // R2018 takes the per-line linetype from the handle stream.
+        assert_eq!(style.lines[0].linetype_index, 0);
+    }
+
+    /// The pre-R2018 `BS ltindex` is not optional: an R2013 body read
+    /// with the R2018 field list leaves both index words unread, and the
+    /// boundary check has to reject that.
+    #[test]
+    fn r2013_body_rejected_by_the_r2018_field_list() {
+        let payload = build(Version::R2013);
+        let style = decode_object(&payload, 8, None, Version::R2013).unwrap();
+        assert_eq!(style.lines[0].linetype_index, 32767);
+        assert!(decode_object(&payload, 8, None, Version::R2018).is_err());
+    }
+
+    /// …and the converse.
+    #[test]
+    fn r2018_body_rejected_by_the_r2013_field_list() {
+        let payload = build(Version::R2018);
+        assert!(decode_object(&payload, 8, None, Version::R2013).is_err());
     }
 
     #[test]
     fn rejects_too_many_lines() {
-        let mut w = BitWriter::new();
-        encode_tv_r2000(&mut w, b"BIG");
-        encode_tv_r2000(&mut w, b"");
-        w.write_bs(0);
-        w.write_bs(0);
-        w.write_bd(90.0);
-        w.write_bd(90.0);
-        w.write_rc(17); // > 16
-        let bytes = w.into_bytes();
-        let mut c = BitCursor::new(&bytes);
-        let err = decode(&mut c, Version::R2000).unwrap_err();
-        assert!(matches!(&err, Error::SectionMap(msg) if msg.contains("ACAD_MLINESTYLE")));
+        let mut body = modern::tests::r2018_object_prefix(0);
+        body.write_bs(0);
+        cmc(&mut body, 0, 0xC000_0000, 0);
+        body.write_bd(0.0);
+        body.write_bd(0.0);
+        body.write_rc(17); // > 16
+        let bits = crate::string_stream::tests::bits_of(&body);
+        let payload = crate::string_stream::tests::build_payload(&bits, &["BIG", ""]);
+        let err = decode_object(&payload, 8, None, Version::R2018).unwrap_err();
+        assert!(matches!(&err, Error::SectionMap(msg) if msg.contains("MLINESTYLE")));
     }
 }

--- a/src/objects/acad_section_view_style.rs
+++ b/src/objects/acad_section_view_style.rs
@@ -1,0 +1,420 @@
+//! ACDBSECTIONVIEWSTYLE object — the style record behind a model
+//! documentation *section view* (identifier, cutting-plane arrows,
+//! view label, and the cut-surface hatch).
+//!
+//! # There is no spec prescription for this object
+//!
+//! The ODA *Open Design Specification for .dwg files* v5.4.1 has **no
+//! §20.4 entry** for `ACDBSECTIONVIEWSTYLE`; its object-prescription
+//! chapter runs from `20.4.1 Common Entity Data` to `20.4.104 XRECORD`
+//! and stops. The field list below was derived by measuring real
+//! records against the boundary the format itself provides.
+//!
+//! # The wire shape — measured
+//!
+//! ```text
+//! BS   unknown_head
+//! TV   name
+//! TV   name_alias                    -- R2018 only
+//! B    unknown_flag_a                -- R2018 only
+//! B    unknown_flag_b                -- R2018 only
+//! BS   flags                         -- 44 in every corpus record
+//! B    flag_c   B    flag_d   B    flag_e
+//! CMC  identifier_color              BD   identifier_height
+//! CMC  arrow_symbol_color            BD   arrow_symbol_size
+//! TV   identifier_exclude_characters BD   identifier_offset
+//! BS   cutting_plane_line_weight     CMC  cutting_plane_line_color
+//! BS   end_line_weight               CMC  end_line_color
+//! BD   end_line_length               BD   end_line_overshoot
+//! CMC  view_label_color              BD   view_label_text_height
+//! BS   view_label_position           BD   view_label_offset
+//! BS   view_label_attachment         TV   view_label_pattern
+//! CMC  hatch_color                   CMC  hatch_background_color
+//! TV   hatch_pattern_name            RC   hatch_flags
+//! BD   hatch_scale                   BS   hatch_transparency
+//! BD   hatch_spacing
+//! BS   hatch_angle_count             BS   unknown_tail
+//! 5 x BD hatch_angles
+//! ```
+//!
+//! `H` fields (text styles, arrow blocks, linetypes) live in the handle
+//! stream and cost no data-stream bits, so they do not appear; this is
+//! the data stream only.
+//!
+//! # Why this is not a guess
+//!
+//! Every record's data fields have to end exactly on the first bit of
+//! its string stream (R2010+) or on its `RL` object-data-size (R2004) —
+//! the boundary `objects::modern::ObjectStream::finish` enforces. The
+//! list above closes **all eleven** ACDBSECTIONVIEWSTYLE records of the
+//! corpus with delta 0:
+//!
+//! | Release | Records | Budget | Delta |
+//! |---|---|---|---|
+//! | R2004 | 3 (`{arc,circle,line}_2004.dwg` handle 105) | 2325 | 0 |
+//! | R2010 | 3 (`*_2010.dwg` handle 105) | 1301 | 0 |
+//! | R2013 | 3 (`*_2013.dwg` handle 105) | 1301 | 0 |
+//! | R2018 | 2 (`sample_AC1032.dwg` handles 426, 923) | 1263 / 1367 | 0 |
+//!
+//! The R2004 record is the discriminating evidence for the string
+//! placement: its four `TV` fields cost 82, 146, 730 and 66 data-stream
+//! bits respectively, so a `TV` in the wrong slot moves everything
+//! after it by hundreds of bits and cannot close. It is also what fixes
+//! the order of `hatch_pattern_name` and `hatch_flags` — on R2010+ a
+//! `TV` costs nothing and the two are interchangeable, but on R2004
+//! only `TV` then `RC` lands the following `BD` on `2.5`.
+//!
+//! Corroboration from the decoded values:
+//!
+//! - the five trailing `BD`s decode `1.5707963267948966`,
+//!   `0.2617993877991494`, `1.3089969389957472`, `-0.2617993877991494`
+//!   and `1.8325957145940461` — exactly 90°, 15°, 75°, −15° and 105° in
+//!   radians, the cutting-plane angle set AutoCAD offers for section
+//!   views. Five consecutive full-width doubles all landing on whole
+//!   degrees is not something a misaligned field list produces;
+//! - `identifier_exclude_characters` decodes `I, O, Q, S, X, Z` — the
+//!   identifier letters AutoCAD reserves and excludes by default;
+//! - `hatch_pattern_name` decodes `ANSI31`;
+//! - `hatch_scale` and `hatch_spacing` decode `2.5`, the metric preset;
+//! - `identifier_height`, `arrow_symbol_size`, `end_line_length` and
+//!   `view_label_text_height` decode `5` on the metric records and
+//!   `0.24` on the imperial one; `view_label_offset` decodes `15` /
+//!   `0.75`; `identifier_offset` decodes `10` / `0.48`;
+//! - `cutting_plane_line_weight` decodes `25` and `end_line_weight`
+//!   `50` — 0.25 mm and 0.50 mm in the DWG lineweight encoding;
+//! - every `CMC` but one decodes true-colour word `0xC0000000`
+//!   (ByLayer); the exception is `hatch_background_color`, which
+//!   decodes `0xC8000000` — the "no colour" method — on every record,
+//!   which is what a hatch with no background fill stores.
+//!
+//! # Naming
+//!
+//! The field **types, widths and order** are measured. The **names**
+//! follow the vocabulary of AutoCAD's Section View Style dialog
+//! (published product documentation — see `CLEANROOM.md`) applied in
+//! wire order. The identifier, arrow, lineweight, view-label and hatch
+//! slots are corroborated by the values above; the `unknown_*` and
+//! `flag_*` slots are positional labels for slots whose layout is
+//! proven and whose meaning is not.
+
+use crate::error::Result;
+use crate::objects::color::{self, ObjectColor};
+use crate::objects::modern;
+use crate::version::Version;
+
+/// Number of cutting-plane angles the record's tail always carries.
+const HATCH_ANGLE_COUNT: usize = 5;
+
+/// A decoded ACDBSECTIONVIEWSTYLE record.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AcadSectionViewStyle {
+    /// Leading `BS`; `0` in every corpus record. Positional name.
+    pub unknown_head: i16,
+    /// Style name.
+    pub name: String,
+    /// Second name `TV`, R2018 only; repeats [`name`](Self::name) in
+    /// both corpus records.
+    pub name_alias: String,
+    /// R2018-only leading flag. Positional name.
+    pub unknown_flag_a: bool,
+    /// R2018-only leading flag. Positional name.
+    pub unknown_flag_b: bool,
+    /// Style flag word; `44` in every corpus record.
+    pub flags: i16,
+    /// Positional name.
+    pub flag_c: bool,
+    /// Positional name.
+    pub flag_d: bool,
+    /// Positional name.
+    pub flag_e: bool,
+    /// Identifier text colour.
+    pub identifier_color: ObjectColor,
+    /// Identifier text height.
+    pub identifier_height: f64,
+    /// Cutting-plane arrow colour.
+    pub arrow_symbol_color: ObjectColor,
+    /// Cutting-plane arrow size.
+    pub arrow_symbol_size: f64,
+    /// Identifier letters excluded from automatic naming.
+    pub identifier_exclude_characters: String,
+    /// Identifier offset.
+    pub identifier_offset: f64,
+    /// Cutting-plane lineweight, hundredths of a millimetre.
+    pub cutting_plane_line_weight: i16,
+    /// Cutting-plane colour.
+    pub cutting_plane_line_color: ObjectColor,
+    /// End-line lineweight, hundredths of a millimetre.
+    pub end_line_weight: i16,
+    /// End-line colour.
+    pub end_line_color: ObjectColor,
+    /// End-line length.
+    pub end_line_length: f64,
+    /// End-line overshoot (positional name).
+    pub end_line_overshoot: f64,
+    /// View-label colour.
+    pub view_label_color: ObjectColor,
+    /// View-label text height.
+    pub view_label_text_height: f64,
+    /// View-label position selector (positional name).
+    pub view_label_position: i16,
+    /// View-label offset.
+    pub view_label_offset: f64,
+    /// View-label attachment selector (positional name).
+    pub view_label_attachment: i16,
+    /// View-label field expression.
+    pub view_label_pattern: String,
+    /// Cut-surface hatch colour.
+    pub hatch_color: ObjectColor,
+    /// Cut-surface hatch background colour; `0xC8______` — the "no
+    /// colour" method — in every corpus record.
+    pub hatch_background_color: ObjectColor,
+    /// Cut-surface hatch pattern name; `ANSI31` in every corpus record.
+    pub hatch_pattern_name: String,
+    /// Hatch flag byte (positional name).
+    pub hatch_flags: u8,
+    /// Hatch scale.
+    pub hatch_scale: f64,
+    /// Hatch transparency (positional name).
+    pub hatch_transparency: i16,
+    /// Hatch spacing.
+    pub hatch_spacing: f64,
+    /// Angle-array selector (positional name); `6` in every corpus
+    /// record, which is one more than the number of angles stored.
+    pub hatch_angle_count: i16,
+    /// Trailing `BS` before the angle array. Positional name.
+    pub unknown_tail: i16,
+    /// The five cutting-plane angles, radians.
+    pub hatch_angles: [f64; HATCH_ANGLE_COUNT],
+}
+
+/// Decode an ACDBSECTIONVIEWSTYLE straight from its raw object payload,
+/// taking its `TV` fields from the R2007+ string stream and checking
+/// that the data fields end exactly on the data-stream boundary.
+pub fn decode_object(
+    payload: &[u8],
+    body_start: usize,
+    inline_data_end: Option<usize>,
+    version: Version,
+) -> Result<AcadSectionViewStyle> {
+    let mut s = modern::open(payload, body_start, inline_data_end, version)?;
+    let r2018 = matches!(version, Version::R2018);
+    let unknown_head = s.data.read_bs()?;
+    let name = modern::read_tv(&mut s.data, &mut s.strings, version)?;
+    let (name_alias, unknown_flag_a, unknown_flag_b) = if r2018 {
+        (
+            modern::read_tv(&mut s.data, &mut s.strings, version)?,
+            s.data.read_b()?,
+            s.data.read_b()?,
+        )
+    } else {
+        (String::new(), false, false)
+    };
+    let flags = s.data.read_bs()?;
+    let flag_c = s.data.read_b()?;
+    let flag_d = s.data.read_b()?;
+    let flag_e = s.data.read_b()?;
+    let identifier_color = color::read(&mut s.data, &mut s.strings, version)?;
+    let identifier_height = s.data.read_bd()?;
+    let arrow_symbol_color = color::read(&mut s.data, &mut s.strings, version)?;
+    let arrow_symbol_size = s.data.read_bd()?;
+    let identifier_exclude_characters = modern::read_tv(&mut s.data, &mut s.strings, version)?;
+    let identifier_offset = s.data.read_bd()?;
+    let cutting_plane_line_weight = s.data.read_bs()?;
+    let cutting_plane_line_color = color::read(&mut s.data, &mut s.strings, version)?;
+    let end_line_weight = s.data.read_bs()?;
+    let end_line_color = color::read(&mut s.data, &mut s.strings, version)?;
+    let end_line_length = s.data.read_bd()?;
+    let end_line_overshoot = s.data.read_bd()?;
+    let view_label_color = color::read(&mut s.data, &mut s.strings, version)?;
+    let view_label_text_height = s.data.read_bd()?;
+    let view_label_position = s.data.read_bs()?;
+    let view_label_offset = s.data.read_bd()?;
+    let view_label_attachment = s.data.read_bs()?;
+    let view_label_pattern = modern::read_tv(&mut s.data, &mut s.strings, version)?;
+    let hatch_color = color::read(&mut s.data, &mut s.strings, version)?;
+    let hatch_background_color = color::read(&mut s.data, &mut s.strings, version)?;
+    let hatch_pattern_name = modern::read_tv(&mut s.data, &mut s.strings, version)?;
+    let hatch_flags = s.data.read_rc()?;
+    let hatch_scale = s.data.read_bd()?;
+    let hatch_transparency = s.data.read_bs()?;
+    let hatch_spacing = s.data.read_bd()?;
+    let hatch_angle_count = s.data.read_bs()?;
+    let unknown_tail = s.data.read_bs()?;
+    let mut hatch_angles = [0.0f64; HATCH_ANGLE_COUNT];
+    for angle in &mut hatch_angles {
+        *angle = s.data.read_bd()?;
+    }
+    s.finish("ACDBSECTIONVIEWSTYLE")?;
+    Ok(AcadSectionViewStyle {
+        unknown_head,
+        name,
+        name_alias,
+        unknown_flag_a,
+        unknown_flag_b,
+        flags,
+        flag_c,
+        flag_d,
+        flag_e,
+        identifier_color,
+        identifier_height,
+        arrow_symbol_color,
+        arrow_symbol_size,
+        identifier_exclude_characters,
+        identifier_offset,
+        cutting_plane_line_weight,
+        cutting_plane_line_color,
+        end_line_weight,
+        end_line_color,
+        end_line_length,
+        end_line_overshoot,
+        view_label_color,
+        view_label_text_height,
+        view_label_position,
+        view_label_offset,
+        view_label_attachment,
+        view_label_pattern,
+        hatch_color,
+        hatch_background_color,
+        hatch_pattern_name,
+        hatch_flags,
+        hatch_scale,
+        hatch_transparency,
+        hatch_spacing,
+        hatch_angle_count,
+        unknown_tail,
+        hatch_angles,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bitwriter::BitWriter;
+    use std::f64::consts::FRAC_PI_2;
+
+    const EXCLUDE: &str = "I, O, Q, S, X, Z";
+    const LABEL: &str = "%<\\AcVar ViewSectionStartId>%";
+    const ANGLES: [f64; 5] = [
+        FRAC_PI_2,
+        0.2617993877991494,
+        1.3089969389957472,
+        -0.2617993877991494,
+        1.8325957145940461,
+    ];
+
+    fn cmc(w: &mut BitWriter, rgb: u32) {
+        w.write_bs_u(0);
+        w.write_bl_u(rgb);
+        w.write_rc(0);
+    }
+
+    fn write_body(w: &mut BitWriter, version: Version, inline_strings: bool) {
+        let r2018 = matches!(version, Version::R2018);
+        w.write_bs(0);
+        if inline_strings {
+            modern::tests::write_inline_tv(w, "Metric50");
+        }
+        if r2018 {
+            w.write_b(false);
+            w.write_b(true);
+        }
+        w.write_bs(44);
+        w.write_b(true);
+        w.write_b(true);
+        w.write_b(false);
+        cmc(w, 0xC000_0000);
+        w.write_bd(5.0);
+        cmc(w, 0xC000_0000);
+        w.write_bd(5.0);
+        if inline_strings {
+            modern::tests::write_inline_tv(w, EXCLUDE);
+        }
+        w.write_bd(10.0);
+        w.write_bs(25);
+        cmc(w, 0xC000_0000);
+        w.write_bs(50);
+        cmc(w, 0xC000_0000);
+        w.write_bd(5.0);
+        w.write_bd(5.0);
+        cmc(w, 0xC000_0000);
+        w.write_bd(5.0);
+        w.write_bs(0);
+        w.write_bd(15.0);
+        w.write_bs(1);
+        if inline_strings {
+            modern::tests::write_inline_tv(w, LABEL);
+        }
+        cmc(w, 0xC000_0000);
+        cmc(w, 0xC800_0000);
+        if inline_strings {
+            modern::tests::write_inline_tv(w, "ANSI31");
+        }
+        w.write_rc(98);
+        w.write_bd(2.5);
+        w.write_bs(0);
+        w.write_bd(2.5);
+        w.write_bs(6);
+        w.write_bs(0);
+        for angle in ANGLES {
+            w.write_bd(angle);
+        }
+    }
+
+    fn build(version: Version) -> Vec<u8> {
+        let mut w = modern::tests::r2018_object_prefix(1);
+        write_body(&mut w, version, false);
+        let bits = crate::string_stream::tests::bits_of(&w);
+        let strings: Vec<&str> = if matches!(version, Version::R2018) {
+            vec!["Metric50", "Metric50", EXCLUDE, LABEL, "ANSI31"]
+        } else {
+            vec!["Metric50", EXCLUDE, LABEL, "ANSI31"]
+        };
+        crate::string_stream::tests::build_payload(&bits, &strings)
+    }
+
+    #[test]
+    fn r2018_section_view_style_closes_on_its_string_stream() {
+        let payload = build(Version::R2018);
+        let s = decode_object(&payload, 8, None, Version::R2018).unwrap();
+        assert_eq!(s.name, "Metric50");
+        assert_eq!(s.name_alias, "Metric50");
+        assert_eq!(s.flags, 44);
+        assert_eq!(s.identifier_exclude_characters, EXCLUDE);
+        assert_eq!(s.hatch_pattern_name, "ANSI31");
+        assert_eq!(s.view_label_pattern, LABEL);
+        assert_eq!(s.cutting_plane_line_weight, 25);
+        assert_eq!(s.end_line_weight, 50);
+        assert_eq!(s.hatch_background_color.method(), 0xC8);
+        assert_eq!(s.hatch_color.method(), 0xC0);
+        assert_eq!(s.hatch_scale, 2.5);
+        assert_eq!(s.hatch_spacing, 2.5);
+        assert_eq!(s.hatch_angle_count, 6);
+        assert!((s.hatch_angles[0] - FRAC_PI_2).abs() < 1e-12);
+        assert!((s.hatch_angles[4] - 1.8325957145940461).abs() < 1e-12);
+    }
+
+    #[test]
+    fn r2013_section_view_style_has_no_r2018_head() {
+        let payload = build(Version::R2013);
+        let s = decode_object(&payload, 8, None, Version::R2013).unwrap();
+        assert_eq!(s.name, "Metric50");
+        assert_eq!(s.name_alias, "");
+        assert_eq!(s.identifier_exclude_characters, EXCLUDE);
+        assert!(decode_object(&payload, 8, None, Version::R2018).is_err());
+    }
+
+    /// The R2004 layout: four inline `TV` fields, closing on the `RL`
+    /// object-data-size boundary.
+    #[test]
+    fn r2004_section_view_style_reads_its_strings_inline() {
+        let mut w = modern::tests::r2004_object_prefix(1);
+        write_body(&mut w, Version::R2004, true);
+        let end = w.position_bits();
+        let bytes = w.into_bytes();
+        let s = decode_object(&bytes, 0, Some(end), Version::R2004).unwrap();
+        assert_eq!(s.name, "Metric50");
+        assert_eq!(s.identifier_exclude_characters, EXCLUDE);
+        assert_eq!(s.hatch_pattern_name, "ANSI31");
+        assert_eq!(s.hatch_scale, 2.5);
+    }
+}

--- a/src/objects/color.rs
+++ b/src/objects/color.rs
@@ -1,0 +1,81 @@
+//! The `CMC` colour form the R2004+ non-entity objects carry.
+//!
+//! §2.11 of the ODA *Open Design Specification for .dwg files* v5.4.1
+//! describes `CMC` as a `BS` colour index optionally followed by a `BL`
+//! true-colour word and an `RC` colour byte. Every R2004+ record this
+//! crate has measured writes all three unconditionally — see the
+//! evidence note on `crate::tables::modern::read_cmc_full` — so the
+//! crate-internal reader here reads all three and then honours the two
+//! name-string bits of the colour byte, which are the one part of
+//! §2.11 that really is conditional.
+
+use crate::bitcursor::BitCursor;
+use crate::error::Result;
+use crate::string_stream::StringReader;
+use crate::version::Version;
+
+/// One `CMC` colour: `BS` index, `BL` true-colour word, `RC` colour byte.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ObjectColor {
+    /// Colour index word.
+    pub index: u16,
+    /// True-colour word; the top octet is the colour method
+    /// (`0xC0` ByLayer, `0xC1` ByBlock, `0xC2` RGB, `0xC3` ACI index,
+    /// `0xC8` none).
+    pub rgb: u32,
+    /// Trailing colour byte; bit 0 introduces a colour name, bit 1 a
+    /// book name.
+    pub color_byte: u8,
+    /// Colour name, when bit 0 of [`color_byte`](Self::color_byte) is set.
+    pub color_name: String,
+    /// Book name, when bit 1 of [`color_byte`](Self::color_byte) is set.
+    pub book_name: String,
+}
+
+impl ObjectColor {
+    /// The colour method octet — the top byte of the true-colour word.
+    pub fn method(&self) -> u8 {
+        (self.rgb >> 24) as u8
+    }
+
+    /// The 24-bit payload of the true-colour word: an RGB triple when
+    /// [`method`](Self::method) is `0xC2`, an ACI index when it is `0xC3`.
+    pub fn payload(&self) -> u32 {
+        self.rgb & 0x00FF_FFFF
+    }
+}
+
+/// Read one `CMC` (§2.11), taking any name strings from `strings` on
+/// the R2007+ split layout and inline before it.
+pub(crate) fn read(
+    c: &mut BitCursor<'_>,
+    strings: &mut Option<StringReader<'_>>,
+    version: Version,
+) -> Result<ObjectColor> {
+    let index = c.read_bs_u()?;
+    if !version.is_r2004_plus() {
+        return Ok(ObjectColor {
+            index,
+            ..ObjectColor::default()
+        });
+    }
+    let rgb = c.read_bl_u()?;
+    let color_byte = c.read_rc()?;
+    let color_name = if color_byte & 1 != 0 {
+        super::modern::read_tv(c, strings, version)?
+    } else {
+        String::new()
+    };
+    let book_name = if color_byte & 2 != 0 {
+        super::modern::read_tv(c, strings, version)?
+    } else {
+        String::new()
+    };
+    Ok(ObjectColor {
+        index,
+        rgb,
+        color_byte,
+        color_name,
+        book_name,
+    })
+}

--- a/src/objects/mod.rs
+++ b/src/objects/mod.rs
@@ -12,13 +12,16 @@
 //!
 //! | Object                   | Module                    | Spec             |
 //! |--------------------------|---------------------------|------------------|
+//! | ACDBDETAILVIEWSTYLE      | [`acad_detail_view_style`]| none — measured  |
 //! | ACAD_GROUP               | [`acad_group`]            | §19.6.7 (L6-11)  |
 //! | LAYOUT                   | [`acad_layout`]           | §20.4.84         |
 //! | ACAD_MATERIAL            | [`acad_material`]         | none — measured  |
-//! | ACAD_MLINESTYLE          | [`acad_mlinestyle`]       | §19.6.4 (L6-13)  |
+//! | MLEADERSTYLE             | [`acad_mleader_style`]    | none — measured  |
+//! | MLINESTYLE               | [`acad_mlinestyle`]       | §20.4.73         |
 //! | PLOTSETTINGS             | [`acad_plot_settings`]    | §20.4.84 (block) |
 //! | ACAD_PROPERTYSET_DATA    | [`acad_property_set_data`]| §19.6.11 (L7-07) |
 //! | ACAD_SCALE               | [`acad_scale`]            | §19.6.8 (L6-15)  |
+//! | ACDBSECTIONVIEWSTYLE     | [`acad_section_view_style`]| none — measured |
 //! | ACAD_VISUALSTYLE         | [`acad_visual_style`]     | none — measured  |
 //! | class-map extension      | [`class_map_extension`]   | §5.7 (L7-03)     |
 //! | *_CONTROL                | [`control`]               | §19.5.1..§19.5.10|
@@ -35,28 +38,37 @@
 //!
 //! The decoders the dispatcher routes to — DICTIONARY, DICTIONARYVAR,
 //! XRECORD, ACDB_PLACEHOLDER, the `*_CONTROL` family, ACAD_GROUP,
-//! ACAD_SCALE, ACAD_VISUALSTYLE, LAYOUT and PLOTSETTINGS — all go
+//! ACAD_SCALE, ACAD_VISUALSTYLE, LAYOUT, PLOTSETTINGS, MLINESTYLE,
+//! MLEADERSTYLE, ACDBDETAILVIEWSTYLE and ACDBSECTIONVIEWSTYLE — all go
 //! through the crate-private
 //! `objects::modern`, so
 //! their `TV` fields come
 //! from the object's string stream on R2007+ and each one checks that
 //! its data fields end exactly on the data-stream boundary.
 //!
-//! The remaining modules ([`acad_material`],
-//! [`acad_property_set_data`],
-//! [`acad_mlinestyle`]) decode a documented *prefix* of their record's
-//! fields, or a field list this crate has not yet matched against real
-//! bytes, so they cannot satisfy that boundary check and are
+//! The remaining modules ([`acad_material`] and
+//! [`acad_property_set_data`]) decode a documented *prefix* of their
+//! record's fields, so they cannot satisfy that boundary check and are
 //! deliberately not dispatched — a partial decoder that cannot
 //! self-validate would inflate the coverage ratio without proving
 //! anything. They remain callable directly.
 //!
-//! Two of the table's "Spec" cells read *none — measured*: the ODA
+//! Six of the table's "Spec" cells read *none — measured*: the ODA
 //! v5.4.1 object-prescription chapter §20.4 stops at XRECORD and
-//! carries no entry for VISUALSTYLE or MATERIAL. Both modules document
-//! what their own byte measurements establish, and
+//! carries no entry for VISUALSTYLE, MATERIAL, MLEADERSTYLE,
+//! ACDBDETAILVIEWSTYLE or ACDBSECTIONVIEWSTYLE. Each module documents
+//! what its own byte measurements establish, and
 //! [`acad_material`] restricts itself to the strings and the budget
 //! precisely because its data-field layout is not among them.
+//!
+//! TABLESTYLE has no §20.4 prescription either and is **not** decoded:
+//! its R2010+ record is a 6,844-bit envelope around four repeated
+//! cell-style blocks of six border sub-records each, and a single
+//! record per corpus file is not enough evidence to pin the token
+//! sequence inside those blocks. `examples/probe_token_scan.rs`
+//! reproduces the block census; ARCHITECTURE.md records the measured
+//! budgets. The records stay in the Unhandled bucket rather than being
+//! decoded on a guess.
 //!
 //! PLOTSETTINGS has no §20.4 prescription of its own either, but it
 //! does not need one: §20.4.84 LAYOUT opens with the whole
@@ -64,15 +76,19 @@
 //! share a single field list and one of them is measured on 31 real
 //! records.
 
+pub mod acad_detail_view_style;
 pub mod acad_group;
 pub mod acad_layout;
 pub mod acad_material;
+pub mod acad_mleader_style;
 pub mod acad_mlinestyle;
 pub mod acad_plot_settings;
 pub mod acad_property_set_data;
 pub mod acad_scale;
+pub mod acad_section_view_style;
 pub mod acad_visual_style;
 pub mod class_map_extension;
+pub mod color;
 pub mod control;
 pub mod custom_dict_entry;
 pub mod dictionary;

--- a/src/objects/modern.rs
+++ b/src/objects/modern.rs
@@ -274,6 +274,25 @@ pub(crate) mod tests {
         w
     }
 
+    /// The common object data an R2000-R2007 non-entity object leads
+    /// with: empty EED chain, `BL` reactor count, and — from R2004 —
+    /// the xdictionary-missing flag. No R2013+ AcDs binary-data bit.
+    pub(crate) fn r2004_object_prefix(num_reactors: i32) -> BitWriter {
+        let mut w = BitWriter::new();
+        w.write_bs_u(0); // EED terminator
+        w.write_bl(num_reactors);
+        w.write_b(true); // no xdictionary
+        w
+    }
+
+    /// Write one pre-R2007 inline `TV`: `BS` length then that many bytes.
+    pub(crate) fn write_inline_tv(w: &mut BitWriter, s: &str) {
+        w.write_bs_u(s.len() as u16);
+        for b in s.as_bytes() {
+            w.write_rc(*b);
+        }
+    }
+
     /// Build an R2010+ object payload whose *strings present* trailer
     /// bit is clear — the shape every `*_CONTROL`, XRECORD and
     /// ACDB_PLACEHOLDER record actually has. The data fields then end

--- a/tests/code_table_agreement.rs
+++ b/tests/code_table_agreement.rs
@@ -213,6 +213,7 @@ fn non_entity_codes_with_decoders_are_routed_not_unhandled() {
         (0x38, "LTYPE_CONTROL"),
         (0x44, "DIMSTYLE_CONTROL"),
         (0x48, "GROUP"),
+        (0x49, "MLINESTYLE"),
         (0x4F, "XRECORD"),
         (0x50, "ACDB_PLACEHOLDER"),
         (0x52, "LAYOUT"),
@@ -230,14 +231,15 @@ fn non_entity_codes_with_decoders_are_routed_not_unhandled() {
 
 /// Non-entity codes this crate has no self-validating decoder for must
 /// stay `Unhandled` — never fed to an entity decoder, and never counted
-/// as decoded. MLINESTYLE is here because its field list has not been
-/// matched against real bytes yet (see `src/objects/mod.rs`).
+/// as decoded. MLINESTYLE left this list once its §20.4.73 field list
+/// was matched against all ten corpus records (see
+/// `src/objects/acad_mlinestyle.rs`).
 #[test]
 fn non_entity_codes_without_decoders_stay_unhandled() {
     use dwg::Version;
     use dwg::entities::decode_from_raw;
 
-    let unhandled = [(0x49, "MLINESTYLE"), (0x4C, "LONG_TRANSACTION")];
+    let unhandled = [(0x4C, "LONG_TRANSACTION"), (0x51, "VBA_PROJECT")];
     for (code, label) in unhandled {
         match decode_from_raw(&zeroed_raw(code), Version::R2018) {
             DecodedEntity::Unhandled { .. } => { /* correct */ }

--- a/tests/dispatch_roundtrip.rs
+++ b/tests/dispatch_roundtrip.rs
@@ -245,8 +245,8 @@ proptest! {
         payload in prop::collection::vec(any::<u8>(), 0..=256)
     ) {
         for &code in &[
-            0x49u16, // MLINESTYLE
-            0x4C,    // LONG_TRANSACTION
+            0x4Cu16, // LONG_TRANSACTION
+            0x51,    // VBA_PROJECT
         ] {
             let raw = make_raw(code, payload.clone());
             let decoded = decode_from_raw(&raw, Version::R2018);
@@ -271,6 +271,7 @@ proptest! {
             0x32,    // LAYER_CONTROL
             0x44,    // DIMSTYLE_CONTROL
             0x48,    // GROUP
+            0x49,    // MLINESTYLE
             0x4F,    // XRECORD
             0x50,    // ACDB_PLACEHOLDER
         ] {


### PR DESCRIPTION
## What this does

Dispatches four more non-entity object types — `MLINESTYLE`,
`MLEADERSTYLE`, `ACDBDETAILVIEWSTYLE` and `ACDBSECTIONVIEWSTYLE` — on
every release band this crate's object walker reaches, and declines the
fifth (`TABLESTYLE`) with a documented budget rather than guessing it.

All 43 records close **exactly** on their own data-stream boundary (the
first bit of the string stream on R2010+, the `RL` object-data-size on
R2004), which `objects::modern::ObjectStream::finish` enforces, so a
wrong field list returns `DecodedEntity::Error` rather than a
plausible-looking struct.

## Spec sections, and where there are none

- **`MLINESTYLE` — ODA *Open Design Specification for .dwg files*
  v5.4.1 §20.4.73** prescribes the whole record: `TV` name, `TV` desc,
  `BS` flags, `CMC` fillcolor, `BD` startang, `BD` endang, `RC`
  linesinstyle, then per line `BD` offset, `CMC` color and — "Before
  R2018" — `BS` Ltindex, which R2018 replaces with a linetype handle.
  The module previously cited a **"§19.6.4 (L6-13)" that does not
  exist** (the spec has no §19.6 chapter) and read `BS` where §20.4.73
  prints `CMC` for both colour fields, which is 42 bits short per record
  on every real file. That citation is withdrawn.
- **`MLEADERSTYLE`, `ACDBDETAILVIEWSTYLE`, `ACDBSECTIONVIEWSTYLE`,
  `TABLESTYLE` — no prescription.** §20.4 runs from `20.4.1 Common
  Entity Data` to `20.4.104 XRECORD` and carries **no entry** for any of
  the four. No citation is claimed for them; the first three were
  derived by the joint-boundary search and the fourth is declined.

## Per-object status and bit-budget evidence

Budget = bits between the end of the common object data (§19.4.2 — EED
chain, `BL num_reactors`, `B` xdictionary flag, R2013+ `B`
has_ds_binary_data) and the record's data-stream boundary. Delta is
`fields_end − boundary`; only 0 counts as decoded.

| Object | Records | R2004 | R2010 | R2013 | R2018 | Delta |
|---|---|---|---|---|---|---|
| MLINESTYLE (§20.4.73) | 10 | 526 | 442 | 442 | 406 | 0 on all 10 |
| MLEADERSTYLE (derived) | 11 | 744 | 692 | 693 | 693 · 749 | 0 on all 11 |
| ACDBDETAILVIEWSTYLE (derived) | 11 | 1209 | 667 | 667 | 677 · 605 | 0 on all 11 |
| ACDBSECTIONVIEWSTYLE (derived) | 11 | 2325 | 1301 | 1301 | 1263 · 1367 | 0 on all 11 |
| TABLESTYLE | 10 | 1849 | 6836 | 6844 | 5820 | **declined** |

Reproduce any row with:

```sh
cargo run --release --example probe_field_list -- samples/arc_2013.dwg 96 \
    'TV,TV,BS,CMC,BD,BD,RC,BD,CMC,BS,BD,CMC,BS'
```

which prints `ended at 490, boundary 490, delta 0` — the 442-bit
MLINESTYLE budget of `arc_2013.dwg` handle 96 named in #55.

### What makes each derivation more than arithmetic

**MLINESTYLE.** The R2013 → R2018 drop of 36 bits is exactly the two
`BS ltindex` words that release moves into the handle stream: both
records carry two elements, both write the index in the 16-bit `BS`
form, 442 − 2 × 18 = 406. Every record decodes
`startang = endang = π/2`, a ByLayer fill colour, elements at `+0.5`
and `−0.5`, and `ltindex = 32767`, the no-linetype sentinel.

**MLEADERSTYLE.** `Standard` decodes AutoCAD's shipped defaults to the
last digit — landing gap `0.09`, dogleg `0.36`, arrowhead `0.18`, text
height `0.18`, break gap `0.125`, block-content scales `1, 1, 1`,
overall scale `1`, all three colours ByBlock (`0xC1000000`) and the
leader lineweight `-2`, the ByBlock sentinel. R2004 is exactly one
10-bit `BS` shorter at the head and 22 bits shorter at the tail than
R2010; R2010 is exactly one bit shorter than R2013.

**The two view styles.** Text heights decode `5` on every `Metric50`
record and `0.24` on every `Imperial24` one; view-label offsets `15` /
`0.75`; lineweights `25` and `50` (0.25 mm and 0.50 mm in the DWG
hundredths-of-a-millimetre encoding); every `CMC` ByLayer except
`ACDBSECTIONVIEWSTYLE`'s hatch background, which is the `0xC8……` "no
colour" method. `ACDBSECTIONVIEWSTYLE` ends in five consecutive
full-width doubles that decode to **90°, 15°, 75°, −15° and 105°** in
radians — the cutting-plane angle set — and carries `I, O, Q, S, X, Z`
(the identifier letters AutoCAD excludes) and `ANSI31`.

The **R2004 band is the discriminating evidence** for string placement:
there a `TV` is inline and costs real data-stream bits (82, 146, 730 and
66 for `ACDBSECTIONVIEWSTYLE`'s four strings), so a string in the wrong
slot moves everything after it by hundreds of bits and cannot close. It
is also what settles the order of `hatch_pattern_name` and the byte
beside it, which are interchangeable on R2010+ where a `TV` is free.

The **two R2018 records of each view style** are the discriminating
evidence for the R2018 head: only placing the two extra bits *after* the
record's leading `BS` keeps `flags` reading the `32` (detail) / `44`
(section) that R2004, R2010 and R2013 all carry — the other placement
turns it into `72` and desynchronises the first `CMC` on both records.

`H` fields are invisible to this search on every band the walker
reaches: R2000+ puts handle references past the object-data-size
boundary, so a handle costs no data-stream bits. The field lists are the
data stream only, and say so.

### Why TABLESTYLE is declined

`examples/probe_token_scan.rs` measures the structure — a 52-bit header
followed by four cell-style blocks (the string stream names them
`Table`, `_TITLE`, `_HEADER`, `_DATA`) of 1738 / 1696 / 1696 / 1662
bits, each ending in six 168-bit border sub-records of the shape
`CMC` + 36 bits + `BD` + 22 bits. The blocks' internal token sequence is
not determined: each corpus file carries exactly **one** TABLESTYLE
record, and one record with a 52-bit header admits thousands of parses
over `B/BS/BL/BD/RC/CMC`. Budgets are recorded in ARCHITECTURE.md §7d.4
for a follow-up; the records stay `Unhandled`.

## Measured coverage

`cargo run --release --example coverage_report -- <19-file corpus>`,
re-measured on the merged tree after `origin/main` (#58) landed, so the
"before" column is main's post-#58 zero-error baseline:

| Version | Files | Decoded | Skipped | Errored | Ratio |
|---|---|---|---|---|---|
| R2004 (AC1018) | 3 | 498 → **510** | 99 → **87** | 0 → 0 | 83.4 % → **85.4 %** |
| R2010 (AC1024) | 3 | 519 → **531** | 24 → **12** | 0 → 0 | 95.6 % → **97.8 %** |
| R2013 (AC1027) | 3 | 372 → **384** | 24 → **12** | 0 → 0 | 93.9 % → **97.0 %** |
| R2018 (AC1032) | 1 | 755 → **762** | 87 → **80** | 0 → 0 | 89.7 % → **90.5 %** |
| **Aggregate** | 19 | **2144 → 2187** | **234 → 191** | **0 → 0** | 90.2 % → **92.0 %** |

Every one of the 43 records moved from Unhandled to decoded, and the
corpus stays at **zero errors** — nothing was converted into a silent
failure.

`origin/main` is merged into this branch (merge commit on top of #58).
Doc conflicts in README / STATUS / CHANGELOG were resolved by keeping
main's post-#58 text and re-measuring on top of it; `objects::modern`
now takes the no-strings boundary from #58's shared
`string_stream::data_field_end` instead of its own copy of the same
rule.

## Also in this diff

- `objects::color::ObjectColor` — one `CMC` reading for the four
  decoders, which also honours the two name-string bits of the colour
  byte that §2.11 makes conditional.
- `examples/probe_token_scan.rs` — reports the self-identifying anchors
  a candidate field list has to reach exactly: full-form `BD`s that
  decode to short decimals, and `CMC`s whose true-colour word carries a
  real method octet. Neither pattern survives a one-bit misalignment.
- `examples/probe_field_list.rs` and `examples/probe_object_layout.rs`
  now consume the R2013+ AcDs binary-data marker as **16** bits,
  matching what `objects::modern` measured in #52; they were still
  reading a single `RC`.
- `tests/code_table_agreement.rs` and `tests/dispatch_roundtrip.rs`:
  MLINESTYLE (0x49) moves from the "no decoder — must stay Unhandled"
  lists into the routed / totality lists; `VBA_PROJECT` (0x51) takes its
  place as the decoderless example.

BitWriter-built tests per decoder cover the R2018 split-stream layout,
the R2013 / R2010 variants where they differ, and the R2004 inline-`TV`
layout, plus the negative cases: an R2013 body must not satisfy the
R2018 field list, and vice versa.

This also completes the MLINESTYLE half of #39, which #52 closed on the
LAYOUT half alone.

## Gate

`cargo fmt --all` · `cargo clippy --all-targets --all-features -D
warnings` · `cargo test --release` (734 lib + 16 integration suites,
all green) · `cargo deny check all` · `RUSTDOCFLAGS='-D warnings' cargo
doc --no-deps --all-features` · `cargo +1.85.0 test --no-run` (MSRV).

## Source-provenance declaration

**Clean-room declaration.** I certify that:

1. All code and tests in this PR were written from scratch by me.
2. I consulted only sources listed as allowed in `CLEANROOM.md`. In
   particular, I did not consult Autodesk SDK source, ODA SDK
   (Drawings SDK / Teigha) source, LibreDWG source, decompilations of
   Autodesk or ODA binaries, or any copyleft-licensed DWG
   implementation code.
3. `MLINESTYLE` cites ODA spec v5.4.1 §20.4.73 and the citation is in
   the diff. The other three objects claim **no** spec section, because
   §20.4 has none for them; their field lists come from the corpus
   bytes.
4. Slot **names** for the three derived objects are published-
   documentation vocabulary only — the conventional `AcDbMLeaderStyle`
   property ordering from Autodesk's public *DXF Reference*, and the
   field vocabulary of AutoCAD's Detail View Style and Section View
   Style dialogs from Autodesk's public product documentation. No code,
   structure or layout was taken from either; they contributed
   vocabulary only, and slots whose decoded values do not corroborate a
   name are labelled `unknown_*` / `flag_*` or documented as positional.
   This is disclosed in `CLEANROOM.md` alongside the existing
   VISUALSTYLE entry.

Closes #55

https://claude.ai/code/session_01BaHKf1Rw5aJBGK5y3xmx7C
