### PR TITLE
feat(objects): decode VISUALSTYLE on R2004 — the flag-less generation (72 records, 92.0% → 95.0%)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -487,12 +487,59 @@ cargo run --release --example probe_field_list -- \
     samples/arc_2010.dwg 42 BS,BS,B,BS,BS,BD,BD
 ```
 
-R2004 and R2007 VISUALSTYLE records store the same styles *without* the
-per-property flags and with a different property count; no sequence
-over the same token set lands their 24 records on their `RL`
-object-data-size boundary, so `objects::acad_visual_style` returns
-`Error::Unsupported` for those bands rather than guessing, and the
-dispatcher maps that to `Unhandled`.
+### 7d.1a The same object one generation earlier — VISUALSTYLE on R2004
+
+R2004 stores the same 24 styles *without* the per-property flags, with
+one fewer property and in a visibly different order, so the R2010 list
+misses its `RL` object-data-size boundary by hundreds of bits. Deriving
+the earlier list needed two things the R2010 pass did not: an anchor at
+each end of the record, and a second file to cross-check values
+against.
+
+Both ends were anchored from the record's own redundancy. At the front,
+`examples/probe_token_scan.rs` reports the self-identifying tokens —
+full-form `BD`s that decode to short decimals, `CMC`s whose true-colour
+word carries a real method octet — and the first three of those pin
+`face_opacity`, `face_specular` and `face_mono_color`. At the back, a
+reverse scan for the *unique* offset at which `BS, BL, BS, B` lands
+exactly on the boundary returns one position per record, and its four
+values reproduce R2010's `edge_style_apply` (`1` / `5` / `13`),
+`display_shadow_type` (`0`) and `is_internal_use_only` — the last of
+which splits the 24 styles into the ten AutoCAD's Visual Styles Manager
+lists and the fourteen it hides. That is the discovery that the
+flag-less generation moved `is_internal_use_only` from the record's
+head to its **final bit**, and that `display_brightness` is a `BL`
+there where R2010 spends a `BD`: `Dim` decodes `-50`, `Brighten` `50`,
+the other 22 records `0`, against R2010's `-50.0` / `50.0` / `0.0`, and
+that `BL` is the entire reason `Dim`'s record is 32 bits longer than
+its neighbours' and `Brighten`'s 8.
+
+With both ends fixed, the middle closes as `arc_2010.dwg`'s field
+values, in `arc_2004.dwg`'s order — 30 fields, delta 0 on all 24
+records of each of the three `*_2004.dwg` files. Twelve `BS` slots,
+all five `CMC`s and both remaining `BD`s reproduce R2010's decoded
+value for the *same style* on all 24 records, including the ones that
+vary style by style (`edge_modifier` `0`/`8`/`10`/`11`/`12`,
+`edge_silhouette_width` `3`/`5`/`6`, `edge_obscured_linetype` `2` on
+`Hidden`, `7` on `Linepattern`). Two slots differ informatively rather
+than worryingly: `face_opacity` and `face_specular` are **signed** on
+R2004, their magnitudes agreeing with R2010 on all 24 while the sign
+tracks whether the property applies to the style.
+
+One 13-bit run — between `edge_silhouette_width` and
+`edge_intersection_linetype` — is constant on all 72 records, so its
+internal boundaries cannot be measured, only its width. The module
+documents that explicitly, names the three properties R2010 places
+there (all of which decode zero), and surfaces the run's leading byte
+as `edge_unknown_byte` rather than inventing a name for it.
+
+R2007 stays undecoded, and not for want of a field list: the container
+parse returns `SectionMapStatus::Deferred` for `AC1021` and
+`string_stream::data_section_end` locates the split-stream trailer from
+a leading `MC` field only R2010+ writes, so no R2007 object of any type
+reaches a decoder. `objects::acad_visual_style` returns
+`Error::Unsupported` for that band and the dispatcher maps it to
+`Unhandled`.
 
 ### 7d.2 Checking a field list the spec *does* carry — LAYOUT
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,67 @@ once the public API stabilizes at 0.1.0.
 
 ## [Unreleased]
 
+### Added — VISUALSTYLE on R2004: the flag-less generation (2026-08-30, refs #48)
+
+`VISUALSTYLE` now dispatches on R2004 as well as R2010+, taking all 72
+of its `AC1018` corpus records — the whole of the largest remaining
+`Unhandled` block. R2004 stores the same 24 shipped styles on a
+**second field list**: 30 fields, no `(value, flag)` pairs, one fewer
+property and a different order. It closes with delta 0 on all 24
+records of each of `arc_2004.dwg`, `circle_2004.dwg` and
+`line_2004.dwg`.
+
+- **Both ends of the record are anchored, not assumed.** The front
+  comes from `examples/probe_token_scan.rs` — the full-form `BD`s and
+  method-carrying `CMC`s that cannot survive a one-bit shift. The back
+  comes from a reverse scan for the unique offset at which
+  `BS, BL, BS, B` lands exactly on the `RL` object-data-size boundary;
+  it returns exactly one position per record, and its values reproduce
+  R2010's `edge_style_apply`, `display_shadow_type` and
+  `is_internal_use_only` on all 24.
+- **Two structural findings.** `is_internal_use_only` is the record's
+  **final bit** on R2004, not part of its head — and it splits the 24
+  styles into precisely the ten AutoCAD's Visual Styles Manager lists
+  and the fourteen it hides, the same partition R2010 makes 500-odd
+  bits earlier. `display_brightness` is a `BL` where R2010 spends a
+  `BD`, decoding `-50` / `50` / `0` against R2010's `-50.0` / `50.0` /
+  `0.0`; that `BL` is the whole reason `Dim`'s record runs 32 bits
+  longer than its neighbours' and `Brighten`'s 8.
+- **Cross-file value corroboration.** Twelve `BS` slots, all five
+  `CMC`s and both remaining `BD`s decode the same value as the *same
+  style* on `arc_2010.dwg`, on all 24 records — `edge_modifier`
+  `0`/`8`/`10`/`11`/`12`, `edge_silhouette_width` `3`/`5`/`6`,
+  `edge_obscured_linetype` `2` on `Hidden`, `7` on `Linepattern`,
+  `edge_crease_angle` `40`/`179`/`1`, `ColorChange`'s grey
+  `0xC2808080` and `Shaded`'s `0xC2787878` silhouette included.
+  `face_opacity` and `face_specular` are **signed** on R2004: their
+  magnitudes match R2010 everywhere, and the sign tracks whether the
+  property applies to the style.
+- **One 13-bit run is declared, not invented.** Between
+  `edge_silhouette_width` and `edge_intersection_linetype` sit 13 bits
+  that are constant on every one of the 72 records, so only their total
+  width is evidence. The module reads them as `RC BS B BS`, names the
+  last three for the three R2010 properties that occupy the same
+  position (all zero), and surfaces the leading byte as
+  `AcadVisualStyle::edge_unknown_byte`.
+- **R2007 stays declined and the reason is upstream.** The container
+  parse is `Deferred` for `AC1021` and the split-stream trailer is
+  located from a leading `MC` field only R2010+ writes, so no R2007
+  object of any type reaches a decoder. `decode_object` returns
+  `Error::Unsupported` there rather than shipping an unmeasured
+  reading, and the dispatcher maps that to `Unhandled` — #48 stays open
+  for that band.
+
+Measured coverage on the local 19-file corpus, before → after:
+
+| Version | Decoded | Skipped | Errored | Ratio |
+|---|---|---|---|---|
+| R2004 (AC1018) | 510 → 582 | 87 → 15 | 0 → 0 | 85.4 % → **97.5 %** |
+| R2010 (AC1024) | 531 → 531 | 12 → 12 | 0 → 0 | 97.8 % → **97.8 %** |
+| R2013 (AC1027) | 384 → 384 | 12 → 12 | 0 → 0 | 97.0 % → **97.0 %** |
+| R2018 (AC1032) | 762 → 762 | 80 → 80 | 0 → 0 | 90.5 % → **90.5 %** |
+| **Aggregate** | **2187 → 2259** | **191 → 119** | **0 → 0** | 92.0 % → **95.0 %** |
+
 ### Added — MLINESTYLE (§20.4.73) and three style classes the spec does not prescribe (2026-08-30, closes #55)
 
 `MLINESTYLE`, `MLEADERSTYLE`, `ACDBDETAILVIEWSTYLE` and

--- a/CLEANROOM.md
+++ b/CLEANROOM.md
@@ -130,6 +130,19 @@ it contributed vocabulary only. ODA spec v5.4.1 has no VISUALSTYLE or MATERIAL
 section; the `§19.6.9` / `§19.6.10` citations previously in this tree were
 withdrawn in the same PR.
 
+The PR for #48 extends `VISUALSTYLE` to the R2004 band and needs **no
+new outside vocabulary at all**. Its field list was derived from bytes
+the same way — the one token sequence that lands all 24 records of each
+of `arc_2004.dwg`, `circle_2004.dwg` and `line_2004.dwg` exactly on
+their `RL` object-data-size boundary — and every name on it is carried
+over from the R2010 list disclosed above, justified slot by slot
+against the value the *same style* decodes on `arc_2010.dwg`. The one
+slot with no R2010 counterpart is labelled `edge_unknown_byte`, and the
+13-bit run it leads is documented as a run whose internal boundaries
+the corpus cannot separate rather than being split into invented
+fields. R2007 is declined outright: no `AC1021` object reaches a
+decoder in this crate, so nothing is claimed about that band.
+
 ## 2026-08-30 — LAYOUT / PLOTSETTINGS field names (ODA spec §20.4.84)
 
 PR for #50 replaces the LAYOUT and PLOTSETTINGS field lists. Unlike

--- a/README.md
+++ b/README.md
@@ -24,16 +24,16 @@ local `samples/` set:
 | Version | Files tested | Decoded | Skipped | Errored | Success rate |
 |---------|--------------|---------|---------|---------|--------------|
 | R14 / R2000 / R2007 | 9 | n/a | n/a | n/a | not supported (no handle-map for this layout yet) |
-| R2004 (AC1018)      | 3 | 510 | 87 | 0 | **85.4 %** |
+| R2004 (AC1018)      | 3 | 582 | 15 | 0 | **97.5 %** |
 | R2010 (AC1024)      | 3 | 531 | 12 | 0 | **97.8 %** |
 | R2013 (AC1027)      | 3 | 384 | 12 | 0 | **97.0 %** |
 | R2018 (AC1032)      | 1 | 762 | 80 | 0 | **90.5 %** |
-| **Aggregate** | **19** | **2187** | **191** | **0** | **92.0 %** |
+| **Aggregate** | **19** | **2259** | **119** | **0** | **95.0 %** |
 
 **Every record of every file in the corpus that reaches a decoder now
-decodes, and none errors.** What is left is the *skipped* column — 191
-records of types this crate has no decoder for at all (VISUALSTYLE on
-R2004/R2007, MATERIAL, TABLESTYLE) — not records it reads wrongly.
+decodes, and none errors.** What is left is the *skipped* column — 119
+records of types this crate has no decoder for at all (MATERIAL,
+TABLESTYLE) — not records it reads wrongly.
 
 That matters more than the ratio, because every R2007+ decoder in this
 crate is *self-validating*: its data fields must end exactly on the first
@@ -56,9 +56,9 @@ correctly too — an `RL` object data size in bits sits between the object
 type and the object handle on the whole R2000..R2007 band, and skipping it
 put every AC1018 record 32 bits out of phase.
 
-The remaining gap is the *unhandled* list, not the errored one: VISUALSTYLE
-on R2004/R2007, MATERIAL and TABLESTYLE have no field list matched against
-real bytes yet. Closing those is the 0.2.0 milestone.
+The remaining gap is the *unhandled* list, not the errored one: MATERIAL
+and TABLESTYLE have no field list matched against real bytes yet. Closing
+those is the 0.2.0 milestone.
 
 ## Capability matrix at a glance
 
@@ -76,7 +76,7 @@ real bytes yet. Closing those is the 0.2.0 milestone.
 | HandleMap + ClassMap parsing | ✓ shipped | — |
 | Header variables | ✓ shipped | Strict + lossy variants |
 | Object-stream walker (R2004+) | ✓ shipped | R14 / R2000 / R2007 pending (#104) |
-| Per-entity field decoders | ⚠ alpha | Broad synthetic coverage; real-file aggregate currently 92.0 %, zero errors (#103) |
+| Per-entity field decoders | ⚠ alpha | Broad synthetic coverage; real-file aggregate currently 95.0 %, zero errors (#103) |
 | Entity graph (owner / reactors / blocks / layers) | ⚠ partial | Resolver APIs exist; trailing-handle/block traversal gaps remain |
 | Symbol tables (LAYER / LTYPE / STYLE / DIMSTYLE / …) | ⚠ partial | R2007+ BLOCK_HEADER and simple LTYPE names decode; broader content fields pending |
 | SVG / PDF export | ⚠ alpha | SVG writer + paged-SVG PDF path; output quality depends on decoded geometry |

--- a/STATUS.md
+++ b/STATUS.md
@@ -12,11 +12,11 @@ scrolling the changelog.
 - **Integration tests:** DXF round-trip (7), glTF smoke (3), SVG
   goldens (3), fuzz-corpus regression (6), write-path (5),
   entity-regression (18), real-DWG value regression (8).
-- **Current real-file decode coverage:** 2,187 decoded / 191 skipped /
-  **0 errored** / 92.0% on the local 19-file `samples/` corpus. The
+- **Current real-file decode coverage:** 2,259 decoded / 119 skipped /
+  **0 errored** / 95.0% on the local 19-file `samples/` corpus. The
   R2018 `sample_AC1032.dwg` sample is 762 / 80 / 0 / 90.5%. **No file
   in the corpus has a single errored record.** Per version:
-  R2004 85.4%, R2010 97.8%, R2013 97.0%, R2018 90.5%. What remains is
+  R2004 97.5%, R2010 97.8%, R2013 97.0%, R2018 90.5%. What remains is
   the *skipped* column — types with no decoder at all — not records
   that decode wrongly.
 - **Handle-map completeness:** every one of the 842 `AcDb:Handles`
@@ -212,8 +212,8 @@ scrolling the changelog.
 These have genuine open scope requiring focused work, not stubs.
 
 - **Current real-file decode baseline:** the 2026-08-30
-  `examples/coverage_report.rs ../../samples` run reports 2187 decoded,
-  191 skipped, 0 errored, 92.0% aggregate coverage. This is the
+  `examples/coverage_report.rs ../../samples` run reports 2259 decoded,
+  119 skipped, 0 errored, 95.0% aggregate coverage. This is the
   practical product-readiness blocker even though synthetic decoder
   tests are broad.
 
@@ -222,14 +222,15 @@ These have genuine open scope requiring focused work, not stubs.
   ACAD_SCALE now dispatch through `src/objects/modern.rs`, taking their
   `TV` fields from the R2007+ string stream and checking their data
   fields end exactly on the record's data-stream boundary.
-  VISUALSTYLE dispatches on R2010, R2013 and R2018 — 168 of its 240
-  corpus records — LAYOUT (with its embedded PLOTSETTINGS block)
+  VISUALSTYLE dispatches on R2004, R2010, R2013 and R2018 — 240 of its
+  240 corpus records, the R2004 band on a second, flag-less field list
+  measured against all 72 of its records — LAYOUT (with its embedded
+  PLOTSETTINGS block)
   dispatches on all 31 of its corpus records, and MLINESTYLE (10),
   MLEADERSTYLE (11), ACDBDETAILVIEWSTYLE (11) and
   ACDBSECTIONVIEWSTYLE (11) dispatch on all of theirs. Still
   unreached, in descending record count on the corpus (counts as of
-  the 2026-08-30 run): VISUALSTYLE on R2004/R2007 (72 records),
-  MATERIAL (38), TABLESTYLE (10). MATERIAL and PROPERTYSET_DATA decode
+  the 2026-08-30 run): MATERIAL (38), TABLESTYLE (10). MATERIAL and PROPERTYSET_DATA decode
   only a documented prefix of their fields, so they cannot satisfy the
   boundary check; TABLESTYLE's block structure is measured
   (ARCHITECTURE.md §7d.4) but a single record per corpus file cannot

--- a/src/objects/acad_visual_style.rs
+++ b/src/objects/acad_visual_style.rs
@@ -1,5 +1,5 @@
 //! ACAD_VISUALSTYLE object — named display style (face lighting model,
-//! edge rendering, silhouette, shadows). R2010+ only.
+//! edge rendering, silhouette, shadows). R2004 and newer.
 //!
 //! # There is no spec prescription for this object
 //!
@@ -11,7 +11,7 @@
 //! section exists.) Everything below was therefore derived by measuring
 //! real records against the boundary the format itself provides.
 //!
-//! # The wire shape — measured
+//! # The wire shape — measured, R2010 and newer
 //!
 //! ```text
 //! TV   description                  -- from the string stream on R2007+
