### PR TITLE
feat(entities): decode the §20.4.41 ACIS record and settle the AcDs marker

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -889,6 +889,146 @@ handle, body-start bit and data boundary;
 `examples/probe_entity_field_list.rs` walks a candidate token list
 against one entity record and prints the delta from that boundary.
 
+## 7h. The ACIS entities, and what settles the AcDs marker (2026-08-30, #61 / #54)
+
+`REGION` (37), `3DSOLID` (38) and `BODY` (39) are one entry in the
+specification — §20.4.41 prescribes a single record shape for all three
+— and until this work the crate decoded only the first bit of it. The
+three records were `Unhandled`, and because they were, they could not
+answer the one question the corpus had been holding open since #52.
+
+### What the corpus actually holds
+
+Across all 19 files there are exactly **three** §20.4.41 records, all in
+`sample_AC1032.dwg` (R2018): 3DSOLID `0xD65`, REGION `0xD69`, 3DSOLID
+`0xD6A`. All three set the R2013+ `has AcDs binary data` bit of the
+common entity data. There is no ACIS record anywhere in the corpus that
+*clears* it, and none outside R2018.
+
+That bit is not decoration. §24.2.2.3 says it plainly: "For each ACIS
+entity (REGION, 3DSOLID), a data record is created with the SAB stream
+of the object." From R2013 the geometry payload leaves the entity
+record and becomes a data record in `AcDb:AcDsPrototype_1b`, keyed by
+handle. The entity keeps everything *except* the geometry.
+
+### The field list
+
+Measured from bit 82 — where the common entity preamble ends on all
+three records — to each record's data-stream boundary:
+
+```text
+B     wireframe data present          1
+B     point present                   1
+3BD   point
+BL    num isolines                    4
+B     isolines present                1
+BL    num wires                       0
+BL    num silhouettes                 0
+B     ACIS empty (2)                  1     -- §20.4.41 "Normally 1"
+BL    unknown (R2007+)                0
+--- R2013+ data-store block, measured ---
+B     unknown_a                       1
+BB    unknown_b                       0
+BB    unknown_c
+BB    unknown_d
+RC×16 revision GUID
+BL    unknown_e                       0
+```
+
+The inline ACIS envelope (`B ACIS empty`, `B unknown`, `BS version`,
+the block loop) is **absent**: only two bits stand between the preamble
+and the point, and both are 1.
+
+| record | data ends | point | isolines | revision GUID | delta |
+|---|---|---|---|---|---|
+| 3DSOLID `0xD65` | bit 437 | `(17.7767…, -220.8501…, 2.5)` | 4 | `833111a1-b7ac-4dd4-824d-78b33668f9e7` | **0** |
+| REGION `0xD69` | bit 373 | `(24.9857…, -220.4000…, 0)` | 4 | `2b80e3b3-b594-475e-8593-6a36b15e7945` | **0** |
+| 3DSOLID `0xD6A` | bit 437 | `(31.6857…, -220.1073…, 2.1902…)` | 4 | `f21ff2a0-ff9c-4ed1-9b2e-7a1e6518d595` | **0** |
+
+Four things corroborate the list independently of the arithmetic:
+
+1. **The points are drawing geometry.** Three bodies in a row at
+   `y ≈ -220`, `x` stepping `17.8 → 25.0 → 31.7`. A list off by one bit
+   produces `1e+88`-scale doubles, which is what every rejected
+   candidate produced.
+2. **`num isolines` is 4 on all three** — AutoCAD's default `ISOLINES`
+   system-variable value.
+3. **The 16 bytes are a valid RFC-4122 version-4 UUID on all three**
+   (version nibble `4`, variant bits `10`). Scanning every 128-bit
+   window of all three records, `data_end - 130` is the *only*
+   alignment at which all three satisfy both constraints; three
+   independent windows doing so by chance is 1 in 2^18.
+4. **Everything else is the spec's own grammar**, decoding the values
+   §20.4.41 says to expect (`ACIS empty (2)` "normally 1", empty wire
+   and silhouette lists, the R2007+ `BL` as 0).
+
+Only the *width* of the seven bits before the GUID is measured; the
+three records agree on `1, 0` for the first two slots and differ after,
+so `B, BB, BB, BB` is a labelling, not a measurement. The module says
+so.
+
+### The AcDs marker is a flag, and nothing follows it
+
+#52 found that four LAYOUT records of the same file need **16** further
+bits after the `has AcDs binary data` flag, and `objects/modern.rs`
+consumed them there. `tables/modern.rs` consumed an `RC` (8 bits) on
+DIMSTYLE evidence. `common_entity.rs` consumed nothing — untested,
+because no entity record whose field list closed had ever set the bit.
+Three readings of one field: issue #54.
+
+The three ACIS records arbitrate it, because their field list closes.
+`examples/probe_acis_records.rs` re-reads the preamble at each candidate
+width and runs §20.4.41 from wherever it lands:
+
+| marker width | preamble ends | preamble values | §20.4.41 list |
+|---|---|---|---|
+| **0 bits** | bit 82 | `colour 0x0100, lts 1.0, invis 0, lw 0x1D` | **delta 0** |
+| 8 bits | — | preamble does not read (reserved `BD` pattern `11`) | — |
+| 16 bits | bit 148-212 | `colour 0xEE10, lts 0` (or `1.5e119`), `lw 0x10/0x12/0xBC` | does not close |
+
+Both halves fail together for every non-zero width. The preamble values
+at 0 bits are exactly the ones every other entity in the file carries —
+BYLAYER colour `0x0100`, linetype scale `1.0`, invisibility `0`,
+lineweight `0x1D` — and at 16 bits they are none of those.
+
+So the flag is a flag. The 16 bits LAYOUT needs are LAYOUT's own, and
+they moved to `src/objects/acad_layout.rs` as a two-byte data-store
+block at the head of its §20.4.84 list, still conditional on the flag
+and still closing all 31 corpus LAYOUT records. `tables/modern.rs`
+keeps its `RC` for now: that path also omits the `BL num_reactors`
+`objects/modern.rs` reads, so its bit accounting has a second unresolved
+variable and is out of scope here. Three record types needing three
+different widths is itself the argument that the width belongs to the
+record, not to the flag.
+
+### Two spec-conformance fixes that fell out
+
+The envelope reader had been carrying two departures from §20.4.41 that
+no corpus record had ever reached:
+
+- the `B unknown` bit between `ACIS empty` and `BS version` was not
+  read at all;
+- the block loop read a `B has_more_blocks` flag before each `BL block
+  size`, where the spec has the loop terminate on a block size of `0`
+  and no flag.
+
+Both are corrected, and version 2 — "immediately following will be an
+acis file … no length is given" — is now refused rather than
+mis-stepped.
+
+### Measured effect
+
+| Corpus slice | Before (`7418d25`) | After |
+|---|---|---|
+| R2004 (AC1018) × 3 | 510 / 87 / 0 / 85.4 % | 510 / 87 / 0 / 85.4 % |
+| R2010 (AC1024) × 3 | 531 / 12 / 0 / 97.8 % | 531 / 12 / 0 / 97.8 % |
+| R2013 (AC1027) × 3 | 384 / 12 / 0 / 97.0 % | 384 / 12 / 0 / 97.0 % |
+| R2018 (AC1032) × 1 | 762 / 80 / 0 / 90.5 % | **765 / 77 / 0 / 90.9 %** |
+| **Aggregate** | **2187 / 191 / 0 / 92.0 %** | **2190 / 188 / 0 / 92.1 %** |
+
+`examples/probe_acis_records.rs` reproduces the census, the field list
+and the arbitration table from the bytes.
+
 ## 8. Write pipeline (current scope)
 
 The inverse pipeline is partially shipped. Stage-1 (per-section

--- a/CLEANROOM.md
+++ b/CLEANROOM.md
@@ -184,3 +184,42 @@ record, and every field name and type in
 "§19.6.4 (L6-13)" citation that module previously carried is withdrawn
 — the spec has no §19.6 chapter — along with the `BS`-where-the-spec-
 prints-`CMC` reading that came with it.
+
+## 2026-08-30 — ACIS entity record (ODA spec §20.4.41 + §24)
+
+The PR for #61 decodes the whole `REGION` / `3DSOLID` / `BODY` record.
+Both halves of it come from the freely-redistributable ODA *Open Design
+Specification for .dwg files* v5.4.1 and from the corpus bytes:
+
+- **§20.4.41 REGION (37) / 3DSOLID (38) / BODY (39)** prescribes the
+  record in one table for all three entities — the ACIS envelope
+  (`ACIS empty` bit, unknown bit, `BS` version, the version-1 block
+  loop), the wireframe / point / isoline block with its wire and
+  silhouette structures, the second `ACIS empty` bit, and the R2007+
+  trailing `BL`. Every field name and type in
+  `src/entities/modeler.rs`, `three_d_solid.rs`, `region.rs` and
+  `body.rs` comes from that table, including the spec's own gloss
+  "Normally 1" on the second empty bit. Two departures the previous
+  code carried — a missing `B unknown` bit and a fabricated
+  `B has_more_blocks` flag inside the block loop — are corrected
+  *toward* the spec, not away from it.
+- **§24.2.2.3** supplies the semantics of the R2013+ shape: "For each
+  ACIS entity (REGION, 3DSOLID), a data record is created with the SAB
+  stream of the object." That is why the three corpus records carry no
+  inline envelope.
+
+The R2013+ data-store block that follows — seven bits, sixteen bytes,
+a `BL` — is **measured**, not borrowed: it is the residue between the
+end of the §20.4.41 grammar and each record's own data-stream boundary,
+and the sixteen bytes are identified as a revision GUID because they are
+a valid RFC-4122 version-4 UUID on all three records at the one
+alignment that fits. The seven bits are labelled `unknown_*`; only their
+width is claimed. The slot names that are claimed — point, isolines,
+wires, silhouettes, revision GUID — are the spec's own vocabulary plus
+the one word the UUID structure earns.
+
+The `has AcDs binary data` width settled in the same PR (#54) is
+likewise measured from the corpus's own boundaries: 0 bits on the
+entity path, with the 16 bits four R2018 LAYOUT records need relocated
+into LAYOUT's own field list. No third-party implementation was
+consulted for either.

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ local `samples/` set:
 | R2004 (AC1018)      | 3 | 510 | 87 | 0 | **85.4 %** |
 | R2010 (AC1024)      | 3 | 531 | 12 | 0 | **97.8 %** |
 | R2013 (AC1027)      | 3 | 384 | 12 | 0 | **97.0 %** |
-| R2018 (AC1032)      | 1 | 762 | 80 | 0 | **90.5 %** |
-| **Aggregate** | **19** | **2187** | **191** | **0** | **92.0 %** |
+| R2018 (AC1032)      | 1 | 765 | 77 | 0 | **90.9 %** |
+| **Aggregate** | **19** | **2190** | **188** | **0** | **92.1 %** |
 
 **Every record of every file in the corpus that reaches a decoder now
-decodes, and none errors.** What is left is the *skipped* column — 191
+decodes, and none errors.** What is left is the *skipped* column — 188
 records of types this crate has no decoder for at all (VISUALSTYLE on
 R2004/R2007, MATERIAL, TABLESTYLE) — not records it reads wrongly.
 
@@ -76,7 +76,7 @@ real bytes yet. Closing those is the 0.2.0 milestone.
 | HandleMap + ClassMap parsing | ✓ shipped | — |
 | Header variables | ✓ shipped | Strict + lossy variants |
 | Object-stream walker (R2004+) | ✓ shipped | R14 / R2000 / R2007 pending (#104) |
-| Per-entity field decoders | ⚠ alpha | Broad synthetic coverage; real-file aggregate currently 92.0 %, zero errors (#103) |
+| Per-entity field decoders | ⚠ alpha | Broad synthetic coverage; real-file aggregate currently 92.1 %, zero errors (#103) |
 | Entity graph (owner / reactors / blocks / layers) | ⚠ partial | Resolver APIs exist; trailing-handle/block traversal gaps remain |
 | Symbol tables (LAYER / LTYPE / STYLE / DIMSTYLE / …) | ⚠ partial | R2007+ BLOCK_HEADER and simple LTYPE names decode; broader content fields pending |
 | SVG / PDF export | ⚠ alpha | SVG writer + paged-SVG PDF path; output quality depends on decoded geometry |

--- a/STATUS.md
+++ b/STATUS.md
@@ -6,17 +6,17 @@ scrolling the changelog.
 
 ## Summary
 
-- **Lib tests:** 734 passing in default/debug and release-all-features
+- **Lib tests:** 741 passing in default/debug and release-all-features
   profiles, clippy + fmt clean.
 - **WASM tests:** 40 passing in `wasm/` sub-crate.
 - **Integration tests:** DXF round-trip (7), glTF smoke (3), SVG
   goldens (3), fuzz-corpus regression (6), write-path (5),
-  entity-regression (18), real-DWG value regression (8).
-- **Current real-file decode coverage:** 2,187 decoded / 191 skipped /
-  **0 errored** / 92.0% on the local 19-file `samples/` corpus. The
-  R2018 `sample_AC1032.dwg` sample is 762 / 80 / 0 / 90.5%. **No file
+  entity-regression (18), real-DWG value regression (15).
+- **Current real-file decode coverage:** 2,190 decoded / 188 skipped /
+  **0 errored** / 92.1% on the local 19-file `samples/` corpus. The
+  R2018 `sample_AC1032.dwg` sample is 765 / 77 / 0 / 90.9%. **No file
   in the corpus has a single errored record.** Per version:
-  R2004 85.4%, R2010 97.8%, R2013 97.0%, R2018 90.5%. What remains is
+  R2004 85.4%, R2010 97.8%, R2013 97.0%, R2018 90.9%. What remains is
   the *skipped* column — types with no decoder at all — not records
   that decode wrongly.
 - **Handle-map completeness:** every one of the 842 `AcDb:Handles`
@@ -59,7 +59,10 @@ scrolling the changelog.
 - DIMENSION base + linear / aligned / radial / diameter /
   angular 2-line / angular 3-point / ordinate subclass decoders.
 - MESH (subdivision) / POLYFACE MESH / POLYGON MESH.
-- 3DFACE, 3DSOLID (SAT passthrough), REGION, BODY.
+- 3DFACE, and the three §20.4.41 ACIS entities — 3DSOLID, REGION,
+  BODY — with the full record (ACIS envelope, wireframe/isoline block,
+  the R2007+ trailing `BL` and the R2013+ data-store revision GUID),
+  closing on all three corpus records (ARCHITECTURE.md §7h).
 - SURFACE: extruded / revolved / swept / lofted.
 - CAMERA, LIGHT, SUN, HELIX.
 - IMAGE / IMAGEDEF, UNDERLAY (PDF/DWF/DGN), GEODATA.
@@ -212,8 +215,8 @@ scrolling the changelog.
 These have genuine open scope requiring focused work, not stubs.
 
 - **Current real-file decode baseline:** the 2026-08-30
-  `examples/coverage_report.rs ../../samples` run reports 2187 decoded,
-  191 skipped, 0 errored, 92.0% aggregate coverage. This is the
+  `examples/coverage_report.rs ../../samples` run reports 2190 decoded,
+  188 skipped, 0 errored, 92.1% aggregate coverage. This is the
   practical product-readiness blocker even though synthetic decoder
   tests are broad.
 
@@ -235,17 +238,17 @@ These have genuine open scope requiring focused work, not stubs.
   (ARCHITECTURE.md §7d.4) but a single record per corpus file cannot
   pin the token sequence inside its cell-style blocks.
 
-- **#54 the R2013+ `has AcDs binary data` marker on *entities*.**
-  `objects/modern.rs` consumes 16 bits after the flag (measured on the
-  four LAYOUTs of `sample_AC1032.dwg`), `tables/modern.rs` consumes an
-  `RC`, and `common_entity.rs` consumes nothing. Exactly three entity
-  records in the corpus set the bit — 3DSOLID `0xD65` and `0xD6A` and
-  REGION `0xD69` — and all three are ACIS pass-through decoders whose
-  field lists this crate does not close, so they cannot arbitrate the
-  width either. None of the 39 records fixed in the residual-entity
-  pass sets the bit, so the reading did not matter for any of them.
-  Settling it still needs a file with a flag-setting record of a type
-  whose field list closes.
+- **#54 the R2013+ `has AcDs binary data` marker — settled.** The
+  three ACIS entity records that set the bit (3DSOLID `0xD65` /
+  `0xD6A`, REGION `0xD69` of `sample_AC1032.dwg`) now have a field
+  list that closes, and it closes only with **zero** bits consumed
+  after the flag. `common_entity.rs` and `objects/modern.rs` agree on
+  that reading; the 16 bits four LAYOUT records need moved into
+  `objects/acad_layout.rs` as LAYOUT's own data-store block.
+  `tables/modern.rs` keeps its `RC` — that path also omits the
+  `BL num_reactors` the object path reads, so its bit accounting has a
+  second unresolved variable (see the next item) and was left alone.
+  Evidence: ARCHITECTURE.md §7h, `examples/probe_acis_records.rs`.
 
 - **R2007+ symbol-table common object prefix.** `tables/modern.rs`
   omits the `BL num_reactors` that `objects/modern.rs` measured as

--- a/examples/probe_acis_records.rs
+++ b/examples/probe_acis_records.rs
@@ -1,0 +1,293 @@
+//! Census every §20.4.41 ACIS record (REGION / 3DSOLID / BODY) in a
+//! corpus and arbitrate the width of the R2013+ `has AcDs binary data`
+//! marker from it.
+//!
+//! # What this proves
+//!
+//! Two facts, in one pass.
+//!
+//! **1 — the census.** How many ACIS records the corpus actually holds,
+//! which release each belongs to, and which of them set the R2013+
+//! `has AcDs binary data` bit of the common entity data (§20.4.1). On
+//! the 19-file corpus the answer is three records, all in
+//! `sample_AC1032.dwg`, all setting the bit.
+//!
+//! **2 — the arbitration (#54).** The spec lists that bit and stops; it
+//! does not say what, if anything, follows when it is set. This crate
+//! carried three different readings — `common_entity` consumed 0 bits,
+//! `objects::modern` 16, `tables::modern` an `RC`. The probe re-reads
+//! the common entity preamble with each candidate width, then runs the
+//! §20.4.41 field list ([`dwg::entities::modeler::decode_record`]) from
+//! wherever that lands, and prints how far the list finishes from the
+//! record's own data-stream boundary. **Only `delta 0` is a valid
+//! reading**, and only one width produces it.
+//!
+//! ```sh
+//! cargo run --release --example probe_acis_records -- samples/
+//! cargo run --release --example probe_acis_records -- samples/sample_AC1032.dwg
+//! ```
+//!
+//! Expected output on the corpus (abridged):
+//!
+//! ```text
+//! sample_AC1032.dwg 0xD65 3DSOLID ds=true data_end=437
+//!    marker  0 bits: preamble ends 82   colour 0x0100 lts 1 invis 0 lw 0x1D
+//!                      delta 0     isolines 4 point (17.7767, -220.8501, 2.5000) guid 833111a1-…
+//!    marker  8 bits: preamble does not read at all (…)
+//!    marker 16 bits: preamble ends 164  colour 0xEE10 lts 0 invis 2640 lw 0x12
+//!                      field list does not close (…)
+//! ```
+//!
+//! Two things fail at once for every non-zero width: the *preamble
+//! values* stop being the ones every other entity in the file carries
+//! (`colour 0x0100`, `linetype scale 1.0`, `invisibility 0`,
+//! `lineweight 0x1D` — BYLAYER throughout), and the §20.4.41 list that
+//! follows cannot close.
+
+use dwg::bitcursor::BitCursor;
+use dwg::entities::modeler;
+use dwg::error::Result;
+use dwg::{DwgFile, ObjectType, Version};
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+/// Candidate widths, in bits, for whatever follows the R2013+
+/// `has AcDs binary data` flag — the three readings this crate has
+/// carried at one time or another.
+const CANDIDATE_MARKER_BITS: [usize; 3] = [0, 8, 16];
+
+/// The preamble fields whose decoded values are the second half of
+/// the arbitration: on this file every entity carries `colour 0x0100`,
+/// `linetype scale 1.0`, `invisibility 0`, `lineweight 0x1D`.
+struct Preamble {
+    has_ds_binary_data: bool,
+    colour: u16,
+    linetype_scale: f64,
+    invisibility: i16,
+    lineweight: u8,
+}
+
+/// Re-read the common entity preamble (§20.4.1) with an explicit
+/// AcDs-marker width, so the candidate readings can be compared
+/// side by side.
+///
+/// Mirrors `common_entity::read_common_entity_data` field for field.
+/// It is kept local to the probe deliberately: the measurement must
+/// not move when the library's own reading changes.
+fn read_preamble(c: &mut BitCursor<'_>, version: Version, marker_bits: usize) -> Result<Preamble> {
+    // EED chain.
+    loop {
+        let size = c.read_bs_u()?;
+        if size == 0 {
+            break;
+        }
+        let _appid = c.read_handle()?;
+        for _ in 0..size {
+            let _ = c.read_rc()?;
+        }
+    }
+    // Graphics-preview block.
+    if c.read_b()? {
+        let bytes = if version.is_r2010_plus() {
+            c.read_bll()?
+        } else {
+            c.read_rl()? as u64
+        };
+        for _ in 0..bytes {
+            let _ = c.read_rc()?;
+        }
+    }
+    let _entmode = c.read_bb()?;
+    let _num_reactors = c.read_bl()?;
+    if version.is_r2004_plus() {
+        let _no_xdictionary = c.read_b()?;
+    }
+    let mut has_ds_binary_data = false;
+    if matches!(version, Version::R2013 | Version::R2018) {
+        has_ds_binary_data = c.read_b()?;
+        if has_ds_binary_data {
+            for _ in 0..marker_bits {
+                let _ = c.read_b()?;
+            }
+        }
+    }
+    // ENC entity colour (§2.11).
+    let colour = c.read_bs_u()?;
+    if version.is_r2004_plus() {
+        let flags = colour >> 8;
+        if flags & 0x20 != 0 {
+            let _transparency = c.read_bl()?;
+        }
+        if flags & 0x40 == 0 && flags & 0x80 != 0 {
+            let _rgb = c.read_bl()?;
+        }
+    }
+    let linetype_scale = c.read_bd()?;
+    let _ltype_flags = c.read_bb()?;
+    let _plotstyle_flags = c.read_bb()?;
+    if version.is_r2007_plus() {
+        let _material_flags = c.read_bb()?;
+        let _shadow_flags = c.read_rc()?;
+    }
+    if version.is_r2010_plus() {
+        let _has_full_visualstyle = c.read_b()?;
+        let _has_face_visualstyle = c.read_b()?;
+        let _has_edge_visualstyle = c.read_b()?;
+    }
+    let invisibility = c.read_bs()?;
+    let lineweight = if matches!(version, Version::R14) {
+        0
+    } else {
+        c.read_rc()?
+    };
+    Ok(Preamble {
+        has_ds_binary_data,
+        colour,
+        linetype_scale,
+        invisibility,
+        lineweight,
+    })
+}
+
+/// Render a 16-byte revision GUID in canonical UUID form.
+fn format_guid(guid: &[u8; 16]) -> String {
+    let hex: String = guid.iter().map(|b| format!("{b:02x}")).collect();
+    format!(
+        "{}-{}-{}-{}-{}",
+        &hex[0..8],
+        &hex[8..12],
+        &hex[12..16],
+        &hex[16..20],
+        &hex[20..32]
+    )
+}
+
+fn dwg_files(path: &PathBuf) -> Vec<PathBuf> {
+    if path.is_dir() {
+        let Ok(entries) = std::fs::read_dir(path) else {
+            return Vec::new();
+        };
+        let mut files: Vec<PathBuf> = entries
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("dwg"))
+            .collect();
+        files.sort();
+        files
+    } else {
+        vec![path.clone()]
+    }
+}
+
+fn main() -> ExitCode {
+    let Some(arg) = std::env::args().nth(1) else {
+        eprintln!("usage: probe_acis_records <dir-or-file.dwg>");
+        return ExitCode::FAILURE;
+    };
+    let files = dwg_files(&PathBuf::from(arg));
+    if files.is_empty() {
+        eprintln!("no .dwg files found");
+        return ExitCode::FAILURE;
+    }
+
+    let mut total = 0usize;
+    for path in &files {
+        let Ok(file) = DwgFile::open(path) else {
+            continue;
+        };
+        let version = file.version();
+        let Some(Ok(objects)) = file.all_objects() else {
+            continue;
+        };
+        let name = path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("?")
+            .to_string();
+        for object in &objects {
+            let kind = ObjectType::from_code(object.type_code);
+            if !matches!(
+                kind,
+                ObjectType::Solid3d | ObjectType::Region | ObjectType::Body
+            ) {
+                continue;
+            }
+            total += 1;
+            let Some(data_end) = dwg::object::data_end_bit(object, version) else {
+                println!("{name} 0x{:X} {} — no boundary", object.handle.value, kind);
+                continue;
+            };
+
+            // The flag value itself does not depend on the marker
+            // width, so read it once with the 0-bit candidate.
+            let mut probe = match dwg::object::body_cursor(object, version) {
+                Ok(c) => c,
+                Err(e) => {
+                    println!(
+                        "{name} 0x{:X}: body cursor failed: {e}",
+                        object.handle.value
+                    );
+                    continue;
+                }
+            };
+            let flag = read_preamble(&mut probe, version, 0)
+                .map(|p| p.has_ds_binary_data)
+                .unwrap_or(false);
+            println!(
+                "{name} 0x{:X} {} ds={flag} data_end={data_end}",
+                object.handle.value, kind
+            );
+
+            for marker_bits in CANDIDATE_MARKER_BITS {
+                let Ok(mut c) = dwg::object::body_cursor(object, version) else {
+                    continue;
+                };
+                let preamble = match read_preamble(&mut c, version, marker_bits) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        println!(
+                            "   marker {marker_bits:>2} bits: preamble does not read at all ({e})"
+                        );
+                        continue;
+                    }
+                };
+                let preamble_end = c.position_bits();
+                println!(
+                    "   marker {marker_bits:>2} bits: preamble ends {preamble_end:<4} \
+                     colour {:#06X} lts {} invis {} lw {:#04X}",
+                    preamble.colour,
+                    preamble.linetype_scale,
+                    preamble.invisibility,
+                    preamble.lineweight
+                );
+                match modeler::decode_record(&mut c, version, preamble.has_ds_binary_data) {
+                    Ok(record) => {
+                        let at = c.position_bits();
+                        let delta = at as isize - data_end as isize;
+                        let point = record
+                            .tail
+                            .point
+                            .map(|p| format!("({:.4}, {:.4}, {:.4})", p.x, p.y, p.z))
+                            .unwrap_or_else(|| "-".into());
+                        let guid = record
+                            .tail
+                            .revision_guid
+                            .as_ref()
+                            .map(format_guid)
+                            .unwrap_or_else(|| "-".into());
+                        println!(
+                            "                     delta {delta:<5} isolines {} point {point} \
+                             guid {guid}",
+                            record.tail.num_isolines
+                        );
+                    }
+                    Err(e) => {
+                        println!("                     field list does not close ({e})");
+                    }
+                }
+            }
+        }
+    }
+    println!("\n{total} ACIS record(s) across {} file(s)", files.len());
+    ExitCode::SUCCESS
+}

--- a/src/common_entity.rs
+++ b/src/common_entity.rs
@@ -20,7 +20,7 @@
 //! BB  entmode              -- entity mode (see [`EntityMode`])
 //! BL  num_reactors
 //! B   no_xdictionary_handle (R2004+)
-//! B   has_ds_binary_data   (R2013+)
+//! B   has_ds_binary_data   (R2013+; no further bits — see below)
 //! CMC color                -- BS index + optional BL rgb + B name_flag + TV name
 //! BD  linetype_scale
 //! BB  ltype_flags
@@ -36,7 +36,38 @@
 //!
 //! After the preamble comes the entity-specific payload, then
 //! handle references (owner/reactors/xdictionary/layer/linetype/...)
-//! collected at the tail.
+//! collected at the end of the record.
+//!
+//! # Measured: the R2013+ `has AcDs binary data` flag is followed by
+//! nothing
+//!
+//! §20.4.1 lists the bit and stops, and this crate carried three
+//! different readings of it (#54): this module consumed 0 bits,
+//! `objects::modern` 16 and `tables::modern` an `RC`. The entity path
+//! was untested — no entity record whose field list closes had ever
+//! set the bit.
+//!
+//! Exactly **three** entity records in the whole corpus set it, all in
+//! `sample_AC1032.dwg` (R2018): 3DSOLID `0xD65`, REGION `0xD69` and
+//! 3DSOLID `0xD6A`. All three are §20.4.41 ACIS records, and with #61
+//! their field list closes:
+//!
+//! | record | preamble ends | data ends | field list | delta |
+//! |---|---|---|---|---|
+//! | 3DSOLID `0xD65` | bit 82 | bit 437 | §20.4.41 + data-store block | 0 |
+//! | REGION `0xD69` | bit 82 | bit 373 | §20.4.41 + data-store block | 0 |
+//! | 3DSOLID `0xD6A` | bit 82 | bit 437 | §20.4.41 + data-store block | 0 |
+//!
+//! The preamble ends at bit 82 on all three with **0** bits consumed
+//! after the flag, and every field it decodes carries the value every
+//! other entity in the file carries — `entmode 2`, `num_reactors 0`,
+//! `no_xdictionary true`, colour `0x0100`, linetype scale `1.0`, all
+//! flag fields `0`, `invisibility 0`, `lineweight 0x1D`. Consuming 16
+//! bits there moves the colour read to bit 67, where it decodes to
+//! none of those, and leaves the §20.4.41 list 16 bits short of the
+//! boundary. See [`crate::entities::modeler`] for the field list and
+//! its value corroboration, and `examples/probe_acis_census.rs` for
+//! the two readings printed side by side.
 //!
 //! # Scope
 //!
@@ -100,7 +131,10 @@ pub struct CommonEntityData {
     pub num_reactors: u32,
     /// Whether an xdictionary handle is absent.
     pub no_xdictionary: bool,
-    /// R2013+: whether DS binary data follows.
+    /// R2013+ `has AcDs binary data` — the record has an associated
+    /// binary data record in the data-storage section (§24). The flag
+    /// consumes no further bits; see the module docs for the three
+    /// records that measure that.
     ///
     /// Kept as `binary_chain` for API compatibility with the earlier
     /// experimental reader.
@@ -296,6 +330,10 @@ pub(crate) fn read_entity_mode_onwards(
     } else {
         true
     };
+    // R2013+ `has AcDs binary data`. The flag is followed by no
+    // further bits — measured on 3DSOLID 0xD65 / 0xD6A and REGION
+    // 0xD69 of `sample_AC1032.dwg`, the only three entity records in
+    // the corpus that set it; see the module docs.
     let binary_chain = if matches!(version, Version::R2013 | Version::R2018) {
         c.read_b()?
     } else {

--- a/src/entities/body.rs
+++ b/src/entities/body.rs
@@ -1,42 +1,66 @@
-//! BODY entity (§19.4.44) — generic ACIS body (non-solid, non-region).
+//! BODY entity (§20.4.41) — generic ACIS body (non-solid, non-region).
 //!
-//! BODY shares an identical on-wire encoding with 3DSOLID (§19.4.42)
-//! and REGION (§19.4.43): an `acis_empty` flag, a version field, and a
-//! loop of length-prefixed payload chunks that concatenate to an
-//! opaque Standard ACIS Text (SAT) blob. See
-//! [`crate::entities::three_d_solid`] for the full stream layout,
-//! defensive caps, and shared helper documentation.
+//! BODY shares one record shape with 3DSOLID and REGION: an ACIS
+//! envelope, the wireframe / isoline / silhouette block, a second
+//! ACIS-empty bit, the R2007+ trailing `BL` and — on an R2013+ record
+//! whose payload lives in the data-storage section — the measured
+//! revision-GUID block. See [`crate::entities::three_d_solid`] for the
+//! envelope and [`crate::entities::modeler`] for the rest of the
+//! record, its evidence and the defensive caps.
 //!
 //! The same [`crate::entities::three_d_solid::MAX_SAT_BLOB_BYTES`]
 //! 32 MiB ceiling applies here.
 
 use crate::bitcursor::BitCursor;
+use crate::entities::modeler::{self, ModelerTail};
 use crate::entities::three_d_solid::read_sat_blob;
 use crate::error::Result;
+use crate::version::Version;
 
-/// BODY entity — §19.4.44.
+/// BODY entity — §20.4.41.
 ///
 /// See [`crate::entities::three_d_solid::ThreeDSolid`] for the meaning
 /// of each field; the encoding is identical.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Body {
-    /// `true` when the entity was written with no body attached
-    /// (`acis_empty` bit set).
+    /// `true` when the entity was written with no inline body
+    /// (`ACIS empty` bit set).
     pub acis_empty: bool,
-    /// ACIS format version reported before the chunk loop. `None`
+    /// ACIS format version reported before the block loop. `None`
     /// when `acis_empty` is `true`.
     pub version: Option<u16>,
     /// Concatenated SAT payload bytes, or `None` when `acis_empty`.
     pub sat_blob: Option<Vec<u8>>,
+    /// R2013+: the SAB stream is a data record in the data-storage
+    /// section (§24) rather than inline.
+    pub in_data_store: bool,
+    /// The §20.4.41 fields that follow the envelope. `None` from the
+    /// envelope-only [`decode`] entry point.
+    pub tail: Option<ModelerTail>,
 }
 
-/// Decode a BODY entity per ODA spec v5.4.1 §19.4.44.
+/// Decode a BODY **envelope** per ODA spec v5.4.1 §20.4.41.
 pub fn decode(c: &mut BitCursor<'_>) -> Result<Body> {
     let (acis_empty, version, sat_blob) = read_sat_blob(c)?;
     Ok(Body {
         acis_empty,
         version,
         sat_blob,
+        in_data_store: false,
+        tail: None,
+    })
+}
+
+/// Decode a whole BODY record — envelope plus the §20.4.41 fields that
+/// follow it.
+pub fn decode_record(c: &mut BitCursor<'_>, version: Version, in_data_store: bool) -> Result<Body> {
+    let record = modeler::decode_record(c, version, in_data_store)?;
+    Ok(Body {
+        acis_empty: record.blob.empty,
+        version: (!record.blob.empty).then_some(record.blob.version),
+        sat_blob: (!record.blob.empty).then_some(record.blob.bytes),
+        in_data_store: record.in_data_store,
+        tail: Some(record.tail),
     })
 }
 
@@ -62,18 +86,50 @@ mod tests {
         let payload = b"BODY_SAT_PAYLOAD_BYTES";
         let mut w = BitWriter::new();
         w.write_b(false);
-        w.write_bs_u(70);
-        w.write_b(true);
+        w.write_b(false); // §20.4.41 unknown bit
+        w.write_bs_u(1);
         w.write_bl(payload.len() as i32);
         for x in payload {
             w.write_rc(*x);
         }
-        w.write_b(false);
+        w.write_bl(0);
         let bytes = w.into_bytes();
         let mut c = BitCursor::new(&bytes);
         let b = decode(&mut c).unwrap();
         assert!(!b.acis_empty);
-        assert_eq!(b.version, Some(70));
+        assert_eq!(b.version, Some(1));
         assert_eq!(b.sat_blob.as_deref(), Some(&payload[..]));
+    }
+
+    /// The R2013+ data-store shape: no inline envelope, a wireframe
+    /// point, `num isolines = 4` and the 16-byte revision GUID.
+    #[test]
+    fn roundtrip_body_data_store_record() {
+        let guid = [0xCDu8; 16];
+        let mut w = BitWriter::new();
+        w.write_b(true); // wireframe data present
+        w.write_b(false); // point present
+        w.write_bl(4); // num isolines
+        w.write_b(false); // isolines present
+        w.write_b(true); // ACIS empty (2)
+        w.write_bl(0); // R2007+ unknown
+        w.write_b(true);
+        w.write_bb(0);
+        w.write_bb(0);
+        w.write_bb(0b10);
+        for b in guid {
+            w.write_rc(b);
+        }
+        w.write_bl(0);
+        let end = w.position_bits();
+        let bytes = w.into_bytes();
+        let mut c = BitCursor::new(&bytes);
+        let b = decode_record(&mut c, Version::R2018, true).unwrap();
+        assert!(b.in_data_store);
+        let fields = b.tail.unwrap();
+        assert_eq!(fields.num_isolines, 4);
+        assert!(!fields.isolines_present);
+        assert_eq!(fields.revision_guid, Some(guid));
+        assert_eq!(c.position_bits(), end);
     }
 }

--- a/src/entities/dispatch.rs
+++ b/src/entities/dispatch.rs
@@ -29,12 +29,13 @@
 //! like HATCH boundary path trees (these remain in the raw bytes).
 
 use crate::bitcursor::BitCursor;
+use crate::common_entity::CommonEntityData;
 use crate::entities::{
-    arc, attdef, attrib, block, camera, circle, dimension, ellipse, endblk, extruded_surface,
+    arc, attdef, attrib, block, body, camera, circle, dimension, ellipse, endblk, extruded_surface,
     geodata, hatch, helix, image, insert, leader, light, line, lofted_surface, lwpolyline, mesh,
-    mleader, mtext, ole2_frame, point, polyface_mesh, polygon_mesh, polyline, ray,
-    revolved_surface, solid, spline, sun, swept_surface, text, three_d_face, tolerance, trace,
-    underlay, vertex, viewport, wipeout, xline,
+    mleader, mtext, ole2_frame, point, polyface_mesh, polygon_mesh, polyline, ray, region,
+    revolved_surface, solid, spline, sun, swept_surface, text, three_d_face, three_d_solid,
+    tolerance, trace, underlay, vertex, viewport, wipeout, xline,
 };
 use crate::error::Result;
 use crate::object::RawObject;
@@ -55,6 +56,12 @@ pub enum DecodedEntity {
     Ray(ray::Ray),
     XLine(xline::XLine),
     Solid(solid::Solid),
+    /// 3DSOLID (§20.4.41) — an ACIS solid body.
+    ThreeDSolid(three_d_solid::ThreeDSolid),
+    /// REGION (§20.4.41) — an ACIS planar bounded face.
+    Region(region::Region),
+    /// BODY (§20.4.41) — a generic ACIS body.
+    Body(body::Body),
     Trace(trace::Trace),
     ThreeDFace(three_d_face::ThreeDFace),
     Spline(spline::Spline),
@@ -156,6 +163,9 @@ impl DecodedEntity {
             Self::Ray(_) => OBJECT_TYPE_RAY,
             Self::XLine(_) => OBJECT_TYPE_XLINE,
             Self::Solid(_) => OBJECT_TYPE_SOLID,
+            Self::ThreeDSolid(_) => OBJECT_TYPE_3DSOLID,
+            Self::Region(_) => OBJECT_TYPE_REGION,
+            Self::Body(_) => OBJECT_TYPE_BODY,
             Self::Trace(_) => OBJECT_TYPE_TRACE,
             Self::ThreeDFace(_) => OBJECT_TYPE_3DFACE,
             Self::Spline(_) => OBJECT_TYPE_SPLINE,
@@ -276,6 +286,11 @@ const OBJECT_TYPE_SHAPE: u16 = 0x21; // 33
 const OBJECT_TYPE_VIEWPORT: u16 = 0x22; // 34
 const OBJECT_TYPE_ELLIPSE: u16 = 0x23; // 35
 const OBJECT_TYPE_SPLINE: u16 = 0x24; // 36
+// REGION / 3DSOLID / BODY are one entry in the spec (§20.4.41) and one
+// field list in this crate; see entities::modeler.
+const OBJECT_TYPE_REGION: u16 = 0x25; // 37
+const OBJECT_TYPE_3DSOLID: u16 = 0x26; // 38
+const OBJECT_TYPE_BODY: u16 = 0x27; // 39
 const OBJECT_TYPE_RAY: u16 = 0x28; // 40
 const OBJECT_TYPE_XLINE: u16 = 0x29; // 41
 const OBJECT_TYPE_MTEXT: u16 = 0x2C; // 44
@@ -714,9 +729,13 @@ fn dispatch_split_stream_class(
                 "DGNUNDERLAY" | "ACDBDGNUNDERLAY" => underlay::UnderlayKind::Dgn,
                 _ => underlay::UnderlayKind::Pdf,
             };
-            checked_inline(raw, object_body_start, version, "UNDERLAY", move |c, v| {
-                underlay::decode(c, kind, v)
-            })
+            checked_inline(
+                raw,
+                object_body_start,
+                version,
+                "UNDERLAY",
+                move |c, v, _ce| underlay::decode(c, kind, v),
+            )
             .map(DecodedEntity::Underlay)
         }
         _ => return None,
@@ -746,13 +765,13 @@ fn checked_inline<T>(
     object_body_start: usize,
     version: Version,
     what: &'static str,
-    decode_body: impl FnOnce(&mut BitCursor<'_>, Version) -> Result<T>,
+    decode_body: impl FnOnce(&mut BitCursor<'_>, Version, &CommonEntityData) -> Result<T>,
 ) -> Result<T> {
     let (_strings, string_start) = crate::tables::modern::open_entity(&raw.raw, version)?;
     let mut c = BitCursor::new(&raw.raw);
     crate::string_stream::seek(&mut c, object_body_start)?;
-    crate::common_entity::read_common_entity_data(&mut c, version)?;
-    let value = decode_body(&mut c, version)?;
+    let common = crate::common_entity::read_common_entity_data(&mut c, version)?;
+    let value = decode_body(&mut c, version, &common)?;
     let at = c.position_bits();
     if at != string_start {
         return Err(crate::tables::modern::misaligned(what, at, string_start));
@@ -802,11 +821,13 @@ fn dispatch_split_stream_entity(
                 .map(DecodedEntity::Spline)
         }
         OBJECT_TYPE_INSERT if version.is_r2010_plus() => {
-            checked_inline(raw, object_body_start, version, "INSERT", insert::decode)
-                .map(DecodedEntity::Insert)
+            checked_inline(raw, object_body_start, version, "INSERT", |c, v, _ce| {
+                insert::decode(c, v)
+            })
+            .map(DecodedEntity::Insert)
         }
         OBJECT_TYPE_3DFACE if version.is_r2010_plus() => {
-            checked_inline(raw, object_body_start, version, "3DFACE", |c, _v| {
+            checked_inline(raw, object_body_start, version, "3DFACE", |c, _v, _ce| {
                 three_d_face::decode(c)
             })
             .map(DecodedEntity::ThreeDFace)
@@ -816,9 +837,31 @@ fn dispatch_split_stream_entity(
             object_body_start,
             version,
             "LWPOLYLINE",
-            lwpolyline::decode,
+            |c, v, _ce| lwpolyline::decode(c, v),
         )
         .map(DecodedEntity::LwPolyline),
+        // REGION / 3DSOLID / BODY — one §20.4.41 field list for all
+        // three. `binary_chain` is the record's `has AcDs binary data`
+        // bit: when it is set the SAB stream lives in the data-storage
+        // section (§24) and the record's shape changes accordingly.
+        OBJECT_TYPE_3DSOLID if version.is_r2010_plus() => {
+            checked_inline(raw, object_body_start, version, "3DSOLID", |c, v, ce| {
+                three_d_solid::decode_record(c, v, ce.binary_chain)
+            })
+            .map(DecodedEntity::ThreeDSolid)
+        }
+        OBJECT_TYPE_REGION if version.is_r2010_plus() => {
+            checked_inline(raw, object_body_start, version, "REGION", |c, v, ce| {
+                region::decode_record(c, v, ce.binary_chain)
+            })
+            .map(DecodedEntity::Region)
+        }
+        OBJECT_TYPE_BODY if version.is_r2010_plus() => {
+            checked_inline(raw, object_body_start, version, "BODY", |c, v, ce| {
+                body::decode_record(c, v, ce.binary_chain)
+            })
+            .map(DecodedEntity::Body)
+        }
         OBJECT_TYPE_LIGHT => {
             light::decode_modern_split_stream(&raw.raw, object_body_start, version)
                 .map(DecodedEntity::Light)

--- a/src/entities/extruded_surface.rs
+++ b/src/entities/extruded_surface.rs
@@ -67,7 +67,7 @@ mod tests {
         let mut w = BitWriter::new();
         let blob = SatBlob {
             empty: false,
-            version: 2,
+            version: 1,
             bytes: b"DUMMY SAT BYTES".to_vec(),
         };
         write_sat_blob(&mut w, &blob);

--- a/src/entities/lofted_surface.rs
+++ b/src/entities/lofted_surface.rs
@@ -97,7 +97,7 @@ mod tests {
             &mut w,
             &SatBlob {
                 empty: false,
-                version: 2,
+                version: 1,
                 bytes: b"LOFT".to_vec(),
             },
         );

--- a/src/entities/modeler.rs
+++ b/src/entities/modeler.rs
@@ -1,34 +1,138 @@
 //! Shared helpers for ACIS-backed modeler entities (3DSOLID, BODY,
 //! REGION, and the SURFACE family) — ODA Open Design Specification
-//! v5.4.1 §19.4.78 and siblings.
+//! v5.4.1 §20.4.41, which prescribes REGION (37), 3DSOLID (38) and
+//! BODY (39) as one record shape.
 //!
 //! Autodesk stores parametric solids and surfaces as an opaque ACIS
-//! SAT (Standard ACIS Text) byte stream wrapped in a thin DWG-level
-//! envelope. The low-level wire decoder lives in
-//! `crate::entities::three_d_solid::read_sat_blob`; this module
-//! offers a small typed wrapper that the four SURFACE variants use
-//! to keep their own structs uncluttered.
+//! SAT/SAB byte stream wrapped in a thin DWG-level envelope. The
+//! low-level envelope decoder lives in
+//! [`crate::entities::three_d_solid`]; this module owns
+//! the rest of §20.4.41 — the wireframe / isoline / silhouette block,
+//! the second ACIS-empty bit, the R2007+ trailing `BL`, and the R2013+
+//! data-store block measured below.
 //!
-//! The re-export keeps the SAT wire shape defined in exactly one
-//! place — if the shape ever needs to evolve (e.g., an R2013 variant
-//! with an extra flag), only `three_d_solid` needs to change and
-//! every SURFACE picks up the new behaviour automatically.
+//! # Stream shape (§20.4.41, after the common entity data)
+//!
+//! ```text
+//! B    ACIS empty                   -- 1 = no SAT/SAB data follows
+//! (if !ACIS empty:)
+//!   B    unknown
+//!   BS   version                    -- 1 = length-prefixed blocks, 2 = raw ACIS file
+//!   (version 1:) loop { BL block size; RC × block size }  until size == 0
+//! B    wireframe data present
+//! (if wireframe data present:)
+//!   B    point present
+//!   (if point present:) 3BD point
+//!   BL   num isolines
+//!   B    isolines present
+//!   (if isolines present:)
+//!     BL   num wires;        wire × num wires
+//!     BL   num silhouettes;  silhouette × num silhouettes
+//! B    ACIS empty (2)                -- "Normally 1"
+//! (if !ACIS empty (2):) the envelope again, with no wireframe block
+//! R2007+:
+//! BL   unknown
+//! ```
+//!
+//! A wire is `RC type, BL selection marker, BS colour, BL ACIS index,
+//! BL point count, 3BD × point count, B transform present` and, when
+//! the transform is present, `3BD × 4, BD scale, B × 3`. A silhouette
+//! is `BL viewport id, 3BD × 3, B perspective, BL wire count` then that
+//! many wires.
+//!
+//! # Measured: the R2013+ data-store block
+//!
+//! §24 of the same specification says the SAB stream of every ACIS
+//! entity is moved into the data-storage section
+//! (`AcDb:AcDsPrototype_1b`) as its own data record, and the record's
+//! `has AcDs binary data` bit in the common entity data (§20.4.1) is
+//! what flags it. All three ACIS records of the corpus —
+//! `sample_AC1032.dwg` (R2018) 3DSOLID `0xD65` / `0xD6A` and REGION
+//! `0xD69` — set that bit, and on all three the record carries **no
+//! inline ACIS envelope at all** and **137 further bits** after the
+//! `BL` §20.4.41 ends on:
+//!
+//! ```text
+//! B     unknown_a                    -- 1 on all three
+//! BB    unknown_b                    -- 0 on all three
+//! BB    unknown_c
+//! BB    unknown_d
+//! RC×16 revision GUID
+//! BL    unknown_e                    -- 0 on all three
+//! ```
+//!
+//! Evidence, per record (bit offsets are from the start of the
+//! payload; the common entity preamble ends at bit 82 on all three):
+//!
+//! | record | point | isolines | GUID | delta |
+//! |---|---|---|---|---|
+//! | 3DSOLID `0xD65` | `(17.7767…, -220.8501…, 2.5)` | 4 | `833111a1-b7ac-4dd4-824d-78b33668f9e7` | 0 |
+//! | REGION `0xD69` | `(24.9857…, -220.4000…, 0)` | 4 | `2b80e3b3-b594-475e-8593-6a36b15e7945` | 0 |
+//! | 3DSOLID `0xD6A` | `(31.6857…, -220.1073…, 2.1902…)` | 4 | `f21ff2a0-ff9c-4ed1-9b2e-7a1e6518d595` | 0 |
+//!
+//! Four independent corroborations, not just an arithmetic fit:
+//!
+//! 1. The three points are real drawing coordinates — three solids in
+//!    a row at `y ≈ -220`, `x` stepping `17.8 → 25.0 → 31.7`.
+//! 2. `num isolines` decodes `4` on every one — AutoCAD's default
+//!    `ISOLINES` system-variable value.
+//! 3. The 16 bytes are a valid RFC-4122 **version-4** UUID on all
+//!    three (version nibble `4`, variant bits `10`). Scanning every
+//!    128-bit window of all three records, bit offset `data_end - 130`
+//!    is the only alignment where all three satisfy both. The chance
+//!    of three independent windows doing so is 1 in 2^18.
+//! 4. The rest of the list is §20.4.41's own grammar, decoding
+//!    `wireframe present = 1`, `point present = 1`, `num wires = 0`,
+//!    `num silhouettes = 0`, `ACIS empty (2) = 1` ("Normally 1" per the
+//!    spec) and the R2007+ `BL` as `0`.
+//!
+//! What the corpus cannot say: whether the missing envelope and the
+//! trailing block are conditional on the `has AcDs binary data` bit or
+//! are unconditional R2013+ changes. No corpus file holds an ACIS
+//! record with the bit clear. This module ties both to the bit, which
+//! is the reading §24 supports; a flag-clear R2013+ record would fail
+//! the boundary check rather than decode wrongly.
+//!
+//! The seven bits before the GUID are read here as `B, BB, BB, BB`.
+//! Only their **total width** is measured — the three records agree on
+//! `1, 0` for the first two slots and differ on the last two, and
+//! nothing in them separates that tokenisation from `3B, BB, BB` or
+//! from seven plain `B`s.
+//!
+//! `examples/probe_acis_census.rs` prints the census and the two
+//! candidate readings of the AcDs marker side by side;
+//! `examples/probe_acis_tail.rs` walks this grammar from every
+//! candidate start bit and reports which ones land on delta 0.
 
 use crate::bitcursor::BitCursor;
-use crate::entities::three_d_solid;
-use crate::error::Result;
+use crate::entities::{Point3D, read_bd3, three_d_solid};
+use crate::error::{Error, Result};
+use crate::version::Version;
 
 /// Re-export of [`three_d_solid::MAX_SAT_BLOB_BYTES`] so SURFACE
 /// decoders can reference a stable symbol without reaching into the
 /// 3DSOLID module.
 pub const MAX_SAT_BYTES: usize = three_d_solid::MAX_SAT_BLOB_BYTES;
 
+/// Defensive cap on the `num wires` / `num silhouettes` / wire point
+/// counts of the §20.4.41 wireframe block.
+///
+/// Every count in that block is a `BL`, so an adversarial record could
+/// declare four billion wires. Real isoline sets on a solid are a
+/// handful; 65 536 is orders of magnitude past anything a modeller
+/// writes and still bounds the walk.
+pub const MAX_MODELER_ELEMENTS: i32 = 65_536;
+
+/// Width in bytes of the R2013+ revision GUID (§ measured — see module docs).
+pub const REVISION_GUID_BYTES: usize = 16;
+
 /// ACIS envelope data decoded from the stream.
 ///
 /// `bytes` is the concatenation of every non-terminator chunk. If
 /// `empty` is true, the drawing stored no SAT payload for this
 /// entity (a legitimate state — some procedural surfaces retain only
-/// their parametric definition, not a cached ACIS body).
+/// their parametric definition, not a cached ACIS body, and from
+/// R2013 the payload moves to the data-storage section entirely).
 #[derive(Debug, Clone, PartialEq)]
 pub struct SatBlob {
     /// Was the `acis_empty` flag set? If so, no payload followed.
@@ -41,6 +145,52 @@ pub struct SatBlob {
     pub bytes: Vec<u8>,
 }
 
+/// The §20.4.41 tail every ACIS entity writes after its envelope.
+///
+/// Per-wire and per-silhouette payloads are *stepped* rather than
+/// surfaced: no corpus record carries any (`num_wires` and
+/// `num_silhouettes` are `0` on all three), so structs for them would
+/// be API that no byte has ever exercised. The counts are surfaced so
+/// a caller can tell an empty block from an absent one.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ModelerTail {
+    /// `wireframe data present` — true when the point/isoline block
+    /// that follows was written.
+    pub wireframe_present: bool,
+    /// The wireframe block's point. `None` when the block is absent or
+    /// its `point present` bit is clear (§20.4.41: "otherwise assume
+    /// 0,0,0 for point").
+    pub point: Option<Point3D>,
+    /// `Num IsoLines` — AutoCAD's `ISOLINES` system variable, `4` by
+    /// default. `0` when no wireframe block was written.
+    pub num_isolines: i32,
+    /// `IsoLines present` — whether the wire/silhouette lists follow.
+    pub isolines_present: bool,
+    /// Number of wires in the isoline list.
+    pub num_wires: i32,
+    /// Number of silhouettes in the silhouette list.
+    pub num_silhouettes: i32,
+    /// The second `ACIS empty` bit — §20.4.41 notes it is "normally 1".
+    pub acis_empty_2: bool,
+    /// R2013+ data-store records only: the 16-byte revision GUID.
+    /// `None` when the record wrote no data-store block.
+    pub revision_guid: Option<[u8; REVISION_GUID_BYTES]>,
+}
+
+/// One whole ACIS record: the envelope plus the §20.4.41 tail.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ModelerRecord {
+    /// The record's inline ACIS envelope. On an R2013+ record whose
+    /// `has AcDs binary data` bit is set there is none, and this is
+    /// `SatBlob { empty: true, .. }`.
+    pub blob: SatBlob,
+    /// `true` when the SAB stream lives in the data-storage section
+    /// (§24) rather than inline.
+    pub in_data_store: bool,
+    /// The §20.4.41 tail.
+    pub tail: ModelerTail,
+}
+
 /// Decode one ACIS envelope by delegating to
 /// `three_d_solid::read_sat_blob` and adapting the tuple result
 /// into the [`SatBlob`] struct.
@@ -50,6 +200,141 @@ pub fn decode_sat_blob(c: &mut BitCursor<'_>) -> Result<SatBlob> {
         empty,
         version: version.unwrap_or(0),
         bytes: bytes.unwrap_or_default(),
+    })
+}
+
+/// Step one §20.4.41 wire struct, consuming its bits without
+/// surfacing them.
+fn step_wire(c: &mut BitCursor<'_>) -> Result<()> {
+    let _wire_type = c.read_rc()?;
+    let _selection_marker = c.read_bl()?;
+    let _colour = c.read_bs()?;
+    let _acis_index = c.read_bl()?;
+    let point_count = bounded_count(c.read_bl()?, "wire point count")?;
+    for _ in 0..point_count {
+        let _ = read_bd3(c)?;
+    }
+    if c.read_b()? {
+        // X / Y / Z axis, translation.
+        for _ in 0..4 {
+            let _ = read_bd3(c)?;
+        }
+        let _scale = c.read_bd()?;
+        let _has_rotation = c.read_b()?;
+        let _has_reflection = c.read_b()?;
+        let _has_shear = c.read_b()?;
+    }
+    Ok(())
+}
+
+/// Reject a `BL` count that cannot describe a real wireframe block.
+fn bounded_count(value: i32, what: &str) -> Result<i32> {
+    if !(0..=MAX_MODELER_ELEMENTS).contains(&value) {
+        return Err(Error::SectionMap(format!(
+            "ACIS {what} is {value}, outside 0..={MAX_MODELER_ELEMENTS}"
+        )));
+    }
+    Ok(value)
+}
+
+/// Read the §20.4.41 record body: the envelope, the wireframe block,
+/// the second ACIS-empty bit, the R2007+ `BL`, and — when
+/// `in_data_store` — the measured R2013+ data-store block.
+///
+/// `in_data_store` is the `has AcDs binary data` bit of the common
+/// entity data ([`crate::common_entity::CommonEntityData::binary_chain`]).
+/// See the module docs for what each branch is measured against.
+pub fn decode_record(
+    c: &mut BitCursor<'_>,
+    version: Version,
+    in_data_store: bool,
+) -> Result<ModelerRecord> {
+    let blob = if in_data_store {
+        // §24.2.2.3: the SAB stream is a data-store record, and the
+        // three corpus records write no inline envelope at all.
+        SatBlob {
+            empty: true,
+            version: 0,
+            bytes: Vec::new(),
+        }
+    } else {
+        decode_sat_blob(c)?
+    };
+
+    let wireframe_present = c.read_b()?;
+    let mut point = None;
+    let mut num_isolines = 0;
+    let mut isolines_present = false;
+    let mut num_wires = 0;
+    let mut num_silhouettes = 0;
+    if wireframe_present {
+        if c.read_b()? {
+            point = Some(read_bd3(c)?);
+        }
+        num_isolines = bounded_count(c.read_bl()?, "isoline count")?;
+        isolines_present = c.read_b()?;
+        if isolines_present {
+            num_wires = bounded_count(c.read_bl()?, "wire count")?;
+            for _ in 0..num_wires {
+                step_wire(c)?;
+            }
+            num_silhouettes = bounded_count(c.read_bl()?, "silhouette count")?;
+            for _ in 0..num_silhouettes {
+                let _viewport_id = c.read_bl()?;
+                // Target, direction from target, up direction.
+                for _ in 0..3 {
+                    let _ = read_bd3(c)?;
+                }
+                let _perspective = c.read_b()?;
+                let wires = bounded_count(c.read_bl()?, "silhouette wire count")?;
+                for _ in 0..wires {
+                    step_wire(c)?;
+                }
+            }
+        }
+    }
+
+    let acis_empty_2 = c.read_b()?;
+    if !acis_empty_2 {
+        // §20.4.41: "acis data follows in the same format as described
+        // above, except no wireframe or silhouette data will be
+        // present". The envelope's own empty bit is not repeated here.
+        let _unknown = c.read_b()?;
+        let version_2 = c.read_bs_u()?;
+        let _blob = three_d_solid::read_sat_blocks(c, version_2)?;
+    }
+    if version.is_r2007_plus() {
+        let _unknown = c.read_bl()?;
+    }
+
+    let revision_guid = if in_data_store {
+        let _unknown_a = c.read_b()?;
+        let _unknown_b = c.read_bb()?;
+        let _unknown_c = c.read_bb()?;
+        let _unknown_d = c.read_bb()?;
+        let mut guid = [0u8; REVISION_GUID_BYTES];
+        for byte in guid.iter_mut() {
+            *byte = c.read_rc()?;
+        }
+        let _unknown_e = c.read_bl()?;
+        Some(guid)
+    } else {
+        None
+    };
+
+    Ok(ModelerRecord {
+        blob,
+        in_data_store,
+        tail: ModelerTail {
+            wireframe_present,
+            point,
+            num_isolines,
+            isolines_present,
+            num_wires,
+            num_silhouettes,
+            acis_empty_2,
+            revision_guid,
+        },
     })
 }
 
@@ -68,15 +353,23 @@ pub(crate) mod tests {
             return;
         }
         w.write_b(false);
+        w.write_b(false); // §20.4.41 unknown bit
         w.write_bs_u(blob.version);
         if !blob.bytes.is_empty() {
-            w.write_b(true); // has_more_blocks
             w.write_bl(blob.bytes.len() as i32);
             for b in &blob.bytes {
                 w.write_rc(*b);
             }
         }
-        w.write_b(false); // no more blocks
+        w.write_bl(0); // terminating block size
+    }
+
+    /// Write the §20.4.41 tail of a record that carries no wireframe
+    /// block and no data-store block.
+    pub(crate) fn write_minimal_tail(w: &mut BitWriter) {
+        w.write_b(false); // wireframe data present
+        w.write_b(true); // ACIS empty (2)
+        w.write_bl(0); // R2007+ unknown
     }
 
     #[test]
@@ -105,7 +398,7 @@ pub(crate) mod tests {
             &mut w,
             &SatBlob {
                 empty: false,
-                version: 70,
+                version: 1,
                 bytes: payload.clone(),
             },
         );
@@ -113,7 +406,153 @@ pub(crate) mod tests {
         let mut c = BitCursor::new(&bytes);
         let b = decode_sat_blob(&mut c).unwrap();
         assert!(!b.empty);
-        assert_eq!(b.version, 70);
+        assert_eq!(b.version, 1);
         assert_eq!(b.bytes, payload);
+    }
+
+    /// The data-store shape measured on `sample_AC1032.dwg`: no inline
+    /// envelope, a wireframe block whose point is real geometry and
+    /// whose isoline count is AutoCAD's default `4`, then the seven
+    /// unknown bits, the revision GUID and the trailing `BL`.
+    #[test]
+    fn roundtrip_r2018_data_store_record() {
+        let guid: [u8; 16] = [
+            0x83, 0x31, 0x11, 0xA1, 0xB7, 0xAC, 0x4D, 0xD4, 0x82, 0x4D, 0x78, 0xB3, 0x36, 0x68,
+            0xF9, 0xE7,
+        ];
+        let mut w = BitWriter::new();
+        w.write_b(true); // wireframe data present
+        w.write_b(true); // point present
+        w.write_bd(17.776_725_469_823_76);
+        w.write_bd(-220.850_122_660_715_93);
+        w.write_bd(2.5);
+        w.write_bl(4); // num isolines
+        w.write_b(true); // isolines present
+        w.write_bl(0); // num wires
+        w.write_bl(0); // num silhouettes
+        w.write_b(true); // ACIS empty (2)
+        w.write_bl(0); // R2007+ unknown
+        w.write_b(true); // unknown_a
+        w.write_bb(0); // unknown_b
+        w.write_bb(0); // unknown_c
+        w.write_bb(0b10); // unknown_d
+        for b in guid {
+            w.write_rc(b);
+        }
+        w.write_bl(0); // unknown_e
+        let end = w.position_bits();
+
+        let bytes = w.into_bytes();
+        let mut c = BitCursor::new(&bytes);
+        let rec = decode_record(&mut c, Version::R2018, true).unwrap();
+        assert!(rec.in_data_store);
+        assert!(rec.blob.empty);
+        assert!(rec.tail.wireframe_present);
+        assert_eq!(rec.tail.num_isolines, 4);
+        assert!(rec.tail.isolines_present);
+        assert_eq!(rec.tail.num_wires, 0);
+        assert_eq!(rec.tail.num_silhouettes, 0);
+        assert!(rec.tail.acis_empty_2);
+        assert_eq!(rec.tail.revision_guid, Some(guid));
+        let p = rec.tail.point.unwrap();
+        assert_eq!(p.z, 2.5);
+        assert_eq!(c.position_bits(), end);
+    }
+
+    /// A record with an inline envelope and no wireframe block closes
+    /// on the same grammar with the data-store branch off.
+    #[test]
+    fn roundtrip_inline_envelope_record() {
+        let mut w = BitWriter::new();
+        write_sat_blob(
+            &mut w,
+            &SatBlob {
+                empty: false,
+                version: 1,
+                bytes: b"400 0 1 0".to_vec(),
+            },
+        );
+        write_minimal_tail(&mut w);
+        let end = w.position_bits();
+
+        let bytes = w.into_bytes();
+        let mut c = BitCursor::new(&bytes);
+        let rec = decode_record(&mut c, Version::R2018, false).unwrap();
+        assert!(!rec.blob.empty);
+        assert_eq!(rec.blob.bytes, b"400 0 1 0".to_vec());
+        assert!(!rec.tail.wireframe_present);
+        assert!(rec.tail.acis_empty_2);
+        assert_eq!(rec.tail.revision_guid, None);
+        assert_eq!(c.position_bits(), end);
+    }
+
+    /// A wire list is stepped, not surfaced — but it must still be
+    /// stepped exactly, or the record misses its boundary.
+    #[test]
+    fn wire_and_silhouette_lists_are_stepped_exactly() {
+        let mut w = BitWriter::new();
+        w.write_b(true); // ACIS empty — no inline envelope
+        w.write_b(true); // wireframe data present
+        w.write_b(false); // point present
+        w.write_bl(4);
+        w.write_b(true); // isolines present
+        w.write_bl(1); // one wire
+        w.write_rc(3); // wire type
+        w.write_bl(7); // selection marker
+        w.write_bs(256); // colour
+        w.write_bl(2); // acis index
+        w.write_bl(2); // point count
+        for _ in 0..2 {
+            w.write_bd(1.0);
+            w.write_bd(2.0);
+            w.write_bd(3.0);
+        }
+        w.write_b(true); // transform present
+        for _ in 0..4 {
+            w.write_bd(1.0);
+            w.write_bd(0.0);
+            w.write_bd(0.0);
+        }
+        w.write_bd(1.0); // scale
+        w.write_b(false);
+        w.write_b(false);
+        w.write_b(false);
+        w.write_bl(1); // one silhouette
+        w.write_bl(11); // viewport id
+        for _ in 0..3 {
+            w.write_bd(0.0);
+            w.write_bd(0.0);
+            w.write_bd(1.0);
+        }
+        w.write_b(false); // perspective
+        w.write_bl(0); // silhouette wire count
+        w.write_b(true); // ACIS empty (2)
+        w.write_bl(0); // R2007+ unknown
+        let end = w.position_bits();
+
+        let bytes = w.into_bytes();
+        let mut c = BitCursor::new(&bytes);
+        let rec = decode_record(&mut c, Version::R2018, false).unwrap();
+        assert_eq!(rec.tail.num_wires, 1);
+        assert_eq!(rec.tail.num_silhouettes, 1);
+        assert_eq!(rec.tail.point, None);
+        assert_eq!(c.position_bits(), end);
+    }
+
+    #[test]
+    fn absurd_wire_count_is_rejected() {
+        let mut w = BitWriter::new();
+        w.write_b(true); // wireframe present
+        w.write_b(false); // point present
+        w.write_bl(4);
+        w.write_b(true); // isolines present
+        w.write_bl(1_000_000); // wire count
+        let bytes = w.into_bytes();
+        let mut c = BitCursor::new(&bytes);
+        let err = decode_record(&mut c, Version::R2018, true).unwrap_err();
+        match err {
+            Error::SectionMap(msg) => assert!(msg.contains("wire count"), "msg: {msg}"),
+            other => panic!("expected SectionMap, got {other:?}"),
+        }
     }
 }

--- a/src/entities/region.rs
+++ b/src/entities/region.rs
@@ -1,42 +1,70 @@
-//! REGION entity (§19.4.43) — 2D ACIS region (planar bounded face).
+//! REGION entity (§20.4.41) — 2D ACIS region (planar bounded face).
 //!
-//! REGION shares an identical on-wire encoding with 3DSOLID (§19.4.42)
-//! and BODY (§19.4.44): an `acis_empty` flag, a version field, and a
-//! loop of length-prefixed payload chunks that concatenate to an
-//! opaque Standard ACIS Text (SAT) blob. See
-//! [`crate::entities::three_d_solid`] for the full stream layout,
-//! defensive caps, and shared helper documentation.
+//! REGION shares one record shape with 3DSOLID and BODY: an ACIS
+//! envelope, the wireframe / isoline / silhouette block, a second
+//! ACIS-empty bit, the R2007+ trailing `BL` and — on an R2013+ record
+//! whose payload lives in the data-storage section — the measured
+//! revision-GUID block. See [`crate::entities::three_d_solid`] for the
+//! envelope and [`crate::entities::modeler`] for the rest of the
+//! record, its evidence and the defensive caps.
 //!
 //! The same [`crate::entities::three_d_solid::MAX_SAT_BLOB_BYTES`]
 //! 32 MiB ceiling applies here.
 
 use crate::bitcursor::BitCursor;
+use crate::entities::modeler::{self, ModelerTail};
 use crate::entities::three_d_solid::read_sat_blob;
 use crate::error::Result;
+use crate::version::Version;
 
-/// REGION entity — §19.4.43.
+/// REGION entity — §20.4.41.
 ///
 /// See [`crate::entities::three_d_solid::ThreeDSolid`] for the meaning
 /// of each field; the encoding is identical.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Region {
-    /// `true` when the entity was written with no body attached
-    /// (`acis_empty` bit set).
+    /// `true` when the entity was written with no inline body
+    /// (`ACIS empty` bit set).
     pub acis_empty: bool,
-    /// ACIS format version reported before the chunk loop. `None`
+    /// ACIS format version reported before the block loop. `None`
     /// when `acis_empty` is `true`.
     pub version: Option<u16>,
     /// Concatenated SAT payload bytes, or `None` when `acis_empty`.
     pub sat_blob: Option<Vec<u8>>,
+    /// R2013+: the SAB stream is a data record in the data-storage
+    /// section (§24) rather than inline.
+    pub in_data_store: bool,
+    /// The §20.4.41 fields that follow the envelope. `None` from the
+    /// envelope-only [`decode`] entry point.
+    pub tail: Option<ModelerTail>,
 }
 
-/// Decode a REGION entity per ODA spec v5.4.1 §19.4.43.
+/// Decode a REGION **envelope** per ODA spec v5.4.1 §20.4.41.
 pub fn decode(c: &mut BitCursor<'_>) -> Result<Region> {
     let (acis_empty, version, sat_blob) = read_sat_blob(c)?;
     Ok(Region {
         acis_empty,
         version,
         sat_blob,
+        in_data_store: false,
+        tail: None,
+    })
+}
+
+/// Decode a whole REGION record — envelope plus the §20.4.41 fields
+/// that follow it.
+pub fn decode_record(
+    c: &mut BitCursor<'_>,
+    version: Version,
+    in_data_store: bool,
+) -> Result<Region> {
+    let record = modeler::decode_record(c, version, in_data_store)?;
+    Ok(Region {
+        acis_empty: record.blob.empty,
+        version: (!record.blob.empty).then_some(record.blob.version),
+        sat_blob: (!record.blob.empty).then_some(record.blob.bytes),
+        in_data_store: record.in_data_store,
+        tail: Some(record.tail),
     })
 }
 
@@ -48,7 +76,7 @@ mod tests {
     #[test]
     fn roundtrip_empty_region() {
         let mut w = BitWriter::new();
-        w.write_b(true); // acis_empty
+        w.write_b(true); // ACIS empty
         let bytes = w.into_bytes();
         let mut c = BitCursor::new(&bytes);
         let r = decode(&mut c).unwrap();
@@ -59,21 +87,58 @@ mod tests {
 
     #[test]
     fn roundtrip_region_with_blob() {
-        let payload = b"REGION_SAT_DATA";
+        let payload = b"400 0 1 0";
         let mut w = BitWriter::new();
         w.write_b(false);
-        w.write_bs_u(700);
-        w.write_b(true);
+        w.write_b(false); // §20.4.41 unknown bit
+        w.write_bs_u(1);
         w.write_bl(payload.len() as i32);
         for b in payload {
             w.write_rc(*b);
         }
-        w.write_b(false);
+        w.write_bl(0);
         let bytes = w.into_bytes();
         let mut c = BitCursor::new(&bytes);
         let r = decode(&mut c).unwrap();
         assert!(!r.acis_empty);
-        assert_eq!(r.version, Some(700));
+        assert_eq!(r.version, Some(1));
         assert_eq!(r.sat_blob.as_deref(), Some(&payload[..]));
+    }
+
+    /// The R2013+ data-store shape: no inline envelope, a wireframe
+    /// point, `num isolines = 4` and the 16-byte revision GUID.
+    #[test]
+    fn roundtrip_region_data_store_record() {
+        let guid = [0xABu8; 16];
+        let mut w = BitWriter::new();
+        w.write_b(true); // wireframe data present
+        w.write_b(true); // point present
+        w.write_bd(1.0);
+        w.write_bd(2.0);
+        w.write_bd(0.0);
+        w.write_bl(4); // num isolines
+        w.write_b(true); // isolines present
+        w.write_bl(0); // num wires
+        w.write_bl(0); // num silhouettes
+        w.write_b(true); // ACIS empty (2)
+        w.write_bl(0); // R2007+ unknown
+        w.write_b(true);
+        w.write_bb(0);
+        w.write_bb(0);
+        w.write_bb(0b10);
+        for b in guid {
+            w.write_rc(b);
+        }
+        w.write_bl(0);
+        let end = w.position_bits();
+        let bytes = w.into_bytes();
+        let mut c = BitCursor::new(&bytes);
+        let r = decode_record(&mut c, Version::R2018, true).unwrap();
+        assert!(r.in_data_store);
+        assert!(r.acis_empty);
+        let fields = r.tail.unwrap();
+        assert_eq!(fields.num_isolines, 4);
+        assert_eq!(fields.revision_guid, Some(guid));
+        assert_eq!(c.position_bits(), end);
     }
 }

--- a/src/entities/swept_surface.rs
+++ b/src/entities/swept_surface.rs
@@ -105,7 +105,7 @@ mod tests {
             &mut w,
             &SatBlob {
                 empty: false,
-                version: 2,
+                version: 1,
                 bytes: b"SW".to_vec(),
             },
         );
@@ -115,7 +115,7 @@ mod tests {
         let bytes = w.into_bytes();
         let mut c = BitCursor::new(&bytes);
         let s = decode(&mut c).unwrap();
-        assert_eq!(s.sat.version, 2);
+        assert_eq!(s.sat.version, 1);
         assert_eq!(s.path_handle.code, 2);
         assert_eq!(s.path_handle.value, 0x42);
         assert_eq!(s.align_option, AlignOption::Normal);

--- a/src/entities/three_d_solid.rs
+++ b/src/entities/three_d_solid.rs
@@ -1,38 +1,50 @@
-//! 3DSOLID entity (§19.4.42) — ACIS-modeled 3D solid body.
+//! 3DSOLID entity (§20.4.41) — ACIS-modeled 3D solid body.
 //!
-//! 3DSOLID, REGION (§19.4.43), and BODY (§19.4.44) share an identical
-//! on-wire shape: an `acis_empty` flag that, when false, is followed by
-//! a version field and a loop of length-prefixed payload chunks. The
-//! concatenated chunk payloads form a Standard ACIS Text (SAT) blob —
-//! a textual representation of the ACIS geometry kernel's B-rep data.
+//! REGION (37), 3DSOLID (38) and BODY (39) are one entry in the ODA
+//! Open Design Specification v5.4.1: §20.4.41 prescribes a single
+//! record shape for all three. This module owns the ACIS *envelope*
+//! — the empty bit, the unknown bit, the version and the
+//! length-prefixed block loop — and [`crate::entities::modeler`] owns
+//! the rest of the record (wireframe block, second empty bit, the
+//! R2007+ `BL`, and the measured R2013+ data-store block).
 //!
-//! This decoder extracts the opaque blob and the version header but
-//! does NOT parse the SAT text itself. SAT is a separate file format
-//! (the Spatial Corp. "Standard ACIS Text" format) with its own spec
-//! and its own parser. Callers who need solid geometry from a DWG
-//! should feed [`ThreeDSolid::sat_blob`] to a SAT parser downstream.
+//! The concatenated block payloads form a Standard ACIS Text (SAT)
+//! blob — a textual representation of the ACIS geometry kernel's B-rep
+//! data. This decoder extracts the opaque blob and the version header
+//! but does NOT parse the SAT text itself: SAT/SAB is a separate file
+//! format with its own specification, and §24 of the ODA document is
+//! explicit that "more detailed description of the ACIS/SAB data falls
+//! outside the scope of this document". Callers who need solid
+//! geometry should feed [`ThreeDSolid::sat_blob`] to a SAT parser
+//! downstream.
 //!
-//! # Stream shape
+//! # Stream shape (§20.4.41 envelope)
 //!
 //! ```text
-//! B   acis_empty                  -- 1 bit: true = no body attached
-//! (if !acis_empty:)
-//!   BS  version                   -- ACIS format version (70 = v7.0, etc.)
-//!   loop:
-//!     B   has_more_blocks         -- 1 bit: true = another chunk follows
-//!     (if has_more_blocks:)
-//!       BL  chunk_size            -- bytes in this chunk
-//!       RC  payload[chunk_size]   -- raw bytes (SAT text fragment)
-//!   (loop ends when has_more_blocks is false)
+//! B   ACIS empty                  -- 1 bit: true = no data follows
+//! (if !ACIS empty:)
+//!   B   unknown
+//!   BS  version                   -- 1 or 2
+//!   (version 1:) repeat until block size is 0:
+//!     BL  block size              -- bytes of SAT data in this block
+//!     RC  data[block size]
 //! ```
 //!
-//! # Shared helper
+//! Version 2 is followed by a raw ACIS file with no length field
+//! ("SAT files must be parsed to find the end"), which cannot be
+//! stepped without an ACIS parser — the envelope reader refuses it
+//! rather than guessing.
 //!
-//! `read_sat_blob` extracts `(version, blob)` per the shape above.
-//! It is re-used by [`crate::entities::region::decode`] and
-//! [`crate::entities::body::decode`] — the three ODA spec sections
-//! §19.4.42/43/44 define identical encodings, so one implementation
-//! backs all three entities.
+//! # Where the R2013+ payload actually lives
+//!
+//! From R2013 the SAB stream of every ACIS entity is moved out of the
+//! entity record into the data-storage section
+//! (`AcDb:AcDsPrototype_1b`, §24.2.2.3: "For each ACIS entity (REGION,
+//! 3DSOLID), a data record is created with the SAB stream of the
+//! object"), and the record's `has AcDs binary data` bit in the common
+//! entity data flags it. All three ACIS records of this crate's corpus
+//! are of that kind — see [`crate::entities::modeler`] for the
+//! measurement.
 //!
 //! # Defensive cap
 //!
@@ -43,7 +55,9 @@
 //! would force an unbounded allocation.
 
 use crate::bitcursor::BitCursor;
+use crate::entities::modeler::{self, ModelerRecord, ModelerTail};
 use crate::error::{Error, Result};
+use crate::version::Version;
 
 /// Maximum accumulated SAT blob size across all chunks (32 MiB).
 ///
@@ -52,45 +66,84 @@ use crate::error::{Error, Result};
 /// [`crate::entities::body`] which share the same decoder.
 pub const MAX_SAT_BLOB_BYTES: usize = 32 * 1024 * 1024;
 
-/// 3DSOLID entity — §19.4.42.
+/// 3DSOLID entity — §20.4.41.
 ///
 /// `sat_blob` is `None` when the on-wire `acis_empty` flag is set.
-/// When present, `sat_blob` is the concatenation of every chunk's raw
+/// When present, `sat_blob` is the concatenation of every block's raw
 /// payload bytes in stream order and `version` is the ACIS format
 /// version reported by the writer.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ThreeDSolid {
-    /// `true` when the entity was written with no body attached
-    /// (`acis_empty` bit set).
+    /// `true` when the entity was written with no inline body
+    /// (`ACIS empty` bit set), which includes every R2013+ record
+    /// whose payload moved to the data-storage section.
     pub acis_empty: bool,
-    /// ACIS format version reported before the chunk loop, e.g. `70`
-    /// for ACIS 7.0. `None` when `acis_empty` is `true`.
+    /// ACIS format version reported before the block loop, `1` or `2`.
+    /// `None` when `acis_empty` is `true`.
     pub version: Option<u16>,
     /// Concatenated SAT payload bytes. `None` when `acis_empty` is
-    /// `true`; `Some(vec![])` when the chunk loop terminated
+    /// `true`; `Some(vec![])` when the block loop terminated
     /// immediately (valid but unusual).
     pub sat_blob: Option<Vec<u8>>,
+    /// R2013+: the record's `has AcDs binary data` bit was set, so the
+    /// SAB stream is a data record in the data-storage section (§24).
+    pub in_data_store: bool,
+    /// The §20.4.41 tail — wireframe block, second ACIS-empty bit and
+    /// the R2013+ revision GUID. `None` from the envelope-only
+    /// [`decode`] entry point, which reads no tail.
+    pub tail: Option<ModelerTail>,
 }
 
-/// Decode a 3DSOLID entity per ODA spec v5.4.1 §19.4.42.
+/// Decode a 3DSOLID **envelope** per ODA spec v5.4.1 §20.4.41.
+///
+/// This reads only the ACIS envelope and leaves the cursor at the
+/// start of the §20.4.41 tail; [`decode_record`] reads the whole
+/// record and is what the dispatcher uses.
 pub fn decode(c: &mut BitCursor<'_>) -> Result<ThreeDSolid> {
     let (acis_empty, version, sat_blob) = read_sat_blob(c)?;
     Ok(ThreeDSolid {
         acis_empty,
         version,
         sat_blob,
+        in_data_store: false,
+        tail: None,
     })
 }
 
-/// Shared SAT-blob extractor used by 3DSOLID, REGION, and BODY.
+/// Build a 3DSOLID from a decoded [`ModelerRecord`].
+pub fn from_record(record: ModelerRecord) -> ThreeDSolid {
+    ThreeDSolid {
+        acis_empty: record.blob.empty,
+        version: (!record.blob.empty).then_some(record.blob.version),
+        sat_blob: (!record.blob.empty).then_some(record.blob.bytes),
+        in_data_store: record.in_data_store,
+        tail: Some(record.tail),
+    }
+}
+
+/// Decode a whole 3DSOLID record — envelope plus §20.4.41 tail.
+pub fn decode_record(
+    c: &mut BitCursor<'_>,
+    version: Version,
+    in_data_store: bool,
+) -> Result<ThreeDSolid> {
+    Ok(from_record(modeler::decode_record(
+        c,
+        version,
+        in_data_store,
+    )?))
+}
+
+/// Shared ACIS-envelope reader used by 3DSOLID, REGION, and BODY.
 ///
 /// Returns `(acis_empty, version, blob)`. `version` and `blob` are
 /// both `None` when `acis_empty` is `true`.
 ///
 /// # Errors
 ///
-/// - [`Error::SectionMap`] if the accumulated blob exceeds
-///   [`MAX_SAT_BLOB_BYTES`] or if a declared `chunk_size` exceeds the
+/// - [`Error::SectionMap`] if the envelope reports version 2 (a raw
+///   ACIS file with no length field), if the accumulated blob exceeds
+///   [`MAX_SAT_BLOB_BYTES`], or if a declared block size exceeds the
 ///   remaining bytes in the cursor.
 /// - Any [`BitCursor`] read error propagated from an underlying field.
 pub(crate) fn read_sat_blob(c: &mut BitCursor<'_>) -> Result<(bool, Option<u16>, Option<Vec<u8>>)> {
@@ -98,57 +151,66 @@ pub(crate) fn read_sat_blob(c: &mut BitCursor<'_>) -> Result<(bool, Option<u16>,
     if acis_empty {
         return Ok((true, None, None));
     }
-
+    let _unknown = c.read_b()?;
     let version = c.read_bs_u()?;
+    let blob = read_sat_blocks(c, version)?;
+    Ok((false, Some(version), Some(blob)))
+}
+
+/// Read the version-1 block loop of an ACIS envelope (§20.4.41).
+///
+/// The loop reads a `BL` block size and that many `RC`s, and ends when
+/// the block size is `0`. Version 2 has no length prefix at all and is
+/// refused.
+pub(crate) fn read_sat_blocks(c: &mut BitCursor<'_>, version: u16) -> Result<Vec<u8>> {
+    if version != 1 {
+        return Err(Error::SectionMap(format!(
+            "ACIS envelope reports version {version}; only the \
+             length-prefixed version 1 form can be stepped without an \
+             ACIS parser (§20.4.41)"
+        )));
+    }
     let mut blob: Vec<u8> = Vec::new();
-
-    // Loop while another block follows. Each iteration reads a flag
-    // first; a false flag terminates the loop before any size/payload
-    // read. This matches the shape documented in ODA spec §19.4.42.
     loop {
-        let has_more_blocks = c.read_b()?;
-        if !has_more_blocks {
-            break;
-        }
-
         // `read_bl` returns i32; negative counts are invalid here.
-        let chunk_size_signed = c.read_bl()?;
-        if chunk_size_signed < 0 {
+        let block_size_signed = c.read_bl()?;
+        if block_size_signed == 0 {
+            return Ok(blob);
+        }
+        if block_size_signed < 0 {
             return Err(Error::SectionMap(format!(
-                "SAT chunk_size is negative ({chunk_size_signed}); \
+                "SAT block size is negative ({block_size_signed}); \
                  entity stream is malformed"
             )));
         }
-        let chunk_size = chunk_size_signed as usize;
+        let block_size = block_size_signed as usize;
 
-        // A chunk_size that exceeds the remaining cursor bytes cannot
+        // A block size that exceeds the remaining cursor bytes cannot
         // be real. Each RC consumes 8 bits, so divide remaining bits by
         // 8 for the byte-level ceiling.
         let remaining_bytes = c.remaining_bits() / 8;
-        if chunk_size > remaining_bytes {
+        if block_size > remaining_bytes {
             return Err(Error::SectionMap(format!(
-                "SAT chunk_size ({chunk_size}) exceeds remaining cursor \
+                "SAT block size ({block_size}) exceeds remaining cursor \
                  bytes ({remaining_bytes})"
             )));
         }
 
         // Check the accumulated total before growing, so an over-sized
-        // first chunk is rejected without a large allocation.
-        if blob.len().saturating_add(chunk_size) > MAX_SAT_BLOB_BYTES {
+        // first block is rejected without a large allocation.
+        if blob.len().saturating_add(block_size) > MAX_SAT_BLOB_BYTES {
             return Err(Error::SectionMap(format!(
                 "SAT blob exceeds {MAX_SAT_BLOB_BYTES}-byte cap \
-                 (accumulated {} + chunk {chunk_size})",
+                 (accumulated {} + block {block_size})",
                 blob.len()
             )));
         }
 
-        blob.reserve(chunk_size);
-        for _ in 0..chunk_size {
+        blob.reserve(block_size);
+        for _ in 0..block_size {
             blob.push(c.read_rc()?);
         }
     }
-
-    Ok((false, Some(version), Some(blob)))
 }
 
 #[cfg(test)]
@@ -158,7 +220,7 @@ mod tests {
 
     #[test]
     fn roundtrip_empty_body() {
-        // acis_empty = true ⇒ no version, no chunks.
+        // acis_empty = true ⇒ no version, no blocks.
         let mut w = BitWriter::new();
         w.write_b(true);
         let bytes = w.into_bytes();
@@ -167,61 +229,78 @@ mod tests {
         assert!(s.acis_empty);
         assert_eq!(s.version, None);
         assert_eq!(s.sat_blob, None);
+        assert_eq!(s.tail, None);
     }
 
     #[test]
-    fn roundtrip_single_chunk() {
-        // acis_empty=false, version=70, one 4-byte chunk, then stop.
-        let payload: [u8; 4] = *b"SAT!";
+    fn roundtrip_single_block() {
+        // acis_empty=false, unknown, version=1, one 9-byte block, stop.
+        // "400 0 1 0" is the header line every SAT stream opens with.
+        let payload: [u8; 9] = *b"400 0 1 0";
         let mut w = BitWriter::new();
         w.write_b(false);
-        w.write_bs_u(70);
-        w.write_b(true); // has_more_blocks
+        w.write_b(false);
+        w.write_bs_u(1);
         w.write_bl(payload.len() as i32);
         for b in payload {
             w.write_rc(b);
         }
-        w.write_b(false); // no more blocks
+        w.write_bl(0); // terminating block size
         let bytes = w.into_bytes();
         let mut c = BitCursor::new(&bytes);
         let s = decode(&mut c).unwrap();
         assert!(!s.acis_empty);
-        assert_eq!(s.version, Some(70));
+        assert_eq!(s.version, Some(1));
         assert_eq!(s.sat_blob.as_deref(), Some(&payload[..]));
     }
 
     #[test]
-    fn roundtrip_multi_chunk() {
-        // Two chunks that together form "hello, world!".
+    fn roundtrip_multi_block() {
+        // Two blocks that together form "hello, world!".
         let mut w = BitWriter::new();
         w.write_b(false);
-        w.write_bs_u(700);
         w.write_b(true);
+        w.write_bs_u(1);
         w.write_bl(7);
         for b in b"hello, " {
             w.write_rc(*b);
         }
-        w.write_b(true);
         w.write_bl(6);
         for b in b"world!" {
             w.write_rc(*b);
         }
-        w.write_b(false);
+        w.write_bl(0);
         let bytes = w.into_bytes();
         let mut c = BitCursor::new(&bytes);
         let s = decode(&mut c).unwrap();
-        assert_eq!(s.version, Some(700));
+        assert_eq!(s.version, Some(1));
         assert_eq!(s.sat_blob.as_deref(), Some(&b"hello, world!"[..]));
     }
 
     #[test]
-    fn chunk_size_over_remaining_rejected() {
-        // Claim 1_000_000 bytes in a single chunk but provide almost
+    fn version_two_is_refused() {
+        // Version 2 embeds a raw ACIS file with no length field.
+        let mut w = BitWriter::new();
+        w.write_b(false);
+        w.write_b(false);
+        w.write_bs_u(2);
+        let bytes = w.into_bytes();
+        let mut c = BitCursor::new(&bytes);
+        let err = decode(&mut c).unwrap_err();
+        match err {
+            Error::SectionMap(msg) => assert!(msg.contains("version 2"), "msg: {msg}"),
+            other => panic!("expected SectionMap, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn block_size_over_remaining_rejected() {
+        // Claim 1_000_000 bytes in a single block but provide almost
         // nothing. Must return SectionMap, not allocate 1M.
         let mut w = BitWriter::new();
         w.write_b(false);
-        w.write_bs_u(70);
-        w.write_b(true);
+        w.write_b(false);
+        w.write_bs_u(1);
         w.write_bl(1_000_000);
         // No payload follows — cursor runs out.
         let bytes = w.into_bytes();

--- a/src/entity_geometry.rs
+++ b/src/entity_geometry.rs
@@ -1794,6 +1794,8 @@ mod tests {
             acis_empty: true,
             version: None,
             sat_blob: None,
+            in_data_store: false,
+            tail: None,
         };
         let m = three_d_solid_to_mesh(&s).unwrap();
         assert!(m.vertices.is_empty());
@@ -1804,8 +1806,10 @@ mod tests {
     fn three_d_solid_to_mesh_with_blob_returns_empty_mesh() {
         let s = crate::entities::three_d_solid::ThreeDSolid {
             acis_empty: false,
-            version: Some(70),
+            version: Some(1),
             sat_blob: Some(b"some opaque ACIS bytes".to_vec()),
+            in_data_store: false,
+            tail: None,
         };
         let m = three_d_solid_to_mesh(&s).unwrap();
         assert!(m.vertices.is_empty());

--- a/src/objects/acad_layout.rs
+++ b/src/objects/acad_layout.rs
@@ -20,6 +20,8 @@
 //! any real record. That list is withdrawn.
 //!
 //! ```text
+//! RC   ds_block[0]                   -- R2013+, only when the record's
+//! RC   ds_block[1]                      `has AcDs binary data` bit is set
 //! <plot-settings block — see acad_plot_settings>
 //! TV   layout_name            (1)
 //! BL   tab_order              (71)
@@ -42,6 +44,33 @@
 //! base and named UCS, and one per viewport — live in the object's
 //! handle stream, past the data-stream boundary this module checks, so
 //! they are not fields of this struct.
+//!
+//! # The R2013+ data-store block — measured
+//!
+//! Across `arc_2013.dwg`, `circle_2013.dwg`, `line_2013.dwg` and
+//! `sample_AC1032.dwg`, exactly four non-entity records set the
+//! R2013+ `has AcDs binary data` bit of the common object data, and
+//! all four are the LAYOUT records of `sample_AC1032.dwg` (handles
+//! 34, 89, 94, 602). The 327 other non-entity records of those files
+//! clear it. On all four, this field list closes on the string-stream
+//! start bit only when **16 further bits** are read before the
+//! plot-settings block: the first byte is `0x2C` on every one of them,
+//! the second `0x0B` on the `Model` record and `0x00` on the three
+//! paper layouts. 8 bits leaves every one of them 8 bits short and 0
+//! bits leaves them 16 short.
+//!
+//! Those 16 bits used to sit in `crate::objects::modern` as a
+//! payload of the flag itself. #61 moved them here: the three ACIS
+//! entity records of the same file also set the flag, and their
+//! §20.4.41 field list closes with **zero** bits after it
+//! ([`crate::entities::modeler`]). One flag cannot be followed by 0
+//! bits on an entity and 16 on an object, so the 16 belong to LAYOUT.
+//!
+//! What the corpus cannot say is whether the block is keyed on the
+//! flag or is an unconditional R2018 addition — no R2018 LAYOUT in the
+//! corpus clears the bit, and no R2004/R2010/R2013 LAYOUT sets it. It
+//! is read conditionally here because that is the reading in which
+//! every one of the 31 corpus records closes.
 //!
 //! # `viewport_count` is a `BL`, not the `RL` §20.4.84 prints
 //!
@@ -138,6 +167,11 @@ fn read_bd3(c: &mut BitCursor<'_>) -> Result<Point3D> {
 /// A decoded LAYOUT record.
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct AcadLayout {
+    /// R2013+ data-store block — the two bytes a LAYOUT writes ahead
+    /// of its plot-settings block when the record's `has AcDs binary
+    /// data` bit is set. `None` on every record that clears the bit.
+    /// See the module docs for the four records that measure it.
+    pub ds_block: Option<[u8; 2]>,
     /// The plot-settings block §20.4.84 opens with.
     pub plot_settings: AcadPlotSettings,
     /// Layout name (group 1), e.g. `Model`, `Layout1`.
@@ -227,6 +261,13 @@ pub fn decode_object(
 ) -> Result<AcadLayout> {
     acad_plot_settings::check_version(version, "LAYOUT")?;
     let mut split = modern::open(payload, body_start, inline_data_end, version)?;
+    // R2013+ data-store block — see the module docs for the four
+    // records that measure it.
+    let ds_block = if split.has_ds_binary_data {
+        Some([split.data.read_rc()?, split.data.read_rc()?])
+    } else {
+        None
+    };
     let plot_settings = acad_plot_settings::read_fields(&mut split, version)?;
     let layout_name = modern::read_tv(&mut split.data, &mut split.strings, version)?;
     let c = &mut split.data;
@@ -257,6 +298,7 @@ pub fn decode_object(
     }
 
     Ok(AcadLayout {
+        ds_block,
         plot_settings,
         layout_name,
         tab_order,

--- a/src/objects/modern.rs
+++ b/src/objects/modern.rs
@@ -53,7 +53,7 @@
 //! EED chain
 //! BL   num_reactors
 //! B    no_xdictionary_handle   -- R2004+
-//! B    has_ds_binary_data      -- R2013+ (16 further bits when set)
+//! B    has_ds_binary_data      -- R2013+ (no further bits; see below)
 //! ```
 //!
 //! Measured three independent ways on `sample_AC1032.dwg` (R2018),
@@ -80,34 +80,37 @@
 //! determinable from the 16 bits an APPID record spends there, so this
 //! module does not touch the table path.
 //!
-//! # The R2013+ AcDs binary-data flag carries 16 further bits
+//! # The R2013+ AcDs binary-data flag carries no further bits
 //!
 //! The spec's common-object-data table gives only the `B` — "indicates
 //! whether the object has associated binary data in the data store
 //! section" — and stops. It does not say what, if anything, follows
-//! when the bit is set, and no corpus record exercised it until LAYOUT
-//! was dispatched: across `arc_2013.dwg`, `circle_2013.dwg`,
-//! `line_2013.dwg` and `sample_AC1032.dwg`, exactly **four** non-entity
-//! records set the bit, and all four are the LAYOUT records of
-//! `sample_AC1032.dwg` (handles 34, 89, 94, 602). The 327 other
-//! non-entity records of those files clear it.
+//! when the bit is set, and until #61 no record whose field list this
+//! crate closes exercised it on the *entity* side, so the width could
+//! not be measured against a self-validating list. This module read 16
+//! bits there, `tables::modern` read 8 and `common_entity` read 0 —
+//! three readings of one field (#54).
 //!
-//! On all four, the §20.4.84 LAYOUT field list closes on the
-//! string-stream start bit only when **16** bits are consumed after the
-//! flag, and the first of those two bytes is `0x2C` on every one of
-//! them (the second is `0x0B` on the `Model` record and `0x00` on the
-//! three paper layouts). An earlier revision of this module consumed a
-//! single `RC` there — an unvalidated guess that no test or corpus
-//! record reached; 8 bits leaves every LAYOUT record 8 bits short of
-//! its boundary, and 0 bits leaves it 16 short.
+//! Issue #61 settled it. The three ACIS entity records of
+//! `sample_AC1032.dwg` — 3DSOLID `0xD65` / `0xD6A` and REGION `0xD69` —
+//! set the bit, and their §20.4.41 field list
+//! ([`crate::entities::modeler`]) closes on the data-stream boundary
+//! with **zero** bits consumed after the flag. The list is corroborated
+//! four independent ways (three real coordinate triples, `num isolines
+//! = 4` on every record, a valid RFC-4122 version-4 GUID, and the
+//! spec's own grammar for everything else), and it cannot close with a
+//! 16-bit marker: the record would then be 16 bits short and the
+//! wireframe point would decode to nonsense.
 //!
-//! Two readings fit the corpus: the marker is 16 bits wide, or it is
-//! absent and LAYOUT gained two leading bytes in R2018. The first is
-//! taken here because the extra bits appear exactly when the flag is
-//! set and the constant leading `0x2C` reads as data-store bookkeeping
-//! rather than page-setup state — and because the second would require
-//! §20.4.84 to be wrong at its very first field. Nothing in the corpus
-//! separates them outright; a non-LAYOUT record with the bit set would.
+//! So the flag is a flag. The 16 bits four LAYOUT records of the same
+//! file need are LAYOUT's own — a data-store block at the head of its
+//! §20.4.84 field list, moved to
+//! [`crate::objects::acad_layout`] where the evidence for it lives.
+//! (`tables::modern`'s 8-bit `RC` is DIMSTYLE's counterpart; that path
+//! also omits the `BL num_reactors` this one reads, so its bit
+//! accounting is a separate open question and is left alone here.)
+//! Three record types needing three different widths is itself the
+//! argument that the width belongs to the record, not to the flag.
 
 use crate::bitcursor::BitCursor;
 use crate::error::{Error, Result};
@@ -128,6 +131,11 @@ pub(crate) struct ObjectStream<'a> {
     data_end: Option<usize>,
     /// `BL num_reactors` from the common object data (§19.4.2).
     pub num_reactors: u32,
+    /// R2013+ `has AcDs binary data` bit from the common object data
+    /// (§20.4.2). The bit itself consumes no further bits — see the
+    /// module docs — but a record that sets it may carry a
+    /// data-store block of its own, as LAYOUT does.
+    pub has_ds_binary_data: bool,
 }
 
 /// Read a `TV` from whichever stream actually holds it.
@@ -217,18 +225,23 @@ pub(crate) fn open<'a>(
 
     let mut data = BitCursor::new(payload);
     string_stream::seek(&mut data, body_start)?;
-    let num_reactors = read_common_object_prefix(&mut data, version)?;
+    let (num_reactors, has_ds_binary_data) = read_common_object_prefix(&mut data, version)?;
 
     Ok(ObjectStream {
         data,
         strings,
         data_end,
         num_reactors,
+        has_ds_binary_data,
     })
 }
 
-/// Consume the common object data of §19.4.2 and return the reactor count.
-fn read_common_object_prefix(c: &mut BitCursor<'_>, version: Version) -> Result<u32> {
+/// Consume the common object data of §19.4.2 and return the reactor
+/// count together with the R2013+ `has AcDs binary data` bit.
+///
+/// The flag consumes **no further bits** — see the module docs for the
+/// three entity records that measure that.
+fn read_common_object_prefix(c: &mut BitCursor<'_>, version: Version) -> Result<(u32, bool)> {
     for _ in 0..MAX_EED_ITERATIONS {
         let size = c.read_bs_u()? as usize;
         if size == 0 {
@@ -236,15 +249,12 @@ fn read_common_object_prefix(c: &mut BitCursor<'_>, version: Version) -> Result<
             if version.is_r2004_plus() {
                 let _no_xdictionary = c.read_b()?;
             }
-            if matches!(version, Version::R2013 | Version::R2018) {
-                let has_binary_data = c.read_b()?;
-                if has_binary_data {
-                    // 16 bits, measured — see the module docs.
-                    let _ds_binary_marker = c.read_rc()?;
-                    let _ds_binary_id = c.read_rc()?;
-                }
-            }
-            return Ok(num_reactors);
+            let has_ds_binary_data = if matches!(version, Version::R2013 | Version::R2018) {
+                c.read_b()?
+            } else {
+                false
+            };
+            return Ok((num_reactors, has_ds_binary_data));
         }
         let _appid = c.read_handle()?;
         for _ in 0..size {

--- a/tests/r2013_entity_values.rs
+++ b/tests/r2013_entity_values.rs
@@ -616,3 +616,82 @@ fn sample_ac1032_recovers_modern_attribute_tags() {
             .collect::<Vec<_>>()
     );
 }
+
+/// The three §20.4.41 ACIS records of `sample_AC1032.dwg` — the only
+/// entity records in the corpus that set the R2013+ `has AcDs binary
+/// data` bit, and therefore the ones that arbitrate its width (#54).
+///
+/// Each must decode with:
+///
+/// - `in_data_store` set (the SAB stream is a data-storage record, §24);
+/// - a wireframe point that is real drawing geometry — the three solids
+///   sit in a row at `y ≈ -220`;
+/// - `num_isolines == 4`, AutoCAD's default `ISOLINES` value;
+/// - a 16-byte revision GUID that is a valid RFC-4122 version-4 UUID.
+///
+/// Reaching a `DecodedEntity` variant at all is itself the boundary
+/// assertion: the dispatcher runs these through `checked_inline`, which
+/// errors unless the field list ends exactly on the record's
+/// data-stream boundary. A 16-bit AcDs marker would leave every one of
+/// them 16 bits short.
+#[test]
+fn sample_ac1032_acis_records_close_on_their_boundary() {
+    let Some(file) = open_if_present("sample_AC1032.dwg") else {
+        return;
+    };
+    assert_eq!(file.version(), Version::R2018);
+
+    let (entities, _summary) = file.decoded_entities().unwrap().unwrap();
+    let mut seen = Vec::new();
+    for entity in &entities {
+        let (label, in_data_store, fields) = match entity {
+            DecodedEntity::ThreeDSolid(solid) => {
+                ("3DSOLID", solid.in_data_store, solid.tail.clone())
+            }
+            DecodedEntity::Region(region) => ("REGION", region.in_data_store, region.tail.clone()),
+            DecodedEntity::Body(body) => ("BODY", body.in_data_store, body.tail.clone()),
+            _ => continue,
+        };
+        let fields = fields.expect("a dispatched ACIS record carries its §20.4.41 fields");
+        assert!(
+            in_data_store,
+            "{label}: every ACIS record of this file sets the AcDs bit"
+        );
+        assert_eq!(
+            fields.num_isolines, 4,
+            "{label}: AutoCAD writes ISOLINES = 4 by default"
+        );
+        assert!(fields.wireframe_present, "{label}: wireframe block present");
+        assert!(fields.acis_empty_2, "{label}: second ACIS-empty bit is 1");
+        let point = fields.point.expect("{label}: point present bit is set");
+        assert!(
+            is_plausible_coord(point.x) && is_plausible_coord(point.y),
+            "{label}: wireframe point {point:?} is not plausible geometry"
+        );
+        assert!(
+            (point.y - -220.0).abs() < 1.0,
+            "{label}: the three ACIS bodies sit in a row at y ≈ -220; got {}",
+            point.y
+        );
+        let guid = fields
+            .revision_guid
+            .expect("{label}: data-store records carry a revision GUID");
+        assert_eq!(
+            guid[6] >> 4,
+            4,
+            "{label}: revision GUID {guid:02X?} is not RFC-4122 version 4"
+        );
+        assert_eq!(
+            guid[8] >> 6,
+            0b10,
+            "{label}: revision GUID {guid:02X?} has the wrong variant bits"
+        );
+        seen.push(label);
+    }
+    seen.sort_unstable();
+    assert_eq!(
+        seen,
+        ["3DSOLID", "3DSOLID", "REGION"],
+        "sample_AC1032.dwg holds exactly two 3DSOLIDs and one REGION"
+    );
+}


### PR DESCRIPTION
## Summary

Decodes the whole §20.4.41 ACIS record — `REGION` (37), `3DSOLID` (38), `BODY` (39) — and uses the three records that carry it to settle the width of the R2013+ `has AcDs binary data` marker (#54), which this crate had been reading three different ways.

## Spec reference

**§20.4.41 REGION (37) / 3DSOLID (38) / BODY (39)** prescribes one record shape for all three, and **§24.2.2.3** explains what R2013 changed: *"For each ACIS entity (REGION, 3DSOLID), a data record is created with the SAB stream of the object."* The geometry payload leaves the entity record and becomes a data record in `AcDb:AcDsPrototype_1b`, flagged by the record's `has AcDs binary data` bit.

### The field list

The corpus holds exactly **three** ACIS records, all in `sample_AC1032.dwg` (R2018), and all three set that bit. Measured from bit 82 — where the common entity preamble ends on all three — to each record's data-stream boundary:

```text
B     wireframe data present          1
B     point present                   1
3BD   point
BL    num isolines                    4
B     isolines present                1
BL    num wires                       0
BL    num silhouettes                 0
B     ACIS empty (2)                  1     -- §20.4.41 "Normally 1"
BL    unknown (R2007+)                0
--- R2013+ data-store block, measured ---
B     unknown_a                       1
BB    unknown_b                       0
BB    unknown_c
BB    unknown_d
RC×16 revision GUID
BL    unknown_e                       0
```

The inline ACIS envelope is **absent**: only two bits stand between the preamble and the point, and both are 1.

| record | data ends | point | isolines | revision GUID | delta |
|---|---|---|---|---|---|
| 3DSOLID `0xD65` | bit 437 | `(17.7767…, -220.8501…, 2.5)` | 4 | `833111a1-b7ac-4dd4-824d-78b33668f9e7` | **0** |
| REGION `0xD69` | bit 373 | `(24.9857…, -220.4000…, 0)` | 4 | `2b80e3b3-b594-475e-8593-6a36b15e7945` | **0** |
| 3DSOLID `0xD6A` | bit 437 | `(31.6857…, -220.1073…, 2.1902…)` | 4 | `f21ff2a0-ff9c-4ed1-9b2e-7a1e6518d595` | **0** |

Four corroborations independent of the arithmetic:

1. **The points are drawing geometry** — three bodies in a row at `y ≈ -220`, `x` stepping `17.8 → 25.0 → 31.7`. Every rejected candidate produced `1e+88`-scale doubles instead.
2. **`num isolines` is 4 on all three** — AutoCAD's default `ISOLINES` value.
3. **The 16 bytes are a valid RFC-4122 version-4 UUID on all three** (version nibble `4`, variant bits `10`). Scanning every 128-bit window of all three records, `data_end - 130` is the *only* alignment where all three satisfy both; three independent windows doing that by chance is 1 in 2^18.
4. **Everything else is the spec's own grammar**, decoding the values §20.4.41 says to expect.

Only the *width* of the seven bits before the GUID is measured. The three records agree on `1, 0` for the first two slots and differ after, so `B, BB, BB, BB` is a labelling, not a measurement, and the module says so. The per-wire and per-silhouette payloads are stepped exactly but not surfaced — no corpus record carries any, so structs for them would be API no byte has exercised.

## The #54 arbitration

#52 measured **16** bits after the flag on four LAYOUT records; `tables/modern.rs` measured an **`RC`** on DIMSTYLE; `common_entity.rs` read **0**, untested, because no entity record whose field list closed had ever set the bit. These three ACIS records are that missing case.

`examples/probe_acis_records.rs` re-reads the preamble at each candidate width and runs §20.4.41 from wherever it lands:

| marker width | preamble ends | preamble values | §20.4.41 list |
|---|---|---|---|
| **0 bits** | bit 82 | `colour 0x0100, lts 1.0, invis 0, lw 0x1D` | **delta 0** |
| 8 bits | — | does not read (reserved `BD` pattern `11`) | — |
| 16 bits | bit 148–212 | `colour 0xEE10, lts 0` (or `1.5e119`), `lw 0x10 / 0x12 / 0xBC` | does not close |

Both halves fail together at every non-zero width. At 0 bits the preamble decodes exactly the values every other entity in the file carries — BYLAYER colour `0x0100`, linetype scale `1.0`, invisibility `0`, lineweight `0x1D`; at 16 bits it decodes none of them, and the field list is then short of its boundary.

**Verdict: the flag is a flag — nothing follows it.** `common_entity.rs` and `objects/modern.rs` now agree on 0 bits. The 16 bits four R2018 LAYOUT records need moved into `src/objects/acad_layout.rs` as LAYOUT's own two-byte data-store block at the head of its §20.4.84 list, still conditional on the flag and still closing all 31 corpus LAYOUT records. `tables/modern.rs` keeps its `RC`: that path also omits the `BL num_reactors` the object path reads, so its bit accounting has a second unresolved variable and is out of scope here. Three record types needing three different widths is itself the argument that the width belongs to the record, not to the flag.

## Two spec-conformance fixes that fell out

The envelope reader carried two departures from §20.4.41 that no corpus record had ever reached:

- the `B unknown` bit between `ACIS empty` and `BS version` was not read at all;
- the block loop read a `B has_more_blocks` flag before each `BL block size`, where the spec terminates the loop on a block size of `0` and has no such flag.

Both are corrected, and version 2 — *"immediately following will be an acis file … no length is given"* — is now refused rather than mis-stepped. Four surface tests that had written the old shape are updated.

## Measured coverage

`cargo run --release --example coverage_report -- ../../samples`, 19-file corpus, re-measured on the merged tree (`origin/main` = `7418d25`, merge is a no-op — already up to date):

| Corpus slice | Before (`7418d25`) | After |
|---|---|---|
| R2004 (AC1018) × 3 | 510 / 87 / 0 / 85.4 % | 510 / 87 / 0 / 85.4 % |
| R2010 (AC1024) × 3 | 531 / 12 / 0 / 97.8 % | 531 / 12 / 0 / 97.8 % |
| R2013 (AC1027) × 3 | 384 / 12 / 0 / 97.0 % | 384 / 12 / 0 / 97.0 % |
| R2018 (AC1032) × 1 | 762 / 80 / 0 / 90.5 % | **765 / 77 / 0 / 90.9 %** |
| **Aggregate** | **2187 / 191 / 0 / 92.0 %** | **2190 / 188 / 0 / 92.1 %** |

Zero errored records, before and after. Every previously-closed decoder still closes, including all 31 LAYOUT records after their 16 bits were relocated.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --release` passes — 741 lib tests (+7), all integration suites green
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` passes
- [x] `cargo deny check all` passes
- [x] `cargo +1.85.0 test --no-run` passes (MSRV)
- [x] New `BitWriter` round-trip tests for the data-store record, the inline-envelope record, exact wire/silhouette stepping, and the absurd-count rejection
- [x] New real-DWG regression test `sample_ac1032_acis_records_close_on_their_boundary` pins `in_data_store`, `num_isolines == 4`, `y ≈ -220`, and the RFC-4122 version/variant nibbles of each GUID
- [x] Coverage-report numbers attached above

## Source-provenance declaration

**Clean-room declaration.** I certify that:

1. All code and tests in this PR were written from scratch by me.
2. I consulted only sources listed as allowed in `CLEANROOM.md` — the ODA's freely-redistributable *Open Design Specification for .dwg files* v5.4.1 (§20.4.41 for the record shape, §24.2.2.3 for the data-storage semantics, §20.4.1 for the common entity data) and the bytes of publicly-available DWG files. In particular I did **not** consult Autodesk SDK source, ODA SDK (Drawings SDK / Teigha) source, LibreDWG source, decompilations of Autodesk or ODA binaries, or any copyleft-licensed DWG implementation code.
3. Every field name and type in the new field list comes from the §20.4.41 table itself, including the spec's own gloss "Normally 1" on the second ACIS-empty bit. The R2013+ data-store block is **measured** — the residue between the end of that grammar and each record's data-stream boundary — and the only word not taken from the spec is "revision GUID", which the RFC-4122 version-4 structure earns. The seven bits before it are labelled `unknown_*`; only their width is claimed. `CLEANROOM.md` records this.
4. I have never had access to any forbidden source in a commercial or NDA'd context.

By submitting this PR I also certify compliance with the [Developer Certificate of Origin 1.1](https://developercertificate.org/).

Closes #61
Closes #54

https://claude.ai/code/session_01BaHKf1Rw5aJBGK5y3xmx7C

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bit accounting on common entity/object prefixes and adds substantial ACIS field parsing; misalignment would corrupt geometry, but decoders self-check against data-stream boundaries and corpus tests pin the three R2018 ACIS records and LAYOUT closure.
> 
> **Overview**
> Implements the full **§20.4.41** record for **REGION**, **3DSOLID**, and **BODY** (shared `modeler` path): wireframe/isoline tail, optional inline SAT envelope, and the measured R2013+ data-store block (revision GUID) when `has AcDs binary data` is set. **3DSOLID**, **REGION**, and **BODY** are now first-class `DecodedEntity` variants with boundary-checked `decode_record` on R2010+.
> 
> **#54:** The R2013+ `has AcDs binary data` bit is treated as a **flag with no following bits** on the entity path (`common_entity`). The **16 bits** previously consumed in `objects/modern` for LAYOUT move into **`acad_layout`** as a conditional two-byte `ds_block` at the start of §20.4.84; object prefix only records the flag via `has_ds_binary_data`.
> 
> **ACIS envelope** reading is aligned with the spec: read the unknown `B`, terminate the version-1 block loop on `BL == 0` (no `has_more_blocks`), and **reject version 2** instead of guessing length.
> 
> Adds **`probe_acis_records`**, real-DWG regression on `sample_AC1032.dwg`, and updates coverage docs (**2190 decoded / 188 skipped / 92.1%** aggregate; R2018 **765 / 77 / 90.9%**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b28f62d446c51c31f5dcbe99290bac753223ceaa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->