@@ -99,18 +99,146 @@
 //! not independently corroborated by this crate. Treat them as labels
 //! for slots whose layout is proven, not as verified semantics.
 //!
+//! # The wire shape — measured, R2004 (the flag-less generation)
+//!
+//! `arc_2004.dwg` stores the same 24 shipped styles with **no**
+//! per-property flags, one fewer property, and a visibly different
+//! order. This is the list that lands all 24 records of each of
+//! `arc_2004.dwg`, `circle_2004.dwg` and `line_2004.dwg` exactly on
+//! their `RL` object-data-size boundary — 72 records, delta 0:
+//!
+//! ```text
+//! TV   description                  -- inline on R2004, string stream on R2007
+//! BS   internal_style_type          BS  face_lighting_model
+//! BS   face_lighting_quality        BS  face_color_mode
+//! BD   face_opacity                 BD  face_specular
+//! CMC  face_mono_color              BS  face_modifier
+//! BS   edge_model                   BS  edge_style
+//! CMC  edge_intersection_color      CMC edge_obscured_color
+//! BS   edge_obscured_linetype       BD  edge_crease_angle
+//! BS   edge_modifier                CMC edge_color
+//! BD   edge_opacity                 BS  edge_width
+//! BS   edge_overhang                BS  edge_jitter
+//! CMC  edge_silhouette_color        BS  edge_silhouette_width
+//! RC   edge_unknown_byte            BS  edge_halo_gap
+//! B    edge_hide_precision          BS  edge_isoline_count
+//! BS   edge_intersection_linetype   BS  edge_style_apply
+//! BL   display_brightness           BS  display_shadow_type
+//! B    is_internal_use_only
+//! ```
+//!
+//! Three slots of the R2010 head are gone or moved: there is no
+//! `format_version` at all, `face_modifier` sits after
+//! `face_mono_color` rather than before `face_opacity`, and
+//! `is_internal_use_only` is the record's **last bit** rather than part
+//! of its head.
+//!
+//! # Why the R2004 list is not a guess either
+//!
+//! The same boundary rule arbitrates it — the record's `RL`
+//! object-data-size from the object prologue — and every slot but two
+//! is cross-checked against the value the *same style* decodes on
+//! `arc_2010.dwg`, where the layout is independently proven:
+//!
+//! - `internal_style_type` agrees on all 24 (`0` `Flat` … `27`
+//!   `Shaded`);
+//! - `face_lighting_model`, `face_color_mode`, `face_modifier`,
+//!   `edge_model`, `edge_style`, `edge_modifier`, `edge_width`,
+//!   `edge_overhang`, `edge_jitter`, `edge_silhouette_width`,
+//!   `edge_style_apply` and `display_shadow_type` agree on all 24 —
+//!   including the values that vary style by style: `edge_modifier`
+//!   `8`/`0`/`10`/`11`/`12`, `edge_silhouette_width` `3`/`5`/`6`,
+//!   `edge_style_apply` `1`/`5`/`13`;
+//! - all five `CMC`s agree on all 24, `ColorChange`'s grey
+//!   `0xC2808080` face and edge colours and `Shaded`'s `0xC2787878`
+//!   silhouette included;
+//! - `edge_crease_angle` agrees on all 24: `40` on `Hidden`,
+//!   `Shades of Gray` and `Sketchy`, `179` on `Conceptual`, `1`
+//!   elsewhere;
+//! - `edge_obscured_linetype` agrees on all 24 (`2` on `Hidden` and
+//!   `Shaded with edges`, `7` on `Linepattern`, `1` elsewhere) and so
+//!   does `edge_intersection_linetype` (`7` on `Linepattern`, `1`
+//!   elsewhere) — the pair that pins the two ends of the trailing run;
+//! - `is_internal_use_only`, the record's final bit, splits the 24
+//!   styles into exactly the ten AutoCAD's Visual Styles Manager lists
+//!   and the fourteen it hides, the same partition R2010 produces from
+//!   a bit 500-odd positions earlier.
+//!
+//! The two slots that do not agree literally are informative rather
+//! than worrying:
+//!
+//! - `display_brightness` is a **`BL`** here where R2010 spends a `BD`,
+//!   and it decodes `-50`, `50` and `0` against R2010's `-50.0`, `50.0`
+//!   and `0.0` — `Dim`, `Brighten` and the other 22. The `BL` is also
+//!   what explains the corpus's bit budgets: `Dim` spends 32 more bits
+//!   than its neighbours (full `BL` vs the `0` form) and `Brighten` 8
+//!   more (byte `BL`), and nothing else in the record varies between
+//!   those three styles.
+//! - `face_opacity` and `face_specular` are **signed** here where
+//!   R2010's are not. Their magnitudes agree with R2010 on all 24
+//!   records; the sign tracks whether the property applies to the
+//!   style. `face_specular` is positive on exactly the seven styles
+//!   that shade faces (`Flat`, `FlatWithEdges`, `Gouraud`,
+//!   `GouraudWithEdges`, `Realistic`, `Shaded`, `Shaded with edges`)
+//!   and negative on the other seventeen; `face_opacity` is positive on
+//!   exactly `X-Ray`, the one translucent style, and negative on the
+//!   other twenty-three. The values are surfaced as measured, sign
+//!   included.
+//!
+//! One further value differs for content rather than layout reasons:
+//! `Realistic` decodes `face_lighting_quality` `2` on R2004 and `3` on
+//! R2010. Every other field of that record agrees, so this is the style
+//! being clamped when it is saved down, not a mis-read field.
+//!
+//! ## What the R2004 list does *not* determine
+//!
+//! Thirteen bits sit between `edge_silhouette_width` and
+//! `edge_intersection_linetype`, and they hold the constant
+//! `0b0_0000_0001_0010` on **every one of the 72 corpus records**. A
+//! run that never varies cannot have its internal boundaries measured,
+//! and several token splits fit it. This module reads it as `RC` `BS`
+//! `B` `BS` — the only fit whose first token is a whole byte — and names
+//! the last three for the three properties R2010 places in exactly this
+//! position, all of which decode `0`, `false` and `0` there on the same
+//! 24 styles. The leading byte has no R2010 counterpart and is
+//! surfaced as [`AcadVisualStyle::edge_unknown_byte`] rather than given
+//! a plausible-sounding name. Only the run's **total width** and its
+//! constant contents are evidence; the boundaries inside it are a
+//! reading, and a future R2004 file with a non-default halo gap or
+//! isoline count would settle them.
+//!
+//! # Naming
+//!
+//! The field **types, widths and order** above are measured. The
+//! **names** follow the conventional `AcDbVisualStyle` property
+//! ordering; the face group is corroborated by the decoded values as
+//! described above, the edge and display groups are positional and are
+//! not independently corroborated by this crate. Treat them as labels
+//! for slots whose layout is proven, not as verified semantics.
+//!
 //! # Versions
 //!
 //! | Release | Status |
 //! |---|---|
-//! | R2010 | 28 properties — closes on all 24 records of `arc_2010.dwg` |
+//! | R2000 and earlier | `CMC` has no true-colour word; [`Error::Unsupported`] |
+//! | R2004 | 30 flag-less fields — closes on all 72 records of the three `*_2004.dwg` files |
+//! | R2007 | not measurable — [`Error::Unsupported`]; see below |
+//! | R2010 | 28 `(value, flag)` properties — closes on all 24 records of `arc_2010.dwg` |
 //! | R2013 / R2018 | 58 properties — closes on all 24 records of `arc_2013.dwg` and all 24 of `sample_AC1032.dwg` |
-//! | R2004 / R2007 | layout differs and is **not** determined; [`Error::Unsupported`] |
 //!
-//! `arc_2004.dwg` stores the same styles without the per-property flags
-//! and with a different property count; no token sequence over
-//! `BS/BD/CMC/B` lands its 24 records on their `RL` object-data-size
-//! boundary, so this module declines that band rather than guessing.
+//! **R2007 stays declined, and not because of this object.** Two
+//! upstream gaps stand between an `AC1021` file and any decoder:
+//! the container parse returns `SectionMapStatus::Deferred` for R2007
+//! (the second Sec_Mask obfuscation layer is not implemented), and
+//! `crate::string_stream::data_section_end` locates the split-stream
+//! trailer from the leading `MC` handle-stream size that only R2010 and
+//! newer write, so it declines R2007 outright. No R2007 object of any
+//! type therefore reaches this module, the corpus cannot say whether
+//! R2007 writes the flag-less list or the paired one, and this module
+//! returns [`Error::Unsupported`] rather than shipping a reading no
+//! byte has ever confirmed. The 24 VISUALSTYLE records in each of
+//! `arc_2007.dwg`, `circle_2007.dwg` and `line_2007.dwg` are invisible
+//! to `examples/coverage_report.rs` for the same reason.
 
 use crate::bitcursor::BitCursor;
 use crate::error::{Error, Result};
@@ -171,7 +299,8 @@ pub struct AcadVisualStyle {
     pub description: String,
     /// Dense per-style enumeration, `0` (`Flat`) … `27` (`Shaded`).
     pub internal_style_type: i16,
-    /// `2` in every record measured.
+    /// `2` in every R2010+ record measured. The R2004 layout has no
+    /// such field, and leaves this `0`.
     pub format_version: i16,
     /// Set on the styles AutoCAD does not offer in the UI.
     pub is_internal_use_only: bool,
@@ -219,6 +348,11 @@ pub struct AcadVisualStyle {
     pub edge_silhouette_color: VisualStyleColor,
     /// Edge property (positional name): silhouette width.
     pub edge_silhouette_width: i16,
+    /// R2004 only: the leading byte of the constant 13-bit run between
+    /// `edge_silhouette_width` and `edge_intersection_linetype`. `0` on
+    /// every corpus record, with no R2010 counterpart — see the module
+    /// docs. Always `0` on R2010 and newer, which have no such slot.
+    pub edge_unknown_byte: u8,
     /// Edge property (positional name): halo gap.
     pub edge_halo_gap: i16,
     /// Edge property (positional name): isoline count.
@@ -227,7 +361,8 @@ pub struct AcadVisualStyle {
     pub edge_hide_precision: bool,
     /// Edge property (positional name): style-apply bits.
     pub edge_style_apply: i16,
-    /// Display property (positional name): brightness.
+    /// Display property (positional name): brightness. A `BD` on
+    /// R2010+ and a whole-number `BL` on R2004, widened here.
     pub display_brightness: f64,
     /// Display property (positional name): shadow type.
     pub display_shadow_type: i16,
@@ -355,22 +490,146 @@ const R2013_TAIL: [TailKind; 30] = [
 /// taking its `TV` fields from the R2007+ string stream and checking
 /// that the data fields end exactly on the data-stream boundary.
 ///
-/// Returns [`Error::Unsupported`] for R2007 and earlier, whose layout
-/// this crate has not matched against real bytes.
+/// R2004 uses the flag-less field list, R2010 and newer the
+/// `(value, flag)` one. Returns [`Error::Unsupported`] for R2007 and
+/// earlier — see the module docs for why neither band can be measured.
 pub fn decode_object(
     payload: &[u8],
     body_start: usize,
     inline_data_end: Option<usize>,
     version: Version,
 ) -> Result<AcadVisualStyle> {
-    if !version.is_r2010_plus() {
-        return Err(Error::Unsupported {
+    match version {
+        Version::R2004 => decode_legacy(payload, body_start, inline_data_end, version),
+        _ if version.is_r2010_plus() => {
+            decode_paired(payload, body_start, inline_data_end, version)
+        }
+        _ => Err(Error::Unsupported {
             feature: format!(
-                "ACAD_VISUALSTYLE layout is only determined for R2010 or newer; got {}",
+                "ACAD_VISUALSTYLE layout is determined for R2004 and R2010 or newer; got {}",
                 version.release()
             ),
-        });
+        }),
     }
+}
+
+/// Read one `CMC` outside the `(value, flag)` reader.
+fn read_color(c: &mut BitCursor<'_>) -> Result<VisualStyleColor> {
+    let (index, rgb, color_byte) = crate::tables::modern::read_cmc_full(c)?;
+    Ok(VisualStyleColor {
+        index,
+        rgb,
+        color_byte,
+    })
+}
+
+/// The R2004 field list — 30 fields, no per-property flags.
+fn decode_legacy(
+    payload: &[u8],
+    body_start: usize,
+    inline_data_end: Option<usize>,
+    version: Version,
+) -> Result<AcadVisualStyle> {
+    let mut split = modern::open(payload, body_start, inline_data_end, version)?;
+    let description = modern::read_tv(&mut split.data, &mut split.strings, version)?;
+    let c = &mut split.data;
+    let internal_style_type = c.read_bs()?;
+    let face_lighting_model = c.read_bs()?;
+    let face_lighting_quality = c.read_bs()?;
+    let face_color_mode = c.read_bs()?;
+    let face_opacity = c.read_bd()?;
+    let face_specular = c.read_bd()?;
+    let face_mono_color = read_color(c)?;
+    let face_modifier = c.read_bs()?;
+    let edge_model = c.read_bs()?;
+    let edge_style = c.read_bs()?;
+    let edge_intersection_color = read_color(c)?;
+    let edge_obscured_color = read_color(c)?;
+    let edge_obscured_linetype = c.read_bs()?;
+    let edge_crease_angle = c.read_bd()?;
+    let edge_modifier = c.read_bs()?;
+    let edge_color = read_color(c)?;
+    let edge_opacity = c.read_bd()?;
+    let edge_width = c.read_bs()?;
+    let edge_overhang = c.read_bs()?;
+    let edge_jitter = c.read_bs()?;
+    let edge_silhouette_color = read_color(c)?;
+    let edge_silhouette_width = c.read_bs()?;
+    // The constant 13-bit run — only its total width is evidence.
+    let edge_unknown_byte = c.read_rc()?;
+    let edge_halo_gap = c.read_bs()?;
+    let edge_hide_precision = c.read_b()?;
+    let edge_isoline_count = c.read_bs()?;
+    let edge_intersection_linetype = c.read_bs()?;
+    let edge_style_apply = c.read_bs()?;
+    let display_brightness = f64::from(c.read_bl()?);
+    let display_shadow_type = c.read_bs()?;
+    let is_internal_use_only = c.read_b()?;
+
+    split.finish("VISUALSTYLE")?;
+
+    Ok(AcadVisualStyle {
+        description,
+        internal_style_type,
+        format_version: 0,
+        is_internal_use_only,
+        face_lighting_model,
+        face_lighting_quality,
+        face_color_mode,
+        face_modifier,
+        face_opacity,
+        face_specular,
+        face_mono_color,
+        edge_model,
+        edge_style,
+        edge_intersection_color,
+        edge_obscured_color,
+        edge_obscured_linetype,
+        edge_intersection_linetype,
+        edge_crease_angle,
+        edge_modifier,
+        edge_color,
+        edge_opacity,
+        edge_width,
+        edge_overhang,
+        edge_jitter,
+        edge_silhouette_color,
+        edge_silhouette_width,
+        edge_unknown_byte,
+        edge_halo_gap,
+        edge_isoline_count,
+        edge_hide_precision,
+        edge_style_apply,
+        display_brightness,
+        display_shadow_type,
+        property_flags: Vec::new(),
+        extended: Vec::new(),
+        trailing_strings: trailing_strings(&mut split),
+    })
+}
+
+/// Drain whatever the record's string stream still holds.
+fn trailing_strings(split: &mut modern::ObjectStream<'_>) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(strings) = split.strings.as_mut() {
+        while !strings.is_exhausted() {
+            match strings.read_tv() {
+                Ok(text) => out.push(text),
+                Err(_) => break,
+            }
+        }
+    }
+    out
+}
+
+/// The R2010+ field list — 28 (R2010) or 58 (R2013+) `(value, flag)`
+/// property pairs behind a three-field head.
+fn decode_paired(
+    payload: &[u8],
+    body_start: usize,
+    inline_data_end: Option<usize>,
+    version: Version,
+) -> Result<AcadVisualStyle> {
     let mut split = modern::open(payload, body_start, inline_data_end, version)?;
     let description = modern::read_tv(&mut split.data, &mut split.strings, version)?;
     let internal_style_type = split.data.read_bs()?;
@@ -421,15 +680,7 @@ pub fn decode_object(
 
     split.finish("VISUALSTYLE")?;
 
-    let mut trailing_strings = Vec::new();
-    if let Some(strings) = split.strings.as_mut() {
-        while !strings.is_exhausted() {
-            match strings.read_tv() {
-                Ok(text) => trailing_strings.push(text),
-                Err(_) => break,
-            }
-        }
-    }
+    let trailing_strings = trailing_strings(&mut split);
 
     Ok(AcadVisualStyle {
         description,
@@ -458,6 +709,7 @@ pub fn decode_object(
         edge_jitter,
         edge_silhouette_color,
         edge_silhouette_width,
+        edge_unknown_byte: 0,
         edge_halo_gap,
         edge_isoline_count,
         edge_hide_precision,
@@ -586,10 +838,100 @@ mod tests {
         crate::string_stream::tests::build_payload(&bits, &["Flat", "strokes_ogs.tif"])
     }
 
+    /// The R2004 field list: 30 fields, no flags, `is_internal_use_only`
+    /// last. Mirrors the module's measured table.
+    fn write_legacy_properties(w: &mut BitWriter) {
+        w.write_bs(0); // internal_style_type
+        w.write_bs(2); // face_lighting_model
+        w.write_bs(1); // face_lighting_quality
+        w.write_bs(1); // face_color_mode
+        w.write_bd(-0.6); // face_opacity — signed on R2004
+        w.write_bd(30.0); // face_specular
+        cmc(w, 0, 0xC2FF_FFFF, 0); // face_mono_color
+        w.write_bs(2); // face_modifier
+        w.write_bs(0); // edge_model
+        w.write_bs(0); // edge_style
+        cmc(w, 0, 0xC300_0007, 0); // edge_intersection_color
+        cmc(w, 0, 0xC800_0000, 0); // edge_obscured_color
+        w.write_bs(1); // edge_obscured_linetype
+        w.write_bd(1.0); // edge_crease_angle
+        w.write_bs(8); // edge_modifier
+        cmc(w, 0, 0xC300_0007, 0); // edge_color
+        w.write_bd(1.0); // edge_opacity
+        w.write_bs(1); // edge_width
+        w.write_bs(6); // edge_overhang
+        w.write_bs(2); // edge_jitter
+        cmc(w, 0, 0xC300_0007, 0); // edge_silhouette_color
+        w.write_bs(5); // edge_silhouette_width
+        w.write_rc(0); // the constant run's leading byte
+        w.write_bs(0); // edge_halo_gap
+        w.write_b(false); // edge_hide_precision
+        w.write_bs(0); // edge_isoline_count
+        w.write_bs(1); // edge_intersection_linetype
+        w.write_bs(13); // edge_style_apply
+        w.write_bl(-50); // display_brightness — a BL on R2004
+        w.write_bs(0); // display_shadow_type
+        w.write_b(true); // is_internal_use_only
+    }
+
+    /// An R2004 record: inline `TV`, inline layout, `RL`-style boundary.
+    fn build_r2004() -> (Vec<u8>, usize) {
+        let mut body = modern::tests::r2004_object_prefix(1);
+        modern::tests::write_inline_tv(&mut body, "Flat");
+        write_legacy_properties(&mut body);
+        let end = body.position_bits();
+        (body.into_bytes(), end)
+    }
+
     #[test]
-    fn rejects_pre_r2010() {
+    fn rejects_pre_r2004() {
         let payload = build(Version::R2018);
-        let err = decode_object(&payload, 8, None, Version::R2004).unwrap_err();
+        let err = decode_object(&payload, 8, None, Version::R2000).unwrap_err();
+        assert!(
+            matches!(&err, Error::Unsupported { feature } if feature.contains("ACAD_VISUALSTYLE"))
+        );
+    }
+
+    #[test]
+    fn r2004_inline_visual_style_closes_on_its_object_data_size() {
+        let (payload, end) = build_r2004();
+        let style = decode_object(&payload, 0, Some(end), Version::R2004).unwrap();
+        assert_eq!(style.description, "Flat");
+        assert_eq!(style.internal_style_type, 0);
+        // R2004 has no format_version slot at all.
+        assert_eq!(style.format_version, 0);
+        assert!(style.is_internal_use_only);
+        assert_eq!(style.face_lighting_model, 2);
+        assert!((style.face_opacity + 0.6).abs() < 1e-12);
+        assert!((style.face_specular - 30.0).abs() < 1e-12);
+        assert_eq!(style.face_modifier, 2);
+        assert_eq!(style.face_mono_color.method(), 0xC2);
+        assert_eq!(style.edge_obscured_color.method(), 0xC8);
+        assert_eq!(style.edge_silhouette_width, 5);
+        assert_eq!(style.edge_unknown_byte, 0);
+        assert_eq!(style.edge_intersection_linetype, 1);
+        assert_eq!(style.edge_style_apply, 13);
+        assert!((style.display_brightness + 50.0).abs() < 1e-12);
+        // No per-property flags exist on this release.
+        assert!(style.property_flags.is_empty());
+        assert!(style.extended.is_empty());
+    }
+
+    /// The flag-less body is 28 `BS` flags shorter than the paired one,
+    /// so the boundary check has to reject it under the R2010 list.
+    #[test]
+    fn r2004_body_rejected_by_the_r2010_field_list() {
+        let (payload, end) = build_r2004();
+        assert!(decode_object(&payload, 0, Some(end), Version::R2010).is_err());
+    }
+
+    /// R2007 is declined, and the decline is an `Unsupported` — so a
+    /// dispatched R2007 record lands in the Unhandled bucket rather than
+    /// being reported as a broken record.
+    #[test]
+    fn rejects_r2007() {
+        let (payload, end) = build_r2004();
+        let err = decode_object(&payload, 0, Some(end), Version::R2007).unwrap_err();
         assert!(
             matches!(&err, Error::Unsupported { feature } if feature.contains("ACAD_VISUALSTYLE"))
         );

--- a/src/objects/mod.rs
+++ b/src/objects/mod.rs
@@ -22,7 +22,7 @@
 //! | ACAD_PROPERTYSET_DATA    | [`acad_property_set_data`]| §19.6.11 (L7-07) |
 //! | ACAD_SCALE               | [`acad_scale`]            | §19.6.8 (L6-15)  |
 //! | ACDBSECTIONVIEWSTYLE     | [`acad_section_view_style`]| none — measured |
-//! | ACAD_VISUALSTYLE         | [`acad_visual_style`]     | none — measured  |
+//! | ACAD_VISUALSTYLE         | [`acad_visual_style`]     | none — measured, two generations |
 //! | class-map extension      | [`class_map_extension`]   | §5.7 (L7-03)     |
 //! | *_CONTROL                | [`control`]               | §19.5.1..§19.5.10|
 //! | custom-dict entries      | [`custom_dict_entry`]     | §19.5.19 (L7-06) |


### PR DESCRIPTION
Closes the R2004 half of #48: `VISUALSTYLE` now dispatches on `AC1018`,
taking all **72** of its corpus records — the largest remaining
`Unhandled` block. The R2007 half stays open, and the reason is upstream
rather than this object (see below).

## Measured coverage

`cargo run --release --example coverage_report -- <samples>`, re-run on
the merged tree (`origin/main` is `7418d25`; nothing moved under it
during this work, so the merge was a no-op).

| Version | Decoded | Skipped | Errored | Ratio |
|---|---|---|---|---|
| R2004 (AC1018) | 510 → **582** | 87 → **15** | 0 → 0 | 85.4 % → **97.5 %** |
| R2010 (AC1024) | 531 → 531 | 12 → 12 | 0 → 0 | 97.8 % |
| R2013 (AC1027) | 384 → 384 | 12 → 12 | 0 → 0 | 97.0 % |
| R2018 (AC1032) | 762 → 762 | 80 → 80 | 0 → 0 | 90.5 % |
| **Aggregate** | **2187 → 2259** | **191 → 119** | **0 → 0** | 92.0 % → **95.0 %** |

Per-file: `arc_2004.dwg`, `circle_2004.dwg` and `line_2004.dwg` each go
170 / 29 / 0 → 194 / 5 / 0. Zero errors corpus-wide is preserved, and
`VISUALSTYLE` now reaches 240 of the 240 records the class census
declares across the walkable files.

## The R2004 layout

30 fields, no `(value, flag)` pairs, one fewer property than R2010, and
a different order. Delta 0 on all 24 records of all three `*_2004.dwg`
files.

```text
TV   description                  -- inline on R2004
BS   internal_style_type          BS  face_lighting_model
BS   face_lighting_quality        BS  face_color_mode
BD   face_opacity                 BD  face_specular
CMC  face_mono_color              BS  face_modifier
BS   edge_model                   BS  edge_style
CMC  edge_intersection_color      CMC edge_obscured_color
BS   edge_obscured_linetype       BD  edge_crease_angle
BS   edge_modifier                CMC edge_color
BD   edge_opacity                 BS  edge_width
BS   edge_overhang                BS  edge_jitter
CMC  edge_silhouette_color        BS  edge_silhouette_width
RC   edge_unknown_byte            BS  edge_halo_gap
B    edge_hide_precision          BS  edge_isoline_count
BS   edge_intersection_linetype   BS  edge_style_apply
BL   display_brightness           BS  display_shadow_type
B    is_internal_use_only
```

Three slots of the R2010 head are gone or moved: there is no
`format_version` at all, `face_modifier` sits after `face_mono_color`,
and `is_internal_use_only` is the record's **last bit**.

## Bit evidence

**Both ends anchored from the record's own redundancy.** At the front,
`examples/probe_token_scan.rs` reports the self-identifying tokens —
full-form `BD`s that decode to short decimals and `CMC`s whose
true-colour word carries a real method octet — which pin `face_opacity`
(bit 435 on `arc_2004.dwg` handle 42), `face_specular` (501) and
`face_mono_color` (567). Neither pattern survives a one-bit shift.

At the back, a reverse scan for the offset at which `BS, BL, BS, B`
lands *exactly* on the `RL` object-data-size boundary returns **exactly
one** position on every one of the 24 records, and its four values
reproduce R2010's `edge_style_apply` (`13` on Flat/FlatWithEdges/
Gouraud/GouraudWithEdges/Realistic/X-Ray, `5` on the two Shaded styles,
`1` elsewhere), `display_shadow_type` (`0`) and `is_internal_use_only`.
That last bit splits the 24 styles into precisely the ten AutoCAD's
Visual Styles Manager lists and the fourteen it hides — the same
partition R2010 produces from a bit 500-odd positions earlier.

**Two structural findings.** `is_internal_use_only` moved from the head
to the final bit; and `display_brightness` is a **`BL`** where R2010
spends a `BD`, decoding `-50` (Dim), `50` (Brighten) and `0` (the other
22) against R2010's `-50.0` / `50.0` / `0.0`. The `BL` is also the whole
explanation for the corpus's bit budgets: the tails after the two edge
`CMC`s measure 124 bits on 22 records, 156 on `Dim` (full `BL`, +32) and
132 on `Brighten` (byte `BL`, +8), and nothing else in the record varies
between those three styles.

**Value corroboration against a second file.** Twelve `BS` slots, all
five `CMC`s and both remaining `BD`s decode the same value as the *same
style* on `arc_2010.dwg`, on all 24 records — including everything that
varies style by style:

- `internal_style_type` `0` Flat … `27` Shaded;
- `edge_modifier` `0`/`8`/`10`/`11`/`12`, `edge_silhouette_width`
  `3`/`5`/`6`, `edge_width` `1`, `edge_overhang` `6`, `edge_jitter` `2`;
- `edge_obscured_linetype` `2` on Hidden and Shaded-with-edges, `7` on
  Linepattern, `1` elsewhere — and `edge_intersection_linetype` `7` on
  Linepattern, `1` elsewhere, the pair that pins the two ends of the
  trailing run;
- `edge_crease_angle` `40` on Hidden / Shades of Gray / Sketchy, `179`
  on Conceptual, `1` elsewhere;
- `face_mono_color` `0xC2FFFFFF` everywhere but ColorChange's
  `0xC2808080`; `edge_silhouette_color` `0xC3000007` everywhere but
  Shaded's `0xC2787878`.

**Two slots differ, informatively.** `face_opacity` and `face_specular`
are **signed** on R2004. Magnitudes match R2010 on all 24; the sign
tracks whether the property applies — `face_specular` is positive on
exactly the seven styles that shade faces (Flat, FlatWithEdges, Gouraud,
GouraudWithEdges, Realistic, Shaded, Shaded with edges) and negative on
the other seventeen, and `face_opacity` is positive on exactly `X-Ray`,
the one translucent style. Values are surfaced as measured, sign
included. One further value differs for content reasons: `Realistic`
decodes `face_lighting_quality` `2` on R2004 and `3` on R2010, with
every other field of that record agreeing — the style being clamped when
saved down, not a mis-read field.

## What is *not* determined — the 13-bit run

Thirteen bits sit between `edge_silhouette_width` and
`edge_intersection_linetype`, and they hold the constant
`0b0_0000_0001_0010` on **every one of the 72 corpus records**. A run
that never varies cannot have its internal boundaries measured, only its
width; an exhaustive enumeration returns many splits that fit. The module
reads it as `RC BS B BS` — the only fit whose first token is a whole byte
— names the last three for the three properties R2010 places in exactly
this position (`edge_halo_gap`, `edge_hide_precision`,
`edge_isoline_count`, all of which decode `0` / `false` / `0` there on
the same 24 styles), and surfaces the leading byte as
`AcadVisualStyle::edge_unknown_byte` rather than giving it a
plausible-sounding name. Documented as a reading, not as evidence, in
the module docs, ARCHITECTURE.md §7d.1a and CLEANROOM.md. A future R2004
file with a non-default halo gap or isoline count would settle it.

## Why R2007 is still declined

Not for want of a field list. Two upstream gaps stand between an
`AC1021` file and any decoder:

1. the container parse returns `SectionMapStatus::Deferred` for R2007
   (#110, second Sec_Mask obfuscation layer);
2. `string_stream::data_section_end` locates the split-stream trailer
   from the leading `MC` handle-stream size that only R2010 and newer
   write, so it declines R2007 outright.

`probe_object_layout` on `arc_2007.dwg` panics with *"this version has
no object-stream walk"*, and `probe_class_census` reports *"no
AcDb:Classes section"*. No R2007 object of any type reaches this module,
so the corpus cannot say whether R2007 writes the flag-less list or the
paired one. `decode_object` returns `Error::Unsupported` for that band
rather than shipping a reading no byte has ever confirmed, and the
dispatcher maps that to `Unhandled`. **#48 stays open for R2007** — this
PR says `Refs #48`, not `Closes`.

## Tests

Four new `BitWriter` fixtures alongside the existing R2010/R2013 ones:

- `r2004_inline_visual_style_closes_on_its_object_data_size` — the
  flag-less body on the inline layout, checking `format_version == 0`
  (no such slot on R2004), the signed `face_opacity`, the `BL`
  brightness, `edge_unknown_byte` and an empty `property_flags`;
- `r2004_body_rejected_by_the_r2010_field_list` — the two lists differ
  by 28 `BS` flags, so the boundary check has to reject the crossover;
- `rejects_r2007` / `rejects_pre_r2004` — both decline with
  `Error::Unsupported`, so a dispatched record lands in the Unhandled
  bucket rather than being reported as broken.

Gate: `cargo fmt --all`, `cargo clippy --all-targets --all-features -D
warnings`, `cargo test --release` (16 suites, all green),
`cargo +1.85.0 test --no-run`, `cargo deny check all`,
`RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --all-features` — all
clean.

## Clean-room declaration

I certify that:

1. All code and tests in this PR were written from scratch by me.
2. I consulted only sources listed as allowed in `CLEANROOM.md`. In
   particular, I did not consult Autodesk SDK source, ODA SDK (Drawings
   SDK / Teigha) source, LibreDWG source, decompilations of Autodesk or
   ODA binaries, or any copyleft-licensed DWG implementation code.
3. This PR needs **no new outside vocabulary**: the R2004 field list was
   derived entirely from the corpus bytes and the boundary the format
   itself carries, and every name on it is carried over from the R2010
   list already disclosed in `CLEANROOM.md` (2026-08-30, VISUALSTYLE
   property names), justified slot by slot against the value the same
   style decodes on `arc_2010.dwg`. The one slot with no R2010
   counterpart is labelled `edge_unknown_byte`. ODA spec v5.4.1 §20.4
   carries no `VISUALSTYLE` entry, and no citation is claimed for it.
   `CLEANROOM.md` records this in the VISUALSTYLE section.
4. I have never had access to any of the forbidden sources in a
   commercial or NDA'd context.

Refs #48

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Non-spec binary layout decoding affects 72 real records; wrong field boundaries would mis-read style data, though boundary self-checks and cross-file corroboration reduce that risk.
> 
> **Overview**
> Adds **R2004 (`AC1018`) decoding for `ACAD_VISUALSTYLE`**, clearing the largest remaining unhandled block (72 corpus records) by routing `decode_object` to a new **30-field, flag-less wire layout** distinct from the R2010+ `(value, flag)` list.
> 
> The R2004 path reads inline `TV`, uses **`BL` for `display_brightness`** (widened to `f64`), leaves **`format_version` at 0**, moves **`is_internal_use_only` to the record tail**, and exposes a constant 13-bit gap as **`edge_unknown_byte`** plus documented halo/isoline slots rather than inventing names. R2010+ behavior is unchanged behind `decode_paired`; pre-R2004 and **R2007 still return `Error::Unsupported`** (upstream object-stream gaps, not guessed).
> 
> **Coverage docs** (`README`, `STATUS`, `CHANGELOG`, `ARCHITECTURE`, `CLEANROOM`) now report **2,259 decoded / 119 skipped / 0 errored (95.0% aggregate)**, with R2004 at **97.5%**. New unit tests assert the R2004 body closes on `RL` boundary and is rejected if parsed with the R2010 field list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 723a6bbeb3fae2470e4652668d8dfacd63bbb6ab. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->