### PR TITLE
fix(entities): hold every entity type to its exact data-stream boundary (2262/116/0 → 2273/96/9)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1076,6 +1076,129 @@ mis-stepped.
 `examples/probe_acis_records.rs` reproduces the census, the field list
 and the arbitration table from the bytes.
 
+## 7i. The exact boundary, everywhere (2026-08-30, #63)
+
+§7a introduced the self-validating decode for the records that had to
+have it — the ones whose `TV` fields moved into the string stream. §7g
+tightened those from `<=` to `==`. Everything else still decoded with
+**no boundary check at all**: the POLYLINE family, MESH, IMAGE,
+WIPEOUT, VIEWPORT, LEADER, MLINE, the swept / lofted / extruded /
+revolved surfaces, RAY, XLINE, POINT, CIRCLE, ARC, LINE, ELLIPSE,
+SOLID, TRACE, ENDBLK, BLOCK — and, on the R2000/R2004 band, *every*
+entity type. Their zero error count was therefore a property of the
+dispatcher, not of the bytes.
+
+### One check, three boundary sources
+
+`entities::dispatch::checked_inline` is now the single path every
+fixed-code and custom-class entity decoder runs through. It asks
+`entity_data_end` where the record says its data fields stop:
+
+| Band | Boundary | Source |
+|---|---|---|
+| R2010 / R2013 / R2018 | string-stream start bit, or handle-stream start − 1 when the record carries no strings | `string_stream::data_field_end` (§7a) |
+| R2000 / R2004 | `RL` object-data-size-in-bits from the object prologue | `RawObject::obj_size_bits` (§7b) |
+| R2007 | none | the `RL` spans data **and** strings, and this crate cannot locate an AC1021 string stream yet (#110) |
+| R13 / R14 | none | the prologue has no size field |
+
+The same call also hands the decoder the record's string reader, which
+is what let BLOCK stop reading its name inline. Nothing about the check
+is version-specific beyond that table: a decoder writes one field list
+and is held to whichever boundary its release states.
+
+### What the check found
+
+Turning it on produced 55 errors across the corpus in five types, and
+a sixth — MLINE — surfaced at the same time because #63 also wired it
+into the dispatcher for the first time. Three of the six were cheap and
+are fixed; three are not and are reported.
+
+| Type | Records | Delta before | Cause | Outcome |
+|---|---|---|---|---|
+| BLOCK | 45 (R2010/R2013/R2018) | +58 … +266 | the one `TV` was read inline; on R2010+ it lives in the string stream and the record's field budget is **0 bits** on all 33 R2010+ records measured | fixed — names now decode as `*Model_Space`, `_ArchTick`, `MyBlock`, matching the BLOCK_RECORD entries they pair with |
+| POLYLINE_PFACE | 1 (R2018) | +52 | five `BS` counts and two inline `H` handles, where the record holds `BS`, `BS`, `BL` in 30 bits | fixed — reads 5 vertices, 2 faces, 7 owned objects |
+| MLINE | 3 (R2018) | n/a (counts decoded as `521` / `-11716`) | `num_lines` read as `BS` where the record writes one `RC` | fixed — 2 lines on all three, `delta 0` |
+| VIEWPORT | 6 (R2018) | −819 | the decoder reads 266 of 1125 bits by design | reported |
+| MESH | 2 (R2018) | −2 | two trailing bits, `10` on both records | reported |
+| LEADER | 1 (R2018) | −12 | field list stops before the text-box block | reported |
+
+The three fixes each meet the same bar as #58: `delta 0` **plus** a
+value that corroborates it independently of the bit count. BLOCK's
+names match the symbol table; POLYLINE_PFACE's counts match the object
+stream (below); MLINE's `num_lines = 2` on every record is what a
+two-element multiline style produces, where the `BS` reading produced a
+negative vertex count.
+
+The three reports each meet the other bar: documented offsets, and
+stop. VIEWPORT's six records are six copies of one shape, so there is
+no variation to separate candidate token sequences with. MESH's two
+bits are `10`, which is the zero/default code of `BS`, `BL` and `BD`
+alike — a zero corroborates nothing. LEADER's twelve bits admit several
+continuations of §19.4.19's list and there is one record.
+
+### The POLYLINE family reads itself back
+
+The check made five previously-`Unhandled` types decodable, and the
+object stream cross-checks them without reference to any bit count.
+Handles `0x422`..`0x431` of `sample_AC1032.dwg` are contiguous:
+
+```text
+0x422  POLYLINE_PFACE   BS 5, BS 2, BL 7          (30 bits, delta 0)
+0x423  VERTEX_PFACE     RC 0xC0, 3BD              (142 bits)   ┐
+ ...                                                            │ 5 vertices
+0x427  VERTEX_PFACE                                            ┘
+0x428  VERTEX_PFACE_FACE  BS [ 1, 2, 3, -4]       (48 bits)    ┐ 2 faces
+0x429  VERTEX_PFACE_FACE  BS [-1, 4, 5,  0]       (40 bits)    ┘
+0x42A  SEQEND           (no fields at all — 0 bits)
+0x42B  POLYLINE_3D      RC 0, RC 0, BL 5          (26 bits, delta 0)
+0x42C  VERTEX_3D        RC 0x20, 3BD              (142/206 bits) ┐
+ ...                                                             │ 5 vertices
+0x430  VERTEX_3D                                                ┘
+0x431  SEQEND           (0 bits)
+```
+
+Every declared count matches the records that follow it: 5 + 2 = the
+`BL 7` owned-object count, and 5 = POLYLINE_3D's. The face indices are
+all inside the 1..=5 range the mesh declares, with the negative-index
+invisible-edge convention and a `0` terminating the three-corner face.
+The flag bytes name themselves — `0x20` is the flag table's "3D
+polyline vertex" bit, `0xC0` its "polyface mesh vertex" and "3D polygon
+mesh vertex" bits together. None of that comes from the bit budget.
+
+`BS` and `BL` are indistinguishable for a value below 256 (both spend
+`01` plus one byte), so the owned-object counts are read as the `BL`
+`tables::block_record` already uses for the same purpose; only the
+width and the value are claimed.
+
+### Three readings that stay undetermined
+
+Gathered here because they are the crate's whole set of "the boundary
+closes, but the bits admit more than one grammar" cases. None is
+changed by this work; each waits on a second file.
+
+| Reading | Where | What is undetermined | What would settle it |
+|---|---|---|---|
+| MULTILEADER's 17 bits | §7g above, `entities/mleader.rs` | 17 bits between `B 293 is annotative` and the R2010+ `BS 271` that §20.4.48 does not list. Read as `MC` + `B`; `B` + `RS` and `B` + two `RC`s consume the same bits. The `MC` holds only `274`, `530`, `786` across 15 records and the `B` is `true` on all of them | one record whose value exceeds `RS` range, or whose `B` is false |
+| UNDERLAY clip-vertex encoding | `entities/underlay.rs` | whether a clip vertex is `2BD` or `2RD`. The single corpus record has a zero clip-vertex count, so no vertex is ever read | any UNDERLAY with a clip boundary |
+| LWPOLYLINE `0x200` | §7g table, `entities/lwpolyline.rs` | `0x200` is not one of §20.4.85's presence bits, and every record carrying it also carries no optional field, so it survives either reading. Treated as "closed" | a record with `0x200` set *and* an optional field present |
+| MESH's trailing `10` | `entities/mesh.rs` | `BS` 0, `BL` 0, `BD` 0.0 and "two spare bits" all encode identically | a MESH whose trailing value is non-zero |
+
+### Measured effect
+
+| Corpus slice | Before (`7b2afe2`) | After |
+|---|---|---|
+| R2004 (AC1018) × 3 | 582 / 15 / 0 / 97.5 % | 582 / 15 / 0 / 97.5 % |
+| R2010 (AC1024) × 3 | 531 / 12 / 0 / 97.8 % | 531 / 12 / 0 / 97.8 % |
+| R2013 (AC1027) × 3 | 384 / 12 / 0 / 97.0 % | 384 / 12 / 0 / 97.0 % |
+| R2018 (AC1032) × 1 | 765 / 77 / 0 / 90.9 % | **776 / 57 / 9 / 92.2 %** |
+| **Aggregate** | **2262 / 116 / 0 / 95.1 %** | **2273 / 96 / 9 / 95.6 %** |
+
+The R2004, R2010 and R2013 slices are unchanged in count — but every
+one of their entity records is now checked where none was before, and
+all of them pass. `examples/probe_entity_budgets.rs` prints the budget
+each record's field list has to fill; `examples/probe_decode_errors.rs`
+prints the nine that do not fill it.
+
 ## 8. Write pipeline (current scope)
 
 The inverse pipeline is partially shipped. Stage-1 (per-section

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,86 @@ once the public API stabilizes at 0.1.0.
 
 ## [Unreleased]
 
+### Changed — the exact-boundary check now covers every entity type (2026-08-30, closes #63)
+
+Until now only the entity types that *had* to know about the R2007+
+split streams asserted anything about where their fields end. The
+POLYLINE family, MESH, IMAGE, WIPEOUT, VIEWPORT, LEADER, MLINE, the
+four SURFACE variants, RAY, XLINE, POINT, CIRCLE, ARC, LINE, ELLIPSE,
+SOLID, TRACE, ENDBLK and BLOCK decoded with **no boundary check at
+all** — and on the R2000/R2004 band, so did every entity type. Their
+zero error count was a property of the dispatcher, not of the bytes.
+
+Every fixed-code and custom-class entity decoder now runs through
+`entities::dispatch::checked_inline`, which requires the field list to
+end exactly on the record's own data-stream boundary: the string-stream
+start bit (or the handle-stream start minus the one `strings present`
+trailer bit) on R2010+, and the `RL` object-data-size-in-bits on
+R2000 / R2004. **On R2010+ the number of entity types that decode
+unchecked is now zero.** R2007 and R13/R14 state no boundary this crate
+can read, and no record of those releases reaches a decoder.
+
+Three field lists the check caught, each fixed to `delta 0` with an
+independent value corroborating it:
+
+- **BLOCK** (45 records, R2010/R2013/R2018) read its one `TV` inline.
+  On R2010+ the name lives in the string stream and the record's data
+  fields have a budget of **zero bits** — 27/27 on `sample_AC1032.dwg`
+  and 3/3 on each of `arc_2010.dwg` / `arc_2013.dwg`. Names now decode
+  as `*Model_Space`, `_ArchTick`, `MyBlock`, matching the BLOCK_RECORD
+  entries they pair with. The R2004 records were already correct and
+  now close on their `RL`.
+- **POLYLINE_PFACE** (1 record) claimed five `BS` counts and two inline
+  `H` handles, overrunning by 52 bits. The record holds `BS 5`, `BS 2`,
+  `BL 7` in 30 bits — and the file carries exactly 5 VERTEX_PFACE and 2
+  VERTEX_PFACE_FACE records, summing to 7.
+- **MLINE** (3 records) read `num_lines` as a `BS` where the record
+  writes one `RC`, decoding `lines = 521` and `verts = -11716`. One
+  token changed; all three now close at `delta 0` with `num_lines = 2`.
+
+Five types that previously came back `Unhandled` are now decoded,
+because the check can prove their field lists right rather than assume
+them — handles `0x422`..`0x431` of `sample_AC1032.dwg` read back as a
+self-consistent chain:
+
+- **SEQEND** — no fields at all; budget 0 on all four records.
+- **POLYLINE_3D** — `RC`, `RC`, `BL 5`; followed by exactly 5 VERTEX_3D.
+- **VERTEX_3D / VERTEX_MESH / VERTEX_PFACE** — `RC flag`, `3BD`; the
+  flags read `0x20` ("3D polyline vertex") and `0xC0` ("polyface mesh
+  vertex" + "3D polygon mesh vertex"), the crate's own flag table.
+- **VERTEX_PFACE_FACE** — four `BS` indices, `[1, 2, 3, -4]` and
+  `[-1, 4, 5, 0]`: all inside the mesh's declared 5-vertex range, with
+  the negative-index invisible-edge convention and the `0` terminator
+  of a three-corner face.
+
+Three decoders fail the check and are reported rather than patched —
+documented offsets, and stop:
+
+| Type | Records | Delta | Why it is not fixed |
+|---|---|---|---|
+| VIEWPORT | 6 | −819 | the decoder reads 266 of 1125 bits by design; six records of one identical shape give no variation to derive the rest from |
+| MESH | 2 | −2 | the two trailing bits read `10` on both records — the zero/default code of `BS`, `BL` and `BD` alike |
+| LEADER | 1 | −12 | twelve bits several continuations of §19.4.19 would fit, on one record |
+
+Also in this change: `POLYGON_MESH` stops reading two `H` handles from
+the data stream (an object reference has never occupied data-stream
+bits from R2000 on), and `examples/probe_entity_budgets.rs` prints the
+bit budget every entity record's field list has to fill.
+
+Measured coverage on the local 19-file corpus, before → after:
+
+| Version | Decoded | Skipped | Errored | Ratio |
+|---|---|---|---|---|
+| R2004 (AC1018) | 582 → 582 | 15 → 15 | 0 → 0 | 97.5 % → **97.5 %** |
+| R2010 (AC1024) | 531 → 531 | 12 → 12 | 0 → 0 | 97.8 % → **97.8 %** |
+| R2013 (AC1027) | 384 → 384 | 12 → 12 | 0 → 0 | 97.0 % → **97.0 %** |
+| R2018 (AC1032) | 765 → 776 | 77 → 57 | 0 → 9 | 90.9 % → **92.2 %** |
+| **Aggregate** | **2262 → 2273** | **116 → 96** | **0 → 9** | 95.1 % → **95.6 %** |
+
+The three unchanged slices are the point: their counts did not move,
+but every entity record in them is now checked where none was before,
+and every one passes.
+
 ### Added — VISUALSTYLE on R2004: the flag-less generation (2026-08-30, refs #48)
 
 `VISUALSTYLE` now dispatches on R2004 as well as R2010+, taking all 72

--- a/README.md
+++ b/README.md
@@ -27,21 +27,29 @@ local `samples/` set:
 | R2004 (AC1018)      | 3 | 582 | 15 | 0 | **97.5 %** |
 | R2010 (AC1024)      | 3 | 531 | 12 | 0 | **97.8 %** |
 | R2013 (AC1027)      | 3 | 384 | 12 | 0 | **97.0 %** |
-| R2018 (AC1032)      | 1 | 765 | 77 | 0 | **90.9 %** |
-| **Aggregate** | **19** | **2262** | **116** | **0** | **95.1 %** |
+| R2018 (AC1032)      | 1 | 776 | 57 | 9 | **92.2 %** |
+| **Aggregate** | **19** | **2273** | **96** | **9** | **95.6 %** |
 
-**Every record of every file in the corpus that reaches a decoder now
-decodes, and none errors.** What is left is the *skipped* column — 119
-records of types this crate has no decoder for at all (MATERIAL,
-TABLESTYLE) — not records it reads wrongly.
+**Every entity record in the corpus is now checked against its own
+data-stream boundary, and nine of them fail it.** That is an
+improvement, not a regression: until #63 the POLYLINE family, MESH,
+IMAGE, VIEWPORT, LEADER, MLINE, the surfaces, RAY / XLINE / POINT /
+CIRCLE / ARC / LINE / ELLIPSE / SOLID / TRACE / BLOCK / ENDBLK and the
+whole R2000-R2004 band decoded with **no boundary check at all**, so
+their zero error count was a property of the code rather than of the
+bytes. Nine errors that each name a specific unfinished field list are
+worth more than a zero that means nothing — see
+[`STATUS.md`](./STATUS.md) for which types they are.
 
-That matters more than the ratio, because every R2007+ decoder in this
-crate is *self-validating*: its data fields must end exactly on the first
-bit of the record's string stream, or — for a record that carries no
-strings — on the bit before the `strings present` trailer flag. A field
-list that is wrong anywhere lands somewhere else and reports an error
-rather than returning plausible-looking geometry. Zero errors therefore
-means zero known mis-reads, not zero unchecked reads.
+Every decoder in this crate is *self-validating*: its data fields must
+end exactly on the first bit of the record's string stream, on the bit
+before the `strings present` trailer flag when it carries no strings
+(R2010+), or on the `RL` object-data-size from the object prologue
+(R2000 / R2004). A field list that is wrong anywhere lands somewhere
+else and reports an error rather than returning plausible-looking
+geometry. On R2010+ there is no longer any entity type that decodes
+unchecked; R13 / R14 / R2007 records state no boundary this crate can
+read yet, and no record of those releases reaches a decoder at all.
 
 **Translation:** R2007+ objects store every `TV` field in a separate string
 stream and every `H` object reference in a separate handle stream (ODA
@@ -51,14 +59,20 @@ consuming no data-stream bits, and then asserts it landed exactly on the
 boundary. LAYER, LTYPE, STYLE, UCS, VIEW, VPORT, APPID, DIMSTYLE,
 BLOCK_HEADER, TEXT, ATTRIB, ATTDEF, MTEXT, TOLERANCE, HATCH, MULTILEADER,
 the DIMENSION family, INSERT, SPLINE, LWPOLYLINE, 3DFACE and the UNDERLAY
-family all go through it. The R2004 (AC1018) object prologue is read
-correctly too — an `RL` object data size in bits sits between the object
-type and the object handle on the whole R2000..R2007 band, and skipping it
-put every AC1018 record 32 bits out of phase.
+family all go through it, and since #63 so does **every other entity
+type** — via the same check, on the R2000/R2004 band as well as R2010+.
+The R2004 (AC1018) object prologue is read correctly too — an `RL` object
+data size in bits sits between the object type and the object handle on
+the whole R2000..R2007 band, and skipping it put every AC1018 record 32
+bits out of phase; that `RL` is now also the boundary AC1018 entities are
+held to.
 
-The remaining gap is the *unhandled* list, not the errored one: MATERIAL
-and TABLESTYLE have no field list matched against real bytes yet. Closing
-those is the 0.2.0 milestone.
+Two gaps remain. The *unhandled* list is the larger one: MATERIAL and
+TABLESTYLE have no field list matched against real bytes yet. The
+*errored* list is the new one, and it is short and named — VIEWPORT
+(6 records, a decoder that reads 266 of 1125 bits), MESH (2 records, two
+unidentified trailing bits) and LEADER (1 record, twelve bits short).
+Closing both is the 0.2.0 milestone.
 
 ## Capability matrix at a glance
 
@@ -76,7 +90,7 @@ those is the 0.2.0 milestone.
 | HandleMap + ClassMap parsing | ✓ shipped | — |
 | Header variables | ✓ shipped | Strict + lossy variants |
 | Object-stream walker (R2004+) | ✓ shipped | R14 / R2000 / R2007 pending (#104) |
-| Per-entity field decoders | ⚠ alpha | Broad synthetic coverage; real-file aggregate currently 95.1 %, zero errors (#103) |
+| Per-entity field decoders | ⚠ alpha | Broad synthetic coverage; real-file aggregate currently 95.6 %, every entity boundary-checked, 9 named errors (#63, #103) |
 | Entity graph (owner / reactors / blocks / layers) | ⚠ partial | Resolver APIs exist; trailing-handle/block traversal gaps remain |
 | Symbol tables (LAYER / LTYPE / STYLE / DIMSTYLE / …) | ⚠ partial | R2007+ BLOCK_HEADER and simple LTYPE names decode; broader content fields pending |
 | SVG / PDF export | ⚠ alpha | SVG writer + paged-SVG PDF path; output quality depends on decoded geometry |

--- a/STATUS.md
+++ b/STATUS.md
@@ -6,19 +6,21 @@ scrolling the changelog.
 
 ## Summary
 
-- **Lib tests:** 741 passing in default/debug and release-all-features
+- **Lib tests:** 751 passing in default/debug and release-all-features
   profiles, clippy + fmt clean.
 - **WASM tests:** 40 passing in `wasm/` sub-crate.
 - **Integration tests:** DXF round-trip (7), glTF smoke (3), SVG
   goldens (3), fuzz-corpus regression (6), write-path (5),
   entity-regression (18), real-DWG value regression (8).
-- **Current real-file decode coverage:** 2,262 decoded / 116 skipped /
-  **0 errored** / 95.0% on the local 19-file `samples/` corpus. The
-  R2018 `sample_AC1032.dwg` sample is 762 / 80 / 0 / 90.5%. **No file
-  in the corpus has a single errored record.** Per version:
-  R2004 97.5%, R2010 97.8%, R2013 97.0%, R2018 90.9%. What remains is
-  the *skipped* column — types with no decoder at all — not records
-  that decode wrongly.
+- **Current real-file decode coverage:** 2,273 decoded / 96 skipped /
+  **9 errored** / 95.6% on the local 19-file `samples/` corpus. The
+  R2018 `sample_AC1032.dwg` sample is 776 / 57 / 9 / 92.2%. Per
+  version: R2004 97.5%, R2010 97.8%, R2013 97.0%, R2018 92.2%.
+- **Every entity record is boundary-checked** (#63). The nine errors
+  are the honest residue of turning that check on for the types that
+  previously had none — see the honesty note below. They are not a
+  regression from the 2,262 / 116 / **0** of #67: the same nine records
+  "decoded" then, without anything checking that they had.
 - **Handle-map completeness:** every one of the 842 `AcDb:Handles`
   entries on `sample_AC1032.dwg` resolves to a record whose own handle
   field matches the map, and the walked records cover 1,191,935 of the
@@ -52,13 +54,13 @@ scrolling the changelog.
 - R2013/R2018 common-entity/body boundary pinned for LINE/CIRCLE/ARC
   with active real-DWG regression tests.
 
-### Entity decoders (Phase 4, 27 modules)
+### Entity decoders (Phase 4, 59 modules under `src/entities/`)
 - LINE, CIRCLE, ARC, ELLIPSE, POINT, LWPOLYLINE, POLYLINE 2D/3D.
 - TEXT, MTEXT, INSERT, ATTRIB/ATTDEF, BLOCK/ENDBLK.
 - SPLINE, HATCH, MLEADER, LEADER, TOLERANCE.
 - DIMENSION base + linear / aligned / radial / diameter /
   angular 2-line / angular 3-point / ordinate subclass decoders.
-- MESH (subdivision) / POLYFACE MESH / POLYGON MESH.
+- MESH (subdivision) / POLYLINE_PFACE / POLYGON MESH.
 - 3DFACE, and the three §20.4.41 ACIS entities — 3DSOLID, REGION,
   BODY — with the full record (ACIS envelope, wireframe/isoline block,
   the R2007+ trailing `BL` and the R2013+ data-store revision GUID),
@@ -69,6 +71,14 @@ scrolling the changelog.
 - OLE2FRAME, WIPEOUT, MLINE.
 - PROXY entity / PROXY object (opaque pass-through).
 - RAY, XLINE, VIEWPORT, TRACE, SOLID-2D.
+- SEQEND, POLYLINE_3D, VERTEX_3D / VERTEX_MESH / VERTEX_PFACE,
+  VERTEX_PFACE_FACE — wired in #63, each field list pinned to `delta 0`
+  on every corpus record of its type and cross-checked against the
+  object stream: the POLYLINE_PFACE at handle `0x422` of
+  `sample_AC1032.dwg` declares 5 vertices, 2 faces and 7 owned objects
+  and is followed by exactly 5 VERTEX_PFACE, 2 VERTEX_PFACE_FACE and a
+  SEQEND; the POLYLINE_3D at `0x42B` declares 5 owned objects and is
+  followed by exactly 5 VERTEX_3D and a SEQEND.
 - `LINE` end coordinates use DD fields with each start coordinate as
   the default; `line_2013.dwg` now asserts the authored
   `(50, 50, 0) -> (100, 100, 0)` geometry.
@@ -215,10 +225,42 @@ scrolling the changelog.
 These have genuine open scope requiring focused work, not stubs.
 
 - **Current real-file decode baseline:** the 2026-08-30
-  `examples/coverage_report.rs ../../samples` run reports 2262 decoded,
-  116 skipped, 0 errored, 95.1% aggregate coverage. This is the
+  `examples/coverage_report.rs ../../samples` run reports 2273 decoded,
+  96 skipped, 9 errored, 95.6% aggregate coverage. This is the
   practical product-readiness blocker even though synthetic decoder
   tests are broad.
+
+- **#63 which entity types are exact-checked — the honesty note.**
+  Every entity type this crate decodes is now routed through
+  `entities::dispatch::checked_inline`, so its field list must end on
+  the record's own data-stream boundary — the string-stream start bit
+  (or the bit before the `strings present` trailer flag) on R2010+, and
+  the `RL` object-data-size on R2000 / R2004. **On R2010+ the number of
+  entity types that decode unchecked is zero.** Two bands are still
+  unchecked, and neither has a record that reaches a decoder:
+
+  | Band | Boundary | Checked |
+  |---|---|---|
+  | R2010 / R2013 / R2018 | string-stream start, or handle-stream start − 1 | **all types** |
+  | R2000 / R2004 | `RL` object-data-size-in-bits | **all types** |
+  | R2007 | `RL` covers data *and* strings; the split point is not locatable yet (#110) | none — no AC1021 record reaches a decoder |
+  | R13 / R14 | record states no size | none — no record reaches a decoder (#104) |
+
+  Nine corpus records now fail the check. All nine are decoders whose
+  field list is genuinely unfinished, and each is documented at the
+  module that owns it:
+
+  | Type | Records | Delta | Why |
+  |---|---|---|---|
+  | VIEWPORT | 6 (R2018) | −819 | the decoder reads 266 of the record's 1125 bits by design (`entities/viewport.rs`); six records of one identical shape give no variation to derive the rest from |
+  | MESH | 2 (R2018) | −2 | two trailing bits reading `10` — the zero/default code of `BS`, `BL` and `BD` alike, so one file cannot say which (`entities/mesh.rs`) |
+  | LEADER | 1 (R2018) | −12 | twelve bits several continuations of the field list would fit; one record cannot choose (`entities/leader.rs`) |
+
+  Types whose check is wired but which no corpus record exercises:
+  POLYLINE_2D, POLYLINE_MESH, VERTEX_2D, VERTEX_MESH, TRACE, OLE2FRAME,
+  CAMERA, SUN, LIGHT, GEODATA, BODY, WIPEOUT, HELIX and the four
+  SURFACE variants. Their field lists are unverified; the check is what
+  will arbitrate them when a record appears.
 
 - **#33 remaining non-entity objects.** DICTIONARY, DICTIONARYVAR,
   XRECORD, ACDB_PLACEHOLDER, the ten `*_CONTROL` owners, ACAD_GROUP and
@@ -259,16 +301,17 @@ These have genuine open scope requiring focused work, not stubs.
   from the 16 bits an APPID record spends there; the names are
   unaffected because they come from the string stream either way.
 
-- **#103 remaining real-file decoder alignment** (P0, error side
-  closed). Every record of every corpus file that reaches a decoder
-  now decodes, and none errors: the R2007+ symbol table, TEXT /
-  ATTRIB / ATTDEF / MTEXT / TOLERANCE / HATCH / MULTILEADER / the
-  DIMENSION family / INSERT / SPLINE / LWPOLYLINE / 3DFACE / the
-  UNDERLAY family all read their `TV`s from the string stream, treat
-  an `H` slot as consuming no data bits, and assert the data fields
-  end exactly on the record's data-stream boundary. What is left under
-  this issue is *coverage*, not alignment: the 234 skipped records
-  belong to types with no field list matched against real bytes yet.
+- **#103 remaining real-file decoder alignment** (P0). The R2007+
+  symbol table, TEXT / ATTRIB / ATTDEF / MTEXT / TOLERANCE / HATCH /
+  MULTILEADER / the DIMENSION family / INSERT / SPLINE / LWPOLYLINE /
+  3DFACE / the UNDERLAY family read their `TV`s from the string
+  stream, treat an `H` slot as consuming no data bits, and assert the
+  data fields end exactly on the record's data-stream boundary — and
+  since #63 so does every other entity type, on the R2000/R2004 band
+  as well. What is left under this issue is mostly *coverage*: the 96
+  skipped records belong to types with no field list matched against
+  real bytes yet. The alignment residue is the nine errored records
+  tabulated in the #63 note above.
 - **#104 R14 / R2000 / R2007 handle-map walker.** Container layer
   ships for these versions, but the object-stream walker is
   R2004+ only. Unlocks `decoded_entities()` for those release

--- a/examples/dump_decoded_entities.rs
+++ b/examples/dump_decoded_entities.rs
@@ -572,6 +572,40 @@ fn print_entity(i: usize, e: &DecodedEntity) {
         DecodedEntity::Viewport(_) => {
             println!("[{i}] VIEWPORT (stub)");
         }
+        DecodedEntity::SeqEnd(_) => {
+            println!("[{i}] SEQEND");
+        }
+        DecodedEntity::VertexPoint(v) => {
+            println!(
+                "[{i}] VERTEX  flag=0x{:02X} location=({:.6}, {:.6}, {:.6})",
+                v.flag, v.location.x, v.location.y, v.location.z
+            );
+        }
+        DecodedEntity::VertexPfaceFace(f) => {
+            println!("[{i}] VERTEX_PFACE_FACE  indices={:?}", f.vertex_indices);
+        }
+        DecodedEntity::Polyline3d(p) => {
+            println!(
+                "[{i}] POLYLINE_3D  flags={:?} owned={:?}",
+                p.flags, p.num_owned_objects
+            );
+        }
+        DecodedEntity::PolyfaceMesh(m) => {
+            println!(
+                "[{i}] POLYLINE_PFACE  vertices={} faces={} owned={:?}",
+                m.vertex_count, m.face_count, m.num_owned_objects
+            );
+        }
+        DecodedEntity::MLine(m) => {
+            println!(
+                "[{i}] MLINE  scale={:.6} justification={:?} lines={} vertices={} flags={}",
+                m.scale_factor,
+                m.justification,
+                m.num_lines,
+                m.vertices.len(),
+                m.open_closed_flags
+            );
+        }
         DecodedEntity::Unhandled { type_code, kind } => {
             println!("[{i}] UNHANDLED  type_code=0x{type_code:04X} kind={kind:?}");
         }

--- a/examples/probe_entity_budgets.rs
+++ b/examples/probe_entity_budgets.rs
@@ -1,0 +1,182 @@
+//! How many data-stream bits does each entity record actually have?
+//!
+//! # What this proves
+//!
+//! Every record in an R2000-R2007 or R2010+ file carries a bit offset
+//! at which its data fields *must* end — the `RL` object-data-size for
+//! the older band, the first bit of the string stream (or the handle
+//! stream minus the one `strings present` trailer bit) for the newer
+//! one. The difference between that offset and the end of the common
+//! entity preamble is the record's **budget**: the exact number of bits
+//! its type-specific field list has to consume, no more and no less.
+//!
+//! `examples/probe_decode_errors.rs` prints the budget for records that
+//! *error*. This probe prints it for **every** entity record, decoded,
+//! unhandled or errored alike, which is what a type with no decoder at
+//! all needs before one can be written:
+//!
+//! ```text
+//! 0x0006 SeqEnd            handle=0x1E5  body@2029  data_end=2029  budget=0     strings=none
+//! 0x000B Vertex3d          handle=0x1DF  body@1859  data_end=2051  budget=192   strings=none
+//! ```
+//!
+//! A `budget` of 0 means the record's field list is empty — every bit
+//! between the preamble and the boundary is already accounted for.
+//!
+//! ```sh
+//! cargo run --release --example probe_entity_budgets -- samples/sample_AC1032.dwg
+//! cargo run --release --example probe_entity_budgets -- samples/sample_AC1032.dwg 0x000B
+//! ```
+//!
+//! The optional second argument filters by type code (`0x000B` or
+//! `11`). With no filter the probe prints one line per record followed
+//! by a per-type budget histogram.
+
+use dwg::{DwgFile, RawObject, Version};
+use std::collections::BTreeMap;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let mut args = std::env::args().skip(1);
+    let Some(path) = args.next() else {
+        eprintln!("usage: probe_entity_budgets <file.dwg> [type-code]");
+        return ExitCode::FAILURE;
+    };
+    let filter = args.next().map(|s| {
+        let s = s.trim().to_ascii_lowercase();
+        let parsed = match s.strip_prefix("0x") {
+            Some(hex) => u16::from_str_radix(hex, 16),
+            None => s.parse::<u16>(),
+        };
+        parsed.expect("type code must be decimal or 0x-prefixed hex")
+    });
+
+    let file = match DwgFile::open(&path) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("open failed ({path}): {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let version = file.version();
+    let Some(objects) = file.all_objects() else {
+        eprintln!("{version} has no handle-driven object walk");
+        return ExitCode::FAILURE;
+    };
+    let objects = match objects {
+        Ok(o) => o,
+        Err(e) => {
+            eprintln!("object walk failed: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let class_map = file.class_map().and_then(std::result::Result::ok);
+
+    println!("=== {path} ===");
+    println!("version: {version}");
+    println!();
+
+    let mut histo: BTreeMap<String, BTreeMap<i64, usize>> = BTreeMap::new();
+    for raw in &objects {
+        if !raw.is_entity() {
+            continue;
+        }
+        if filter.is_some_and(|f| f != raw.type_code) {
+            continue;
+        }
+        let label = class_map
+            .as_ref()
+            .and_then(|m| m.by_type_code(raw.type_code))
+            .map(|d| d.dxf_class_name.clone())
+            .unwrap_or_else(|| format!("{}", raw.kind));
+        let report = measure(raw, version);
+        println!(
+            "0x{:04X} {label:<24} handle=0x{:<6X} body@{:<7} data_end={:<7} budget={:<7} \
+             strings={}",
+            raw.type_code,
+            raw.handle.value,
+            render(report.body_start),
+            render(report.data_end),
+            render_i(report.budget),
+            report.strings,
+        );
+        if let Some(budget) = report.budget {
+            *histo
+                .entry(format!("0x{:04X} {label}", raw.type_code))
+                .or_default()
+                .entry(budget)
+                .or_default() += 1;
+        }
+    }
+
+    println!();
+    println!("=== budget histogram (bits between the preamble and the boundary) ===");
+    for (label, buckets) in &histo {
+        let total: usize = buckets.values().sum();
+        let rendered = buckets
+            .iter()
+            .map(|(bits, n)| format!("{bits}×{n}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        println!("{label:<32} n={total:<4} {rendered}");
+    }
+    ExitCode::SUCCESS
+}
+
+struct Report {
+    body_start: Option<usize>,
+    data_end: Option<usize>,
+    budget: Option<i64>,
+    strings: String,
+}
+
+/// Boundary the entity's data fields must land on, per release band.
+///
+/// R2010+ reads it out of the string-stream trailer; R2000-R2007 from
+/// the object prologue's `RL`. R13/R14 have neither.
+fn entity_data_end(raw: &RawObject, version: Version) -> Option<usize> {
+    if version.is_r2010_plus() {
+        return dwg::string_stream::data_field_end(&raw.raw, version);
+    }
+    if version.is_r2007() {
+        // The R2007 string stream is not locatable in this crate yet,
+        // so the RL covers data + strings and is not the field boundary.
+        return None;
+    }
+    raw.obj_size_bits.map(|b| b as usize)
+}
+
+fn measure(raw: &RawObject, version: Version) -> Report {
+    let data_end = entity_data_end(raw, version);
+    let strings = match version.is_r2010_plus() {
+        true => match dwg::string_stream::locate(&raw.raw, version) {
+            Some(s) => format!("{}bits", s.len_bits()),
+            None => "none".to_string(),
+        },
+        false => "n/a".to_string(),
+    };
+    let body_start = dwg::object::body_cursor(raw, version)
+        .ok()
+        .and_then(|mut cursor| {
+            dwg::common_entity::read_common_entity_data(&mut cursor, version).ok()?;
+            Some(cursor.position_bits())
+        });
+    let budget = match (body_start, data_end) {
+        (Some(b), Some(e)) => Some(e as i64 - b as i64),
+        _ => None,
+    };
+    Report {
+        body_start,
+        data_end,
+        budget,
+        strings,
+    }
+}
+
+fn render(v: Option<usize>) -> String {
+    v.map(|v| v.to_string()).unwrap_or_else(|| "?".into())
+}
+
+fn render_i(v: Option<i64>) -> String {
+    v.map(|v| v.to_string()).unwrap_or_else(|| "?".into())
+}

--- a/src/entities/block.rs
+++ b/src/entities/block.rs
@@ -13,11 +13,42 @@
 
 use crate::bitcursor::BitCursor;
 use crate::error::{Error, Result};
+use crate::string_stream::StringReader;
 use crate::version::Version;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Block {
     pub name: String,
+}
+
+/// Decode a BLOCK, taking its one `TV` from whichever stream holds it.
+///
+/// `Some(reader)` is the R2010+ split layout: the name's characters
+/// live in the object's string stream and the slot costs the data
+/// stream nothing. `None` is the inline layout of R2000-R2004.
+///
+/// # Measured
+///
+/// BLOCK's entire field list is that one `TV`, so on R2010+ its data
+/// fields have a budget of **zero** bits — and every BLOCK record in
+/// the corpus has exactly that: 27/27 on `sample_AC1032.dwg` (R2018)
+/// and 3/3 on each of `arc_2010.dwg` and `arc_2013.dwg`, measured with
+/// `examples/probe_entity_budgets.rs`. Reading the name inline instead
+/// overran the boundary on all 33 (deltas +58 … +266). On R2004 the
+/// same records spend 114-122 bits there, which is exactly the inline
+/// `BS` length plus the NUL-terminated name, and they close on the
+/// `RL` object-data-size with the reading below.
+pub fn decode_field(
+    c: &mut BitCursor<'_>,
+    version: Version,
+    strings: &mut Option<StringReader<'_>>,
+) -> Result<Block> {
+    match strings.as_mut() {
+        Some(reader) => Ok(Block {
+            name: reader.read_tv()?,
+        }),
+        None => decode(c, version),
+    }
 }
 
 /// Decodes the `Block` payload that follows the common entity header.

--- a/src/entities/dispatch.rs
+++ b/src/entities/dispatch.rs
@@ -33,13 +33,14 @@ use crate::common_entity::CommonEntityData;
 use crate::entities::{
     arc, attdef, attrib, block, body, camera, circle, dimension, ellipse, endblk, extruded_surface,
     geodata, hatch, helix, image, insert, leader, light, line, lofted_surface, lwpolyline, mesh,
-    mleader, mtext, ole2_frame, point, polyface_mesh, polygon_mesh, polyline, ray, region,
-    revolved_surface, solid, spline, sun, swept_surface, text, three_d_face, three_d_solid,
+    mleader, mline, mtext, ole2_frame, point, polyface_mesh, polygon_mesh, polyline, ray, region,
+    revolved_surface, seqend, solid, spline, sun, swept_surface, text, three_d_face, three_d_solid,
     tolerance, trace, underlay, vertex, viewport, wipeout, xline,
 };
 use crate::error::Result;
 use crate::object::RawObject;
 use crate::object_type::ObjectType;
+use crate::string_stream::StringReader;
 use crate::version::Version;
 
 /// A decoded entity — one variant per type this crate knows how to decode.
@@ -73,7 +74,18 @@ pub enum DecodedEntity {
     Block(block::Block),
     EndBlk(endblk::EndBlk),
     Vertex(vertex::Vertex),
+    /// VERTEX_3D / VERTEX_MESH / VERTEX_PFACE — one field list for all
+    /// three; the flag byte says which.
+    VertexPoint(vertex::VertexPoint),
+    /// VERTEX_PFACE_FACE — four indices into a POLYLINE_PFACE's vertex list.
+    VertexPfaceFace(vertex::VertexPfaceFace),
+    /// SEQEND — closes an INSERT's or POLYLINE's sub-entity list.
+    SeqEnd(seqend::SeqEnd),
     Polyline(polyline::Polyline),
+    /// POLYLINE_3D — the 3D polyline header (§19.4.46).
+    Polyline3d(polyline::Polyline3d),
+    /// MLINE — the multi-line entity (§19.4.71).
+    MLine(Box<mline::MLine>),
     LwPolyline(lwpolyline::LwPolyline),
     Mesh(mesh::Mesh),
     PolyfaceMesh(polyface_mesh::PolyfaceMesh),
@@ -177,7 +189,15 @@ impl DecodedEntity {
             Self::Block(_) => OBJECT_TYPE_BLOCK,
             Self::EndBlk(_) => OBJECT_TYPE_ENDBLK,
             Self::Vertex(_) => OBJECT_TYPE_VERTEX_2D,
+            // VERTEX_3D / VERTEX_MESH / VERTEX_PFACE share one variant;
+            // the sentinel points at VERTEX_3D, the commonest of the
+            // three, and the flag byte carries the real distinction.
+            Self::VertexPoint(_) => OBJECT_TYPE_VERTEX_3D,
+            Self::VertexPfaceFace(_) => OBJECT_TYPE_VERTEX_PFACE_FACE,
+            Self::SeqEnd(_) => OBJECT_TYPE_SEQEND,
             Self::Polyline(_) => OBJECT_TYPE_POLYLINE_2D,
+            Self::Polyline3d(_) => OBJECT_TYPE_POLYLINE_3D,
+            Self::MLine(_) => OBJECT_TYPE_MLINE,
             Self::LwPolyline(_) => OBJECT_TYPE_LWPOLYLINE,
             // MESH (subdivision) is a custom class — code varies per
             // file via AcDb:Classes. Return 0 so callers consult the
@@ -262,9 +282,17 @@ const OBJECT_TYPE_ATTRIB: u16 = 0x02; // 2
 const OBJECT_TYPE_ATTDEF: u16 = 0x03; // 3
 const OBJECT_TYPE_BLOCK: u16 = 0x04; // 4
 const OBJECT_TYPE_ENDBLK: u16 = 0x05; // 5
+const OBJECT_TYPE_SEQEND: u16 = 0x06; // 6
 const OBJECT_TYPE_INSERT: u16 = 0x07; // 7
 const OBJECT_TYPE_VERTEX_2D: u16 = 0x0A; // 10
+// VERTEX_3D / VERTEX_MESH / VERTEX_PFACE share one measured field list
+// (`RC flag, 3BD location`); VERTEX_PFACE_FACE has its own.
+const OBJECT_TYPE_VERTEX_3D: u16 = 0x0B; // 11
+const OBJECT_TYPE_VERTEX_MESH: u16 = 0x0C; // 12
+const OBJECT_TYPE_VERTEX_PFACE: u16 = 0x0D; // 13
+const OBJECT_TYPE_VERTEX_PFACE_FACE: u16 = 0x0E; // 14
 const OBJECT_TYPE_POLYLINE_2D: u16 = 0x0F; // 15
+const OBJECT_TYPE_POLYLINE_3D: u16 = 0x10; // 16
 // Legacy mesh entities — POLYFACE_MESH (face-list) + POLYGON_MESH (M×N grid).
 // Vertex data for both lives in a handle chain of VERTEX_PFACE /
 // VERTEX_MESH sub-entities — the headers decoded here carry only the
@@ -293,6 +321,7 @@ const OBJECT_TYPE_3DSOLID: u16 = 0x26; // 38
 const OBJECT_TYPE_BODY: u16 = 0x27; // 39
 const OBJECT_TYPE_RAY: u16 = 0x28; // 40
 const OBJECT_TYPE_XLINE: u16 = 0x29; // 41
+const OBJECT_TYPE_MLINE: u16 = 0x2F; // 47
 const OBJECT_TYPE_MTEXT: u16 = 0x2C; // 44
 const OBJECT_TYPE_LEADER: u16 = 0x2D; // 45
 const OBJECT_TYPE_TOLERANCE: u16 = 0x2E; // 46
@@ -373,8 +402,8 @@ pub fn decode_from_raw_with_class_map(
     }
     // Position cursor past header + common preamble, then dispatch by
     // DXF class name.
-    let mut cursor = match position_cursor_at_entity_body(raw, version) {
-        Ok(c) => c,
+    let body_start = match position_cursor_at_entity_body(raw, version) {
+        Ok(c) => c.position_bits(),
         Err(e) => {
             return DecodedEntity::Error {
                 type_code,
@@ -389,53 +418,63 @@ pub fn decode_from_raw_with_class_map(
     if let Some(decoded) = dispatch_split_stream_class(
         raw,
         class_def.dxf_class_name.as_str(),
-        cursor.position_bits(),
+        body_start,
         type_code,
         raw.kind,
         version,
     ) {
         return decoded;
     }
-    if let Err(e) = crate::common_entity::read_common_entity_data(&mut cursor, version) {
-        return DecodedEntity::Error {
-            type_code,
-            kind: raw.kind,
-            message: format!("common entity preamble: {e}"),
-        };
-    }
-    let result: std::result::Result<DecodedEntity, String> = match class_def.dxf_class_name.as_str()
-    {
-        "IMAGE" | "RASTERIMAGE" => image::decode(&mut cursor, version)
-            .map(DecodedEntity::Image)
-            .map_err(|e| e.to_string()),
+    let name = class_def.dxf_class_name.as_str();
+    // Every custom-class entity decoder below runs through
+    // `checked_inline`, so it has to land exactly on the record's own
+    // data-stream boundary — the same rule the fixed-code path applies.
+    let result: Result<DecodedEntity> = match name {
+        "IMAGE" | "RASTERIMAGE" => {
+            checked_inline(raw, body_start, version, "IMAGE", |c, v, _, _| {
+                image::decode(c, v).map(DecodedEntity::Image)
+            })
+        }
         // SURFACE family + HELIX — type codes vary per-file, dispatched
         // on the DXF class name recorded in AcDb:Classes. See spec
         // §19.4.76 (HELIX) and §19.4.78-81 (SURFACE variants).
-        "EXTRUDEDSURFACE" | "ACDBEXTRUDEDSURFACE" => extruded_surface::decode(&mut cursor)
-            .map(DecodedEntity::ExtrudedSurface)
-            .map_err(|e| e.to_string()),
-        "REVOLVEDSURFACE" | "ACDBREVOLVEDSURFACE" => revolved_surface::decode(&mut cursor)
-            .map(DecodedEntity::RevolvedSurface)
-            .map_err(|e| e.to_string()),
-        "SWEPTSURFACE" | "ACDBSWEPTSURFACE" => swept_surface::decode(&mut cursor)
-            .map(DecodedEntity::SweptSurface)
-            .map_err(|e| e.to_string()),
-        "LOFTEDSURFACE" | "ACDBLOFTEDSURFACE" => lofted_surface::decode(&mut cursor)
-            .map(DecodedEntity::LoftedSurface)
-            .map_err(|e| e.to_string()),
-        "HELIX" | "ACDBHELIX" => helix::decode(&mut cursor)
-            .map(DecodedEntity::Helix)
-            .map_err(|e| e.to_string()),
-        // UNDERLAY family (§19.4.86) — PDF / DWF / DGN share one payload.
-        "WIPEOUT" | "ACDBWIPEOUT" => wipeout::decode(&mut cursor, version)
-            .map(DecodedEntity::Wipeout)
-            .map_err(|e| e.to_string()),
+        "EXTRUDEDSURFACE" | "ACDBEXTRUDEDSURFACE" => {
+            checked_inline(raw, body_start, version, "EXTRUDEDSURFACE", |c, _, _, _| {
+                extruded_surface::decode(c).map(DecodedEntity::ExtrudedSurface)
+            })
+        }
+        "REVOLVEDSURFACE" | "ACDBREVOLVEDSURFACE" => {
+            checked_inline(raw, body_start, version, "REVOLVEDSURFACE", |c, _, _, _| {
+                revolved_surface::decode(c).map(DecodedEntity::RevolvedSurface)
+            })
+        }
+        "SWEPTSURFACE" | "ACDBSWEPTSURFACE" => {
+            checked_inline(raw, body_start, version, "SWEPTSURFACE", |c, _, _, _| {
+                swept_surface::decode(c).map(DecodedEntity::SweptSurface)
+            })
+        }
+        "LOFTEDSURFACE" | "ACDBLOFTEDSURFACE" => {
+            checked_inline(raw, body_start, version, "LOFTEDSURFACE", |c, _, _, _| {
+                lofted_surface::decode(c).map(DecodedEntity::LoftedSurface)
+            })
+        }
+        "HELIX" | "ACDBHELIX" => checked_inline(raw, body_start, version, "HELIX", |c, _, _, _| {
+            helix::decode(c).map(DecodedEntity::Helix)
+        }),
+        // WIPEOUT shares the IMAGE payload (§19.4.86).
+        "WIPEOUT" | "ACDBWIPEOUT" => {
+            checked_inline(raw, body_start, version, "WIPEOUT", |c, v, _, _| {
+                wipeout::decode(c, v).map(DecodedEntity::Wipeout)
+            })
+        }
         // MESH (subdivision surface) — R2010+ custom class §19.4.66.
         // Class name varies slightly across AutoCAD versions; all three
         // observed names dispatch to the same decoder.
-        "MESH" | "ACDBSUBDMESH" | "ACDBMESH" => mesh::decode(&mut cursor, version)
-            .map(DecodedEntity::Mesh)
-            .map_err(|e| e.to_string()),
+        "MESH" | "ACDBSUBDMESH" | "ACDBMESH" => {
+            checked_inline(raw, body_start, version, "MESH", |c, v, _, _| {
+                mesh::decode(c, v).map(DecodedEntity::Mesh)
+            })
+        }
         _ => {
             return DecodedEntity::Unhandled {
                 type_code,
@@ -445,10 +484,10 @@ pub fn decode_from_raw_with_class_map(
     };
     match result {
         Ok(entity) => entity,
-        Err(message) => DecodedEntity::Error {
+        Err(e) => DecodedEntity::Error {
             type_code,
             kind: raw.kind,
-            message,
+            message: e.to_string(),
         },
     }
 }
@@ -488,7 +527,7 @@ pub fn decode_from_raw(raw: &RawObject, version: Version) -> DecodedEntity {
             {
                 decoded
             } else {
-                dispatch(&mut cursor, type_code, kind, version)
+                dispatch_fixed_code(raw, cursor.position_bits(), type_code, kind, version)
             }
         }
         Err(e) => DecodedEntity::Error {
@@ -734,7 +773,7 @@ fn dispatch_split_stream_class(
                 object_body_start,
                 version,
                 "UNDERLAY",
-                move |c, v, _ce| underlay::decode(c, kind, v),
+                move |c, v, _ce, _s| underlay::decode(c, kind, v),
             )
             .map(DecodedEntity::Underlay)
         }
@@ -750,33 +789,99 @@ fn dispatch_split_stream_class(
     })
 }
 
+/// Bit offset at which an entity's data-stream fields must end, when
+/// the record states it.
+///
+/// | Release band | Boundary |
+/// |---|---|
+/// | R2010+ | first bit of the string stream, or the handle-stream start minus the one `B` "strings present" trailer bit (§19.1) |
+/// | R2000 / R2004 | the `RL` object-data-size-in-bits from the object prologue (§19.1) |
+/// | R2007 | not knowable here — see below |
+/// | R13 / R14 | no such field |
+///
+/// R2007 (`AC1021`) splits the data and string streams like R2010+ but
+/// records only the *combined* size in its `RL`, and this crate cannot
+/// locate an R2007 string stream yet ([`crate::string_stream::locate`]
+/// returns `None` there). Using the `RL` as the field boundary would
+/// therefore charge every record for its own strings. `None` is the
+/// honest answer until the R2007 object walk lands — no `AC1021` record
+/// reaches a decoder in this crate today.
+fn entity_data_end(raw: &RawObject, version: Version) -> Option<usize> {
+    if version.is_r2010_plus() {
+        return crate::string_stream::data_field_end(&raw.raw, version);
+    }
+    if version.is_r2007() {
+        return None;
+    }
+    raw.obj_size_bits.map(|b| b as usize)
+}
+
+/// Open the `TV` source for an entity record.
+///
+/// R2010+ takes every `TV` from the object's string stream — a record
+/// whose *strings present* trailer bit is clear still has the slots,
+/// they simply hold nothing and consume no data-stream bits, which is
+/// what [`StringReader::empty`] models. Earlier releases (and R2007,
+/// whose stream this crate cannot locate) keep the characters inline,
+/// which `None` selects.
+fn entity_strings<'a>(payload: &'a [u8], version: Version) -> Result<Option<StringReader<'a>>> {
+    if !version.is_r2010_plus() {
+        return Ok(None);
+    }
+    Ok(Some(match crate::string_stream::locate(payload, version) {
+        Some(stream) => StringReader::new(payload, stream)?,
+        None => StringReader::empty(payload),
+    }))
+}
+
 /// Run an inline entity decoder against a record's payload and require
 /// it to end **exactly** on the record's data-stream boundary — the
-/// first bit of its string stream, or the start of its handle stream
-/// when it holds no strings (§19.1).
+/// first bit of its string stream, the start of its handle stream when
+/// it holds no strings (§19.1), or the `RL` object-data-size on the
+/// R2000/R2004 band.
 ///
 /// Entities with no `TV` field do not need the split streams to read
 /// their values, but they still get the boundary for free, and the
 /// boundary is what turns a wrong field list into an error instead of
-/// plausible-looking geometry. Types listed here have been measured
-/// against every record of that type in the corpus.
+/// plausible-looking geometry. Every fixed-code and custom-class entity
+/// decoder in this crate runs through here, so on R2010+ **no** entity
+/// decodes unchecked; on R13/R14/R2007 the record states no boundary
+/// and [`entity_data_end`] returns `None`, so the decode runs unchecked
+/// and says so in `STATUS.md`.
 fn checked_inline<T>(
     raw: &RawObject,
     object_body_start: usize,
     version: Version,
     what: &'static str,
-    decode_body: impl FnOnce(&mut BitCursor<'_>, Version, &CommonEntityData) -> Result<T>,
+    decode_body: impl FnOnce(
+        &mut BitCursor<'_>,
+        Version,
+        &CommonEntityData,
+        &mut Option<StringReader<'_>>,
+    ) -> Result<T>,
 ) -> Result<T> {
-    let (_strings, string_start) = crate::tables::modern::open_entity(&raw.raw, version)?;
+    let data_end = entity_data_end(raw, version);
+    let mut strings = entity_strings(&raw.raw, version)?;
     let mut c = BitCursor::new(&raw.raw);
     crate::string_stream::seek(&mut c, object_body_start)?;
     let common = crate::common_entity::read_common_entity_data(&mut c, version)?;
-    let value = decode_body(&mut c, version, &common)?;
-    let at = c.position_bits();
-    if at != string_start {
-        return Err(crate::tables::modern::misaligned(what, at, string_start));
+    let value = decode_body(&mut c, version, &common, &mut strings)?;
+    if let Some(end) = data_end {
+        let at = c.position_bits();
+        if at != end {
+            return Err(misaligned_entity(what, at, end));
+        }
     }
     Ok(value)
+}
+
+/// Error describing an entity whose data fields did not land on the
+/// record's own data-stream boundary.
+fn misaligned_entity(what: &str, at: usize, data_end: usize) -> crate::error::Error {
+    crate::error::Error::SectionMap(format!(
+        "{what} data fields ended at bit {at}, data stream ends at {data_end} (delta {})",
+        at as isize - data_end as isize
+    ))
 }
 
 /// Dispatch the R2007+ entities whose `TV` fields live in the object's
@@ -819,48 +924,6 @@ fn dispatch_split_stream_entity(
         OBJECT_TYPE_SPLINE if version.is_r2010_plus() => {
             spline::decode_modern_split_stream(&raw.raw, object_body_start, version)
                 .map(DecodedEntity::Spline)
-        }
-        OBJECT_TYPE_INSERT if version.is_r2010_plus() => {
-            checked_inline(raw, object_body_start, version, "INSERT", |c, v, _ce| {
-                insert::decode(c, v)
-            })
-            .map(DecodedEntity::Insert)
-        }
-        OBJECT_TYPE_3DFACE if version.is_r2010_plus() => {
-            checked_inline(raw, object_body_start, version, "3DFACE", |c, _v, _ce| {
-                three_d_face::decode(c)
-            })
-            .map(DecodedEntity::ThreeDFace)
-        }
-        OBJECT_TYPE_LWPOLYLINE if version.is_r2010_plus() => checked_inline(
-            raw,
-            object_body_start,
-            version,
-            "LWPOLYLINE",
-            |c, v, _ce| lwpolyline::decode(c, v),
-        )
-        .map(DecodedEntity::LwPolyline),
-        // REGION / 3DSOLID / BODY — one §20.4.41 field list for all
-        // three. `binary_chain` is the record's `has AcDs binary data`
-        // bit: when it is set the SAB stream lives in the data-storage
-        // section (§24) and the record's shape changes accordingly.
-        OBJECT_TYPE_3DSOLID if version.is_r2010_plus() => {
-            checked_inline(raw, object_body_start, version, "3DSOLID", |c, v, ce| {
-                three_d_solid::decode_record(c, v, ce.binary_chain)
-            })
-            .map(DecodedEntity::ThreeDSolid)
-        }
-        OBJECT_TYPE_REGION if version.is_r2010_plus() => {
-            checked_inline(raw, object_body_start, version, "REGION", |c, v, ce| {
-                region::decode_record(c, v, ce.binary_chain)
-            })
-            .map(DecodedEntity::Region)
-        }
-        OBJECT_TYPE_BODY if version.is_r2010_plus() => {
-            checked_inline(raw, object_body_start, version, "BODY", |c, v, ce| {
-                body::decode_record(c, v, ce.binary_chain)
-            })
-            .map(DecodedEntity::Body)
         }
         OBJECT_TYPE_LIGHT => {
             light::decode_modern_split_stream(&raw.raw, object_body_start, version)
@@ -1028,143 +1091,188 @@ fn position_cursor_at_entity_body<'a>(
     crate::object::body_cursor(raw, version)
 }
 
-fn dispatch(
-    cursor: &mut BitCursor<'_>,
+/// Name of the fixed-code entity this dispatcher decodes, or `None`
+/// when the code has no decoder at all.
+///
+/// This is the gate [`dispatch_fixed_code`] consults *before* running a
+/// record through [`checked_inline`], so it must list exactly the codes
+/// [`decode_fixed_entity_body`] handles — `tests::fixed_entity_label_covers_every_body_arm`
+/// pins that. Keeping the two in step is what lets an unknown type come
+/// back `Unhandled` instead of tripping a boundary check it was never
+/// going to satisfy.
+fn fixed_entity_label(type_code: u16) -> Option<&'static str> {
+    Some(match type_code {
+        OBJECT_TYPE_LINE => "LINE",
+        OBJECT_TYPE_POINT => "POINT",
+        OBJECT_TYPE_CIRCLE => "CIRCLE",
+        OBJECT_TYPE_ARC => "ARC",
+        OBJECT_TYPE_ELLIPSE => "ELLIPSE",
+        OBJECT_TYPE_RAY => "RAY",
+        OBJECT_TYPE_XLINE => "XLINE",
+        OBJECT_TYPE_SOLID => "SOLID",
+        OBJECT_TYPE_TRACE => "TRACE",
+        OBJECT_TYPE_3DFACE => "3DFACE",
+        OBJECT_TYPE_3DSOLID => "3DSOLID",
+        OBJECT_TYPE_REGION => "REGION",
+        OBJECT_TYPE_BODY => "BODY",
+        OBJECT_TYPE_SPLINE => "SPLINE",
+        OBJECT_TYPE_TEXT => "TEXT",
+        OBJECT_TYPE_MTEXT => "MTEXT",
+        OBJECT_TYPE_ATTRIB => "ATTRIB",
+        OBJECT_TYPE_ATTDEF => "ATTDEF",
+        OBJECT_TYPE_INSERT => "INSERT",
+        OBJECT_TYPE_BLOCK => "BLOCK",
+        OBJECT_TYPE_ENDBLK => "ENDBLK",
+        OBJECT_TYPE_SEQEND => "SEQEND",
+        OBJECT_TYPE_VERTEX_2D => "VERTEX_2D",
+        OBJECT_TYPE_VERTEX_3D => "VERTEX_3D",
+        OBJECT_TYPE_VERTEX_MESH => "VERTEX_MESH",
+        OBJECT_TYPE_VERTEX_PFACE => "VERTEX_PFACE",
+        OBJECT_TYPE_VERTEX_PFACE_FACE => "VERTEX_PFACE_FACE",
+        OBJECT_TYPE_POLYLINE_2D => "POLYLINE_2D",
+        OBJECT_TYPE_POLYLINE_3D => "POLYLINE_3D",
+        OBJECT_TYPE_MLINE => "MLINE",
+        OBJECT_TYPE_LWPOLYLINE => "LWPOLYLINE",
+        OBJECT_TYPE_POLYLINE_PFACE => "POLYLINE_PFACE",
+        OBJECT_TYPE_POLYLINE_MESH => "POLYLINE_MESH",
+        OBJECT_TYPE_LEADER => "LEADER",
+        OBJECT_TYPE_TOLERANCE => "TOLERANCE",
+        OBJECT_TYPE_OLE2FRAME => "OLE2FRAME",
+        OBJECT_TYPE_HATCH => "HATCH",
+        OBJECT_TYPE_VIEWPORT => "VIEWPORT",
+        OBJECT_TYPE_CAMERA => "CAMERA",
+        OBJECT_TYPE_SUN => "SUN",
+        OBJECT_TYPE_LIGHT => "LIGHT",
+        OBJECT_TYPE_GEODATA => "GEODATA",
+        // DIMENSION family per ODA §5 Table 4:
+        //   0x14 ORDINATE, 0x15 LINEAR, 0x16 ALIGNED, 0x17 ANG_3PT,
+        //   0x18 ANG_2LN, 0x19 RADIUS, 0x1A DIAMETER.
+        OBJECT_TYPE_DIMENSION_MIN..=OBJECT_TYPE_DIMENSION_MAX => "DIMENSION",
+        // SHAPE has no field list matched against real bytes yet — the
+        // one record in the corpus has a 160-bit budget and nothing to
+        // spend it on, so it stays `Unhandled` rather than being fed a
+        // guess. IMAGE and MLEADER are custom classes whose codes vary
+        // per file and resolve through `decode_from_raw_with_class_map`.
+        OBJECT_TYPE_SHAPE => return None,
+        _ => return None,
+    })
+}
+
+/// Decode one fixed-code entity's type-specific field list.
+///
+/// The cursor arrives past the common entity preamble; `strings` is the
+/// R2010+ string stream (`None` on the inline bands), and `common`
+/// carries the preamble's flags — [`CommonEntityData::binary_chain`] in
+/// particular, which changes the shape of the §20.4.41 ACIS records.
+///
+/// Callers reach this only for codes [`fixed_entity_label`] names, so
+/// the fall-through arm is unreachable in practice; it returns an error
+/// rather than panicking because parsing paths in this crate never
+/// panic.
+fn decode_fixed_entity_body(
+    c: &mut BitCursor<'_>,
+    type_code: u16,
+    version: Version,
+    common: &CommonEntityData,
+    strings: &mut Option<StringReader<'_>>,
+) -> Result<DecodedEntity> {
+    let _ = strings;
+    Ok(match type_code {
+        OBJECT_TYPE_LINE => DecodedEntity::Line(line::decode(c)?),
+        OBJECT_TYPE_POINT => DecodedEntity::Point(point::decode(c)?),
+        OBJECT_TYPE_CIRCLE => DecodedEntity::Circle(circle::decode(c)?),
+        OBJECT_TYPE_ARC => DecodedEntity::Arc(arc::decode(c)?),
+        OBJECT_TYPE_ELLIPSE => DecodedEntity::Ellipse(ellipse::decode(c)?),
+        OBJECT_TYPE_RAY => DecodedEntity::Ray(ray::decode(c)?),
+        OBJECT_TYPE_XLINE => DecodedEntity::XLine(xline::decode(c)?),
+        OBJECT_TYPE_SOLID => DecodedEntity::Solid(solid::decode(c)?),
+        OBJECT_TYPE_TRACE => DecodedEntity::Trace(trace::decode(c)?),
+        OBJECT_TYPE_3DFACE => DecodedEntity::ThreeDFace(three_d_face::decode(c)?),
+        // REGION / 3DSOLID / BODY — one §20.4.41 field list for all
+        // three. `binary_chain` is the record's `has AcDs binary data`
+        // bit: when it is set the SAB stream lives in the data-storage
+        // section (§24) and the record's shape changes accordingly.
+        OBJECT_TYPE_3DSOLID => DecodedEntity::ThreeDSolid(three_d_solid::decode_record(
+            c,
+            version,
+            common.binary_chain,
+        )?),
+        OBJECT_TYPE_REGION => {
+            DecodedEntity::Region(region::decode_record(c, version, common.binary_chain)?)
+        }
+        OBJECT_TYPE_BODY => {
+            DecodedEntity::Body(body::decode_record(c, version, common.binary_chain)?)
+        }
+        OBJECT_TYPE_SPLINE => DecodedEntity::Spline(spline::decode(c, version)?),
+        OBJECT_TYPE_TEXT => DecodedEntity::Text(text::decode(c, version)?),
+        OBJECT_TYPE_MTEXT => DecodedEntity::MText(mtext::decode(c, version)?),
+        OBJECT_TYPE_ATTRIB => DecodedEntity::Attrib(attrib::decode(c, version)?),
+        OBJECT_TYPE_ATTDEF => DecodedEntity::AttDef(attdef::decode(c, version)?),
+        OBJECT_TYPE_INSERT => DecodedEntity::Insert(insert::decode(c, version)?),
+        OBJECT_TYPE_BLOCK => DecodedEntity::Block(block::decode_field(c, version, strings)?),
+        OBJECT_TYPE_ENDBLK => DecodedEntity::EndBlk(endblk::decode(c)?),
+        OBJECT_TYPE_SEQEND => DecodedEntity::SeqEnd(seqend::decode(c)?),
+        OBJECT_TYPE_VERTEX_2D => DecodedEntity::Vertex(vertex::decode(c, version)?),
+        OBJECT_TYPE_VERTEX_3D | OBJECT_TYPE_VERTEX_MESH | OBJECT_TYPE_VERTEX_PFACE => {
+            DecodedEntity::VertexPoint(vertex::decode_point(c)?)
+        }
+        OBJECT_TYPE_VERTEX_PFACE_FACE => {
+            DecodedEntity::VertexPfaceFace(vertex::decode_pface_face(c)?)
+        }
+        OBJECT_TYPE_POLYLINE_2D => DecodedEntity::Polyline(polyline::decode(c)?),
+        OBJECT_TYPE_POLYLINE_3D => DecodedEntity::Polyline3d(polyline::decode_3d(c, version)?),
+        OBJECT_TYPE_MLINE => DecodedEntity::MLine(Box::new(mline::decode(c)?)),
+        OBJECT_TYPE_LWPOLYLINE => DecodedEntity::LwPolyline(lwpolyline::decode(c, version)?),
+        OBJECT_TYPE_POLYLINE_PFACE => {
+            DecodedEntity::PolyfaceMesh(polyface_mesh::decode_record(c, version)?)
+        }
+        OBJECT_TYPE_POLYLINE_MESH => DecodedEntity::PolygonMesh(polygon_mesh::decode(c)?),
+        OBJECT_TYPE_LEADER => DecodedEntity::Leader(leader::decode(c)?),
+        OBJECT_TYPE_TOLERANCE => DecodedEntity::Tolerance(tolerance::decode(c, version)?),
+        OBJECT_TYPE_OLE2FRAME => DecodedEntity::Ole2Frame(ole2_frame::decode(c)?),
+        OBJECT_TYPE_HATCH => DecodedEntity::Hatch(hatch::decode(c, version)?),
+        OBJECT_TYPE_VIEWPORT => DecodedEntity::Viewport(viewport::decode(c)?),
+        OBJECT_TYPE_CAMERA => DecodedEntity::Camera(camera::decode(c, version)?),
+        OBJECT_TYPE_SUN => DecodedEntity::Sun(sun::decode(c, version)?),
+        OBJECT_TYPE_LIGHT => DecodedEntity::Light(light::decode(c, version)?),
+        OBJECT_TYPE_GEODATA => DecodedEntity::GeoData(geodata::decode(c, version)?),
+        OBJECT_TYPE_DIMENSION_MIN..=OBJECT_TYPE_DIMENSION_MAX => {
+            let kind =
+                dimension::DimensionKind::from_object_type_code(type_code).ok_or_else(|| {
+                    crate::error::Error::SectionMap(format!("no DIMENSION subtype for {type_code}"))
+                })?;
+            DecodedEntity::Dimension(dimension::decode(c, version, kind)?)
+        }
+        _ => {
+            return Err(crate::error::Error::SectionMap(format!(
+                "no fixed-code entity decoder for type 0x{type_code:04X}"
+            )));
+        }
+    })
+}
+
+/// Decode a fixed-code entity and require its field list to close
+/// exactly on the record's data-stream boundary.
+fn dispatch_fixed_code(
+    raw: &RawObject,
+    object_body_start: usize,
     type_code: u16,
     kind: ObjectType,
     version: Version,
 ) -> DecodedEntity {
-    // Step through the common entity preamble first (§19.4.1).
-    if let Err(e) = crate::common_entity::read_common_entity_data(cursor, version) {
-        return DecodedEntity::Error {
-            type_code,
-            kind,
-            message: format!("common entity preamble: {e}"),
-        };
-    }
-
-    // Dispatch on fixed type code.
-    let result: std::result::Result<DecodedEntity, String> = match type_code {
-        OBJECT_TYPE_LINE => line::decode(cursor)
-            .map(DecodedEntity::Line)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_POINT => point::decode(cursor)
-            .map(DecodedEntity::Point)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_CIRCLE => circle::decode(cursor)
-            .map(DecodedEntity::Circle)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_ARC => arc::decode(cursor)
-            .map(DecodedEntity::Arc)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_ELLIPSE => ellipse::decode(cursor)
-            .map(DecodedEntity::Ellipse)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_RAY => ray::decode(cursor)
-            .map(DecodedEntity::Ray)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_XLINE => xline::decode(cursor)
-            .map(DecodedEntity::XLine)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_SOLID => solid::decode(cursor)
-            .map(DecodedEntity::Solid)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_TRACE => trace::decode(cursor)
-            .map(DecodedEntity::Trace)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_3DFACE => three_d_face::decode(cursor)
-            .map(DecodedEntity::ThreeDFace)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_SPLINE => spline::decode(cursor, version)
-            .map(DecodedEntity::Spline)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_TEXT => text::decode(cursor, version)
-            .map(DecodedEntity::Text)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_MTEXT => mtext::decode(cursor, version)
-            .map(DecodedEntity::MText)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_ATTRIB => attrib::decode(cursor, version)
-            .map(DecodedEntity::Attrib)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_ATTDEF => attdef::decode(cursor, version)
-            .map(DecodedEntity::AttDef)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_INSERT => insert::decode(cursor, version)
-            .map(DecodedEntity::Insert)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_BLOCK => block::decode(cursor, version)
-            .map(DecodedEntity::Block)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_ENDBLK => endblk::decode(cursor)
-            .map(DecodedEntity::EndBlk)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_VERTEX_2D => vertex::decode(cursor, version)
-            .map(DecodedEntity::Vertex)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_POLYLINE_2D => polyline::decode(cursor)
-            .map(DecodedEntity::Polyline)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_LWPOLYLINE => lwpolyline::decode(cursor, version)
-            .map(DecodedEntity::LwPolyline)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_POLYLINE_PFACE => polyface_mesh::decode(cursor)
-            .map(DecodedEntity::PolyfaceMesh)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_POLYLINE_MESH => polygon_mesh::decode(cursor)
-            .map(DecodedEntity::PolygonMesh)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_LEADER => leader::decode(cursor)
-            .map(DecodedEntity::Leader)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_TOLERANCE => tolerance::decode(cursor, version)
-            .map(DecodedEntity::Tolerance)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_OLE2FRAME => ole2_frame::decode(cursor)
-            .map(DecodedEntity::Ole2Frame)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_HATCH => hatch::decode(cursor, version)
-            .map(DecodedEntity::Hatch)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_VIEWPORT => viewport::decode(cursor)
-            .map(DecodedEntity::Viewport)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_CAMERA => camera::decode(cursor, version)
-            .map(DecodedEntity::Camera)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_SUN => sun::decode(cursor, version)
-            .map(DecodedEntity::Sun)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_LIGHT => light::decode(cursor, version)
-            .map(DecodedEntity::Light)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_GEODATA => geodata::decode(cursor, version)
-            .map(DecodedEntity::GeoData)
-            .map_err(|e| e.to_string()),
-        OBJECT_TYPE_SHAPE => return DecodedEntity::Unhandled { type_code, kind },
-        // DIMENSION family per ODA §5 Table 4:
-        //   0x14 ORDINATE, 0x15 LINEAR, 0x16 ALIGNED, 0x17 ANG_3PT,
-        //   0x18 ANG_2LN, 0x19 RADIUS, 0x1A DIAMETER.
-        OBJECT_TYPE_DIMENSION_MIN..=OBJECT_TYPE_DIMENSION_MAX => {
-            match dimension::DimensionKind::from_object_type_code(type_code) {
-                Some(dk) => dimension::decode(cursor, version, dk)
-                    .map(DecodedEntity::Dimension)
-                    .map_err(|e| e.to_string()),
-                None => return DecodedEntity::Unhandled { type_code, kind },
-            }
-        }
-        // IMAGE and MLEADER are custom classes (AcDb:Classes lookup) —
-        // their codes vary per-file, so they're handled in the custom-
-        // class dispatch pass (see task #96) not here.
-        _ => return DecodedEntity::Unhandled { type_code, kind },
+    let Some(what) = fixed_entity_label(type_code) else {
+        return DecodedEntity::Unhandled { type_code, kind };
     };
+    let result = checked_inline(raw, object_body_start, version, what, |c, v, ce, s| {
+        decode_fixed_entity_body(c, type_code, v, ce, s)
+    });
 
     match result {
         Ok(entity) => entity,
-        Err(message) => DecodedEntity::Error {
+        Err(e) => DecodedEntity::Error {
             type_code,
             kind,
-            message,
+            message: e.to_string(),
         },
     }
 }
@@ -1434,6 +1542,143 @@ mod tests {
             crate::tables::read_tv(&mut c, Version::R2004).unwrap(),
             "ACAD"
         );
+    }
+
+    /// The boundary check is the point of #63: a record whose `RL`
+    /// object-data-size disagrees with what the field list consumed
+    /// must come back as an `Error`, not as a plausible LINE.
+    #[test]
+    fn r2004_line_with_a_wrong_obj_size_errors() {
+        let probe = build_r2004_line_record(0);
+        let mut c = BitCursor::new(&probe);
+        c.read_bs_u().unwrap();
+        c.read_rl().unwrap();
+        c.read_handle().unwrap();
+        crate::common_entity::read_common_entity_data(&mut c, Version::R2004).unwrap();
+        line::decode(&mut c).unwrap();
+        let true_size = c.position_bits() as u32;
+
+        for skew in [-8i32, -1, 1, 8] {
+            let claimed = (true_size as i32 + skew) as u32;
+            let bytes = build_r2004_line_record(claimed);
+            let raw = RawObject {
+                stream_offset: 0,
+                size_bytes: bytes.len() as u32,
+                type_code: OBJECT_TYPE_LINE,
+                kind: ObjectType::Line,
+                handle: crate::bitcursor::Handle {
+                    code: 0,
+                    counter: 1,
+                    value: 0x83,
+                },
+                raw: bytes,
+                obj_size_bits: Some(claimed),
+            };
+            match decode_from_raw(&raw, Version::R2004) {
+                DecodedEntity::Error { message, .. } => {
+                    assert!(
+                        message.contains("LINE data fields ended at bit"),
+                        "skew {skew}: unexpected message {message}"
+                    );
+                }
+                other => panic!("skew {skew}: expected an Error, got {other:?}"),
+            }
+        }
+    }
+
+    /// A code with no decoder must be rejected by
+    /// [`fixed_entity_label`] *before* the boundary check runs —
+    /// otherwise an unknown type would be reported as a misaligned
+    /// record rather than an unhandled one.
+    #[test]
+    fn fixed_entity_label_covers_every_body_arm() {
+        // Every code the body dispatcher decodes.
+        for code in [
+            OBJECT_TYPE_TEXT,
+            OBJECT_TYPE_ATTRIB,
+            OBJECT_TYPE_ATTDEF,
+            OBJECT_TYPE_BLOCK,
+            OBJECT_TYPE_ENDBLK,
+            OBJECT_TYPE_SEQEND,
+            OBJECT_TYPE_INSERT,
+            OBJECT_TYPE_VERTEX_2D,
+            OBJECT_TYPE_VERTEX_3D,
+            OBJECT_TYPE_VERTEX_MESH,
+            OBJECT_TYPE_VERTEX_PFACE,
+            OBJECT_TYPE_VERTEX_PFACE_FACE,
+            OBJECT_TYPE_POLYLINE_2D,
+            OBJECT_TYPE_POLYLINE_3D,
+            OBJECT_TYPE_ARC,
+            OBJECT_TYPE_CIRCLE,
+            OBJECT_TYPE_LINE,
+            OBJECT_TYPE_POINT,
+            OBJECT_TYPE_3DFACE,
+            OBJECT_TYPE_POLYLINE_PFACE,
+            OBJECT_TYPE_POLYLINE_MESH,
+            OBJECT_TYPE_SOLID,
+            OBJECT_TYPE_TRACE,
+            OBJECT_TYPE_VIEWPORT,
+            OBJECT_TYPE_ELLIPSE,
+            OBJECT_TYPE_SPLINE,
+            OBJECT_TYPE_REGION,
+            OBJECT_TYPE_3DSOLID,
+            OBJECT_TYPE_BODY,
+            OBJECT_TYPE_RAY,
+            OBJECT_TYPE_XLINE,
+            OBJECT_TYPE_MTEXT,
+            OBJECT_TYPE_LEADER,
+            OBJECT_TYPE_TOLERANCE,
+            OBJECT_TYPE_MLINE,
+            OBJECT_TYPE_OLE2FRAME,
+            OBJECT_TYPE_LWPOLYLINE,
+            OBJECT_TYPE_HATCH,
+            OBJECT_TYPE_CAMERA,
+            OBJECT_TYPE_SUN,
+            OBJECT_TYPE_LIGHT,
+            OBJECT_TYPE_GEODATA,
+        ]
+        .into_iter()
+        .chain(OBJECT_TYPE_DIMENSION_MIN..=OBJECT_TYPE_DIMENSION_MAX)
+        {
+            assert!(
+                fixed_entity_label(code).is_some(),
+                "0x{code:04X} decodes but has no label, so it would be reported Unhandled"
+            );
+        }
+        // SHAPE has a code but no field list; the reserved range has
+        // neither.
+        assert!(fixed_entity_label(OBJECT_TYPE_SHAPE).is_none());
+        for code in [0x00u16, 0x08, 0x09, 0x1FF, 0xFFFF] {
+            assert!(fixed_entity_label(code).is_none(), "0x{code:04X}");
+        }
+    }
+
+    /// R13/R14 records state no boundary at all, and R2007's `RL`
+    /// covers its string stream too, so neither band can be checked —
+    /// `STATUS.md` says so and this pins it.
+    #[test]
+    fn only_r2000_plus_states_an_entity_boundary() {
+        let raw = RawObject {
+            stream_offset: 0,
+            size_bytes: 0,
+            type_code: OBJECT_TYPE_LINE,
+            kind: ObjectType::Line,
+            handle: crate::bitcursor::Handle {
+                code: 0,
+                counter: 0,
+                value: 0,
+            },
+            raw: vec![0u8; 16],
+            obj_size_bits: Some(64),
+        };
+        assert_eq!(entity_data_end(&raw, Version::R2000), Some(64));
+        assert_eq!(entity_data_end(&raw, Version::R2004), Some(64));
+        assert_eq!(entity_data_end(&raw, Version::R2007), None);
+        let r14 = RawObject {
+            obj_size_bits: None,
+            ..raw
+        };
+        assert_eq!(entity_data_end(&r14, Version::R14), None);
     }
 
     #[test]

--- a/src/entities/leader.rs
+++ b/src/entities/leader.rs
@@ -30,6 +30,23 @@
 //! Full spec is over 30 fields. This decoder covers the core
 //! geometric fields (points, end projection, extrusion) — the text
 //! attachment details are skipped via deliberate field count.
+//!
+//! # Measured: twelve bits short, on one record
+//!
+//! Since #63 this decoder is held to the record's own data-stream
+//! boundary. The single LEADER record in the corpus
+//! (`sample_AC1032.dwg`, handle `0x512`) has a 581-bit data-field
+//! budget and this list consumes 569 of them, so the record reports
+//! `delta -12` instead of returning a struct that only looks complete.
+//!
+//! Twelve bits is small enough that several continuations of the field
+//! list above would fit it, and one record cannot choose between them:
+//! any combination of defaulted `BD`s and trailing `B` flags summing
+//! to twelve satisfies the budget equally well. Under this crate's
+//! evidence rule that is "documented offsets and stop", not a fix. A
+//! second file with a LEADER — ideally one with a text box, where the
+//! `box_height` / `box_width` pair is written explicitly rather than
+//! defaulted — separates the candidates immediately.
 
 use crate::bitcursor::BitCursor;
 use crate::entities::{Point3D, Vec3D, read_bd3};

--- a/src/entities/mesh.rs
+++ b/src/entities/mesh.rs
@@ -51,14 +51,28 @@
 //! `0x343` mesh reads `(1, 60)` correctly but the list then walks off
 //! its own budget.
 //!
-//! ## The three bits this decoder does not read
+//! ## The two bits this decoder does not read — MESH does not close
 //!
 //! After the last crease both records leave exactly **3 bits** before
-//! the data/handle-stream boundary, and both hold `100`. That is
-//! consistent with a trailing `BL` of 0 followed by one bit of byte
-//! padding, but two records that both encode zero cannot distinguish a
-//! `BL` from a `BS` from two spare bits, so this decoder stops at the
-//! last crease and the offsets are recorded here instead of guessed.
+//! the handle stream, and both hold `100`. The last of those three is
+//! the §19.1 *strings present* trailer flag, which is not one of the
+//! record's own fields, so what MESH actually leaves unread is the
+//! two-bit run `10` in front of it.
+//!
+//! `10` is the zero/default code of a `BS`, a `BL` and a `BD` alike, so
+//! two records that both encode zero there cannot say which field it
+//! is — or whether it is a field at all. Under the evidence rule this
+//! crate holds itself to (delta 0 *with* a corroborating value, or
+//! documented offsets and stop) a zero corroborates nothing, so this
+//! decoder still stops at the last crease.
+//!
+//! The consequence, since #63 wired MESH through the exact-boundary
+//! check like every other entity: **both corpus MESH records report an
+//! error with `delta -2`** rather than returning a struct that only
+//! looks complete. That is the honest state — the geometry above is
+//! right (the Euler characteristics prove it), the last two bits are
+//! not identified, and one file cannot identify them. A record whose
+//! trailing value is non-zero would settle it immediately.
 //!
 //! Every claimed count is capped against both a hard ceiling and
 //! [`BitCursor::remaining_bits`], the defensive pattern from

--- a/src/entities/mline.rs
+++ b/src/entities/mline.rs
@@ -21,7 +21,7 @@
 //! BD3   extrusion
 //! BS    open_closed_flags    -- bit 0 = closed, bit 1 = suppressed_start,
 //!                               bit 2 = suppressed_end (et al.)
-//! BS    num_lines            -- parallel elements at each vertex (≤ 16 per spec)
+//! RC    num_lines            -- parallel elements at each vertex (≤ 16 per spec)
 //! BS    num_verts            -- vertices along the path
 //! // For each vertex:
 //! BD3     vertex_point
@@ -34,6 +34,23 @@
 //! BD × N   area_fill_parameters
 //! H     mline_style_handle
 //! ```
+//!
+//! # `num_lines` is an `RC`, not a `BS` — measured
+//!
+//! This module read `BS` there until the exact-boundary check reached
+//! MLINE (#63). With `BS` all three MLINE records of
+//! `sample_AC1032.dwg` (handles `0x38B`, `0x3A5`, `0x3A6`) decode
+//! nonsense immediately — `lines = 521`, `verts = -11716` on two of
+//! them — because the `BS` swallows the byte after it. Reading one
+//! `RC` instead is the single-token change that lands all three
+//! records exactly on their data-stream boundary (`delta 0`).
+//!
+//! The values corroborate the width rather than merely fitting it: all
+//! three read `num_lines = 2`, which is what a two-element multiline
+//! style produces, with `num_verts` 8 / 2 / 2, `justification`
+//! Zero / Top / Zero and `scale_factor` 1.5 / 2.13 / 1.598 — every one
+//! a value a drawing would plausibly hold, where the `BS` reading
+//! produced a negative vertex count.
 //!
 //! # Honest partial decode
 //!
@@ -125,17 +142,16 @@ pub fn decode(c: &mut BitCursor<'_>) -> Result<MLine> {
     let scale_point = read_bd3(c)?;
     let extrusion = read_bd3(c)?;
     let open_closed_flags = c.read_bs()?;
-    let num_lines_signed = c.read_bs()?;
+    let num_lines = c.read_rc()? as usize;
     let num_verts_signed = c.read_bs()?;
 
-    // Defensive: negative counts are nonsense — spec emits BS unsigned
-    // here but read_bs returns i16.
-    if num_lines_signed < 0 || num_verts_signed < 0 {
+    // Defensive: a negative vertex count is nonsense — the spec emits
+    // an unsigned value here but `read_bs` returns i16.
+    if num_verts_signed < 0 {
         return Err(Error::SectionMap(format!(
-            "MLINE negative counts (lines={num_lines_signed}, verts={num_verts_signed})"
+            "MLINE negative vertex count {num_verts_signed}"
         )));
     }
-    let num_lines = num_lines_signed as usize;
     let num_verts = num_verts_signed as usize;
 
     let remaining = c.remaining_bits();
@@ -244,7 +260,7 @@ mod tests {
         w.write_bd(0.0);
         w.write_bd(1.0); // extrusion
         w.write_bs(0); // open
-        w.write_bs(2); // 2 parallel lines
+        w.write_rc(2); // 2 parallel lines
         w.write_bs(3); // 3 vertices
 
         // Vertex 0
@@ -329,7 +345,7 @@ mod tests {
         w.write_bd(0.0);
         w.write_bd(1.0);
         w.write_bs(0);
-        w.write_bs(2);
+        w.write_rc(2);
         // Claim 30000 vertices but no further payload.
         w.write_bs(30000);
         let bytes = w.into_bytes();
@@ -349,7 +365,7 @@ mod tests {
         w.write_bd(0.0);
         w.write_bd(1.0);
         w.write_bs(0);
-        w.write_bs(0); // 0 lines
+        w.write_rc(0); // 0 lines
         w.write_bs(0); // 0 vertices
         let bytes = w.into_bytes();
         let mut c = BitCursor::new(&bytes);

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -19,6 +19,9 @@
 //! | MLINE          | [`mline`]         | §19.4.71     |
 //! | POLYFACE_MESH  | [`polyface_mesh`] | §19.4.29     |
 //! | POLYGON_MESH   | [`polygon_mesh`]  | §19.4.30     |
+//! | POLYLINE_3D    | [`polyline`]      | §19.4.46     |
+//! | VERTEX_*       | [`vertex`]        | §19.4.55-59  |
+//! | SEQEND         | [`seqend`]        | §19.4.6      |
 //! | IMAGE          | [`image`]         | §19.4.35     |
 //! | IMAGEDEF       | [`imagedef`]      | §19.5.26     |
 //! | PROXY ENTITY   | [`proxy_entity_passthrough`] | §19.4.91 |
@@ -89,6 +92,7 @@ pub mod proxy_entity_passthrough;
 pub mod ray;
 pub mod region;
 pub mod revolved_surface;
+pub mod seqend;
 pub mod solid;
 pub mod spline;
 pub mod sun;

--- a/src/entities/polyface_mesh.rs
+++ b/src/entities/polyface_mesh.rs
@@ -1,77 +1,77 @@
-//! POLYFACE_MESH entity (§19.4.29) — legacy face-list 3D mesh.
+//! POLYLINE_PFACE entity (§19.4.29) — legacy face-list 3D mesh header.
 //!
 //! Predates both ACIS solids and the R2010 subdivision [`super::mesh::Mesh`].
-//! A POLYFACE_MESH header holds only the counts and the endpoints of a
-//! handle chain — the actual vertex and face records live in separate
-//! `VERTEX_PFACE` / `VERTEX_PFACE_FACE` sub-entities whose traversal is
-//! a downstream concern (see [`crate::entities::vertex::Vertex`]).
+//! A POLYLINE_PFACE header holds only counts — the actual vertex and
+//! face records live in separate `VERTEX_PFACE` /
+//! `VERTEX_PFACE_FACE` sub-entities the object stream owns (see
+//! [`crate::entities::vertex`]), reached through the record's handle
+//! stream rather than through any field decoded here.
 //!
-//! The `m_vert_count` / `n_vert_count` naming is preserved verbatim from
-//! the ODA spec, which is regrettably misleading: in POLYFACE_MESH the
-//! two fields are **vertex count** and **face count**, not the M×N grid
-//! dimensions they imply in [`super::polygon_mesh::PolygonMesh`]. The
-//! doc-comments call this out explicitly to keep spec-matching code
-//! out of the naming trap.
-//!
-//! # Stream shape (all supported versions, L4-35)
+//! # Stream shape — measured
 //!
 //! ```text
-//! BS   flags
-//! BS   m_vert_count          -- vertices in the mesh
-//! BS   n_vert_count          -- faces in the mesh (see note above)
-//! BS   m_density             -- approximation density (carried for
-//!                                shape compatibility with POLYGON_MESH;
-//!                                ignored for POLYFACE semantics)
-//! BS   n_density             -- ditto
-//! H    first_vertex_handle   -- head of the VERTEX_PFACE chain
-//! H    last_vertex_handle    -- tail of the VERTEX_PFACE chain
+//! BS   vertex_count           -- VERTEX_PFACE sub-entities
+//! BS   face_count             -- VERTEX_PFACE_FACE sub-entities
+//! BL   num_owned_objects      -- R2004+ only
 //! ```
+//!
+//! The single POLYLINE_PFACE record of `sample_AC1032.dwg`
+//! (handle `0x422`) has a 30-bit data-field budget, and that reading is
+//! the one that lands on it exactly — `delta 0` with
+//! `examples/probe_entity_field_list.rs`. Its three values are `5`, `2`
+//! and `7`, and the same file carries exactly **5** `VERTEX_PFACE`
+//! records and **2** `VERTEX_PFACE_FACE` records, whose sum is 7. So
+//! the counts are corroborated by the object stream itself, not just by
+//! the bit budget.
+//!
+//! Two earlier readings are corrected here. The header used to claim
+//! five `BS` count/density fields followed by two inline `H` handles;
+//! the handles never sit in the data stream (they live in the record's
+//! handle stream, which is what the boundary marks the start of), and
+//! the density pair belongs to POLYGON_MESH, not to a face-list mesh.
+//! Together those two mistakes overran the boundary by 52 bits.
+//!
+//! `BS` and `BL` are indistinguishable at this value — both spend
+//! `01` plus one byte for a count below 256 — so the third field is
+//! read as the `BL num_owned_objects` that
+//! [`crate::tables::block_record`] already reads on R2004+ for the
+//! same purpose, rather than as a third count. Only its width and
+//! value are claimed by the corpus.
 
-use crate::bitcursor::{BitCursor, Handle};
+use crate::bitcursor::BitCursor;
 use crate::error::Result;
+use crate::version::Version;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PolyfaceMesh {
-    /// Flag bits per §19.4.29 (closed M / closed N / face-type bits).
-    /// Kept verbatim so round-trip writers can re-emit the same form.
-    pub flags: u16,
-    /// Number of vertices in the mesh. Despite the spec name (`m_vert_count`)
-    /// this is a linear vertex count — the mesh is not a grid.
+    /// Number of `VERTEX_PFACE` sub-entities the mesh owns.
     pub vertex_count: u16,
-    /// Number of faces in the mesh (`n_vert_count` in ODA naming).
+    /// Number of `VERTEX_PFACE_FACE` sub-entities the mesh owns.
     pub face_count: u16,
-    /// Approximation density, M direction. Semantically meaningful only
-    /// for POLYGON_MESH; carried here for shape compatibility.
-    pub m_density: u16,
-    /// Approximation density, N direction. See [`Self::m_density`].
-    pub n_density: u16,
-    /// First VERTEX_PFACE / VERTEX_PFACE_FACE sub-entity in the handle chain.
-    pub first_vertex_handle: Handle,
-    /// Last VERTEX_PFACE / VERTEX_PFACE_FACE sub-entity in the handle chain.
-    pub last_vertex_handle: Handle,
+    /// R2004+ owned-object count — the sub-entities reachable through
+    /// this record's handle stream. `None` before R2004, where the
+    /// field is absent.
+    pub num_owned_objects: Option<u32>,
 }
 
-/// Decode a POLYFACE_MESH header.
+/// Decode a POLYLINE_PFACE header from a cursor parked past the common
+/// entity preamble.
 ///
-/// Only the header is parsed here — the vertex handle chain between
-/// `first_vertex_handle` and `last_vertex_handle` is walked at the
-/// object-stream layer, not by this decoder.
-pub fn decode(c: &mut BitCursor<'_>) -> Result<PolyfaceMesh> {
-    let flags = c.read_bs_u()?;
+/// Only the header is parsed here — the `VERTEX_PFACE` /
+/// `VERTEX_PFACE_FACE` sub-entities are separate records in the object
+/// stream, walked at the object-stream layer.
+pub fn decode_record(c: &mut BitCursor<'_>, version: Version) -> Result<PolyfaceMesh> {
     let vertex_count = c.read_bs_u()?;
     let face_count = c.read_bs_u()?;
-    let m_density = c.read_bs_u()?;
-    let n_density = c.read_bs_u()?;
-    let first_vertex_handle = c.read_handle()?;
-    let last_vertex_handle = c.read_handle()?;
+    let num_owned_objects = if version.is_r2004_plus() {
+        Some(c.read_bl()? as u32)
+    } else {
+        None
+    };
     Ok(PolyfaceMesh {
-        flags,
         vertex_count,
         face_count,
-        m_density,
-        n_density,
-        first_vertex_handle,
-        last_vertex_handle,
+        num_owned_objects,
     })
 }
 
@@ -80,107 +80,37 @@ mod tests {
     use super::*;
     use crate::bitwriter::BitWriter;
 
-    struct PfaceFields {
-        flags: u16,
-        vc: u16,
-        fc: u16,
-        md: u16,
-        nd: u16,
-        first: (u8, u64),
-        last: (u8, u64),
-    }
-
-    fn write_pface(w: &mut BitWriter, f: &PfaceFields) {
-        w.write_bs_u(f.flags);
-        w.write_bs_u(f.vc);
-        w.write_bs_u(f.fc);
-        w.write_bs_u(f.md);
-        w.write_bs_u(f.nd);
-        w.write_handle(f.first.0, f.first.1);
-        w.write_handle(f.last.0, f.last.1);
-    }
-
+    /// The corpus record's own values: 5 vertices, 2 faces, 7 owned
+    /// objects, in exactly 30 bits.
     #[test]
-    fn roundtrip_minimal_header() {
+    fn roundtrip_measured_r2018_header() {
         let mut w = BitWriter::new();
-        write_pface(
-            &mut w,
-            &PfaceFields {
-                flags: 0,
-                vc: 8,
-                fc: 6,
-                md: 0,
-                nd: 0,
-                first: (3, 0x100),
-                last: (3, 0x110),
-            },
-        );
+        w.write_bs_u(5);
+        w.write_bs_u(2);
+        w.write_bl(7);
+        assert_eq!(w.position_bits(), 30);
         let bytes = w.into_bytes();
         let mut c = BitCursor::new(&bytes);
-        let p = decode(&mut c).unwrap();
-        assert_eq!(p.flags, 0);
+        let p = decode_record(&mut c, Version::R2018).unwrap();
+        assert_eq!(p.vertex_count, 5);
+        assert_eq!(p.face_count, 2);
+        assert_eq!(p.num_owned_objects, Some(7));
+        assert_eq!(c.position_bits(), 30);
+    }
+
+    /// Before R2004 the owned-object count is absent, so the same two
+    /// counts close 10 bits earlier.
+    #[test]
+    fn r2000_header_has_no_owned_count() {
+        let mut w = BitWriter::new();
+        w.write_bs_u(8);
+        w.write_bs_u(6);
+        let bytes = w.into_bytes();
+        let mut c = BitCursor::new(&bytes);
+        let p = decode_record(&mut c, Version::R2000).unwrap();
         assert_eq!(p.vertex_count, 8);
         assert_eq!(p.face_count, 6);
-        assert_eq!(p.m_density, 0);
-        assert_eq!(p.n_density, 0);
-        assert_eq!(p.first_vertex_handle.code, 3);
-        assert_eq!(p.first_vertex_handle.value, 0x100);
-        assert_eq!(p.last_vertex_handle.value, 0x110);
-    }
-
-    #[test]
-    fn roundtrip_nonzero_flags_and_densities() {
-        let mut w = BitWriter::new();
-        // flags bit 0x40 is the POLYFACE-MESH indicator in related
-        // POLYLINE flags; any nonzero mask round-trips here.
-        write_pface(
-            &mut w,
-            &PfaceFields {
-                flags: 0x0040,
-                vc: 24,
-                fc: 32,
-                md: 4,
-                nd: 6,
-                first: (3, 0xAB),
-                last: (3, 0xCD),
-            },
-        );
-        let bytes = w.into_bytes();
-        let mut c = BitCursor::new(&bytes);
-        let p = decode(&mut c).unwrap();
-        assert_eq!(p.flags, 0x0040);
-        assert_eq!(p.vertex_count, 24);
-        assert_eq!(p.face_count, 32);
-        assert_eq!(p.m_density, 4);
-        assert_eq!(p.n_density, 6);
-        assert_eq!(p.first_vertex_handle.value, 0xAB);
-        assert_eq!(p.last_vertex_handle.value, 0xCD);
-    }
-
-    #[test]
-    fn roundtrip_zero_handles() {
-        // A handle with value 0 encodes with counter = 0 (no payload
-        // bytes). Important edge case — round-tripping zero-valued
-        // handles is how empty meshes are expressed.
-        let mut w = BitWriter::new();
-        write_pface(
-            &mut w,
-            &PfaceFields {
-                flags: 0,
-                vc: 0,
-                fc: 0,
-                md: 0,
-                nd: 0,
-                first: (5, 0),
-                last: (5, 0),
-            },
-        );
-        let bytes = w.into_bytes();
-        let mut c = BitCursor::new(&bytes);
-        let p = decode(&mut c).unwrap();
-        assert_eq!(p.first_vertex_handle.counter, 0);
-        assert_eq!(p.first_vertex_handle.value, 0);
-        assert_eq!(p.last_vertex_handle.counter, 0);
-        assert_eq!(p.last_vertex_handle.value, 0);
+        assert_eq!(p.num_owned_objects, None);
+        assert_eq!(c.position_bits(), 20);
     }
 }

--- a/src/entities/polygon_mesh.rs
+++ b/src/entities/polygon_mesh.rs
@@ -2,9 +2,9 @@
 //!
 //! A POLYGON_MESH header stores the (M, N) dimensions of an indexed
 //! surface patch plus closed-direction flags. The vertex grid itself
-//! lives in a handle chain of `VERTEX_MESH` sub-entities referenced by
-//! `first_vertex_handle` .. `last_vertex_handle`; the
-//! traversal is a downstream concern, not handled here.
+//! lives in a chain of `VERTEX_MESH` sub-entities the record owns
+//! through its handle stream; the traversal is a downstream concern,
+//! not handled here.
 //!
 //! POLYGON_MESH and [`super::polyface_mesh::PolyfaceMesh`] are sibling
 //! legacy 3D representations — polygon-mesh is indexed (parametric M×N
@@ -24,11 +24,28 @@
 //! BS   n_density
 //! BS   m_vert_count   -- grid dimension M
 //! BS   n_vert_count   -- grid dimension N
-//! H    first_vertex_handle
-//! H    last_vertex_handle
 //! ```
+//!
+//! # Not verified against real bytes
+//!
+//! No file in the corpus carries a POLYGON_MESH record, so unlike its
+//! sibling [`super::polyface_mesh`] — whose list is pinned to the one
+//! record of `sample_AC1032.dwg` — this field list has never been
+//! landed on a data-stream boundary. It is wired through the same
+//! exact-boundary check as every other entity (#63), so the first real
+//! record to reach it will either confirm the list or report a delta;
+//! it will not silently return plausible-looking numbers.
+//!
+//! Two `H` reads were removed from the list in #63. An object
+//! reference never occupies data-stream bits from R2000 onward — the
+//! handle stream begins exactly where the boundary this decoder is
+//! checked against ends — so reading the vertex-chain endpoints inline
+//! was wrong on every release the crate walks. That was measurable on
+//! POLYLINE_PFACE, whose identical mistake overran its boundary by 52
+//! bits; it is corrected here by the same rule rather than by a
+//! measurement of this type.
 
-use crate::bitcursor::{BitCursor, Handle};
+use crate::bitcursor::BitCursor;
 use crate::error::Result;
 
 /// Flag bits (§19.4.30). Named constants for the documented bits; any
@@ -52,8 +69,6 @@ pub struct PolygonMesh {
     pub m_vert_count: u16,
     /// Grid dimension along the N axis.
     pub n_vert_count: u16,
-    pub first_vertex_handle: Handle,
-    pub last_vertex_handle: Handle,
 }
 
 impl PolygonMesh {
@@ -69,24 +84,21 @@ impl PolygonMesh {
 
 /// Decode a POLYGON_MESH header.
 ///
-/// Only the header is parsed here — the VERTEX_MESH grid referenced by
-/// the handle chain is walked at the object-stream layer.
+/// Only the header is parsed here — the VERTEX_MESH grid the record
+/// owns is reached through its handle stream, which begins where this
+/// decoder's data fields must end.
 pub fn decode(c: &mut BitCursor<'_>) -> Result<PolygonMesh> {
     let flags = c.read_bs_u()?;
     let m_density = c.read_bs_u()?;
     let n_density = c.read_bs_u()?;
     let m_vert_count = c.read_bs_u()?;
     let n_vert_count = c.read_bs_u()?;
-    let first_vertex_handle = c.read_handle()?;
-    let last_vertex_handle = c.read_handle()?;
     Ok(PolygonMesh {
         flags,
         m_density,
         n_density,
         m_vert_count,
         n_vert_count,
-        first_vertex_handle,
-        last_vertex_handle,
     })
 }
 
@@ -101,8 +113,6 @@ mod tests {
         nd: u16,
         m: u16,
         n: u16,
-        first: (u8, u64),
-        last: (u8, u64),
     }
 
     fn write_pmesh(w: &mut BitWriter, f: &PmeshFields) {
@@ -111,8 +121,6 @@ mod tests {
         w.write_bs_u(f.nd);
         w.write_bs_u(f.m);
         w.write_bs_u(f.n);
-        w.write_handle(f.first.0, f.first.1);
-        w.write_handle(f.last.0, f.last.1);
     }
 
     #[test]
@@ -126,10 +134,9 @@ mod tests {
                 nd: 6,
                 m: 5,
                 n: 4,
-                first: (3, 0x200),
-                last: (3, 0x214),
             },
         );
+        let end = w.position_bits();
         let bytes = w.into_bytes();
         let mut c = BitCursor::new(&bytes);
         let m = decode(&mut c).unwrap();
@@ -140,8 +147,9 @@ mod tests {
         assert_eq!(m.n_density, 6);
         assert_eq!(m.m_vert_count, 5);
         assert_eq!(m.n_vert_count, 4);
-        assert_eq!(m.first_vertex_handle.value, 0x200);
-        assert_eq!(m.last_vertex_handle.value, 0x214);
+        // The five counts are the whole data-stream field list — the
+        // vertex-chain handles are not in it.
+        assert_eq!(c.position_bits(), end);
     }
 
     #[test]
@@ -155,8 +163,6 @@ mod tests {
                 nd: 4,
                 m: 16,
                 n: 8,
-                first: (3, 0x300),
-                last: (3, 0x310),
             },
         );
         let bytes = w.into_bytes();
@@ -179,8 +185,6 @@ mod tests {
                 nd: 8,
                 m: 24,
                 n: 12,
-                first: (3, 0x400),
-                last: (3, 0x41C),
             },
         );
         let bytes = w.into_bytes();
@@ -189,8 +193,8 @@ mod tests {
         assert!(m.is_closed_m());
         assert!(m.is_closed_n());
         assert_eq!(m.flags & 0x3, 0x3);
-        assert_eq!(m.first_vertex_handle.value, 0x400);
-        assert_eq!(m.last_vertex_handle.value, 0x41C);
+        assert_eq!(m.m_vert_count, 24);
+        assert_eq!(m.n_vert_count, 12);
     }
 
     #[test]
@@ -207,8 +211,6 @@ mod tests {
                 nd: 3,
                 m: 7,
                 n: 5,
-                first: (3, 1),
-                last: (3, 2),
             },
         );
         let bytes = w.into_bytes();

--- a/src/entities/polyline.rs
+++ b/src/entities/polyline.rs
@@ -26,6 +26,55 @@
 use crate::bitcursor::BitCursor;
 use crate::entities::{Vec3D, read_be, read_bt};
 use crate::error::Result;
+use crate::version::Version;
+
+/// POLYLINE_3D (§19.4.46) — the 3D polyline header.
+///
+/// Unlike [`Polyline`] (the 2D form) it carries no widths, thickness,
+/// elevation or extrusion; the geometry lives entirely in the
+/// `VERTEX_3D` sub-entities the record owns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Polyline3d {
+    /// The two flag bytes, kept verbatim so a writer can re-emit them.
+    pub flags: [u8; 2],
+    /// R2004+ owned-object count — the `VERTEX_3D` sub-entities
+    /// reachable through this record's handle stream. `None` before
+    /// R2004, where the field is absent.
+    pub num_owned_objects: Option<u32>,
+}
+
+/// Decode a POLYLINE_3D header from a cursor parked past the common
+/// entity preamble.
+///
+/// # Stream shape — measured
+///
+/// ```text
+/// RC   flags_1
+/// RC   flags_2
+/// BL   num_owned_objects   -- R2004+ only
+/// ```
+///
+/// The one POLYLINE_3D record of `sample_AC1032.dwg` (handle `0x42B`)
+/// has a 26-bit data-field budget, and this list lands on it exactly
+/// (`delta 0`, `examples/probe_entity_field_list.rs`). Its owned-object
+/// count decodes to **5**, and the five records that immediately follow
+/// it in the object stream — handles `0x42C`..`0x430` — are exactly
+/// five `VERTEX_3D` sub-entities, closed by a SEQEND at `0x431`. The
+/// `BL` is the same R2004+ owned-object count
+/// [`crate::tables::block_record`] reads; `BS` cannot be separated from
+/// `BL` at a value of 5, so only the width and the value are claimed.
+pub fn decode_3d(c: &mut BitCursor<'_>, version: Version) -> Result<Polyline3d> {
+    let flags = [c.read_rc()?, c.read_rc()?];
+    let num_owned_objects = if version.is_r2004_plus() {
+        Some(c.read_bl()? as u32)
+    } else {
+        None
+    };
+    Ok(Polyline3d {
+        flags,
+        num_owned_objects,
+    })
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Polyline {
@@ -94,6 +143,37 @@ mod tests {
         assert!(p.is_closed());
         assert!(!p.is_3d());
         assert_eq!(p.thickness, 0.0);
+    }
+
+    /// The measured POLYLINE_3D shape: two zero flag bytes and an
+    /// owned-object count of 5, in exactly 26 bits.
+    #[test]
+    fn roundtrip_measured_polyline_3d() {
+        let mut w = BitWriter::new();
+        w.write_rc(0);
+        w.write_rc(0);
+        w.write_bl(5);
+        assert_eq!(w.position_bits(), 26);
+        let bytes = w.into_bytes();
+        let mut c = BitCursor::new(&bytes);
+        let p = decode_3d(&mut c, Version::R2018).unwrap();
+        assert_eq!(p.flags, [0, 0]);
+        assert_eq!(p.num_owned_objects, Some(5));
+        assert_eq!(c.position_bits(), 26);
+    }
+
+    /// Before R2004 the owned-object count is absent.
+    #[test]
+    fn polyline_3d_has_no_owned_count_before_r2004() {
+        let mut w = BitWriter::new();
+        w.write_rc(0x08);
+        w.write_rc(0x00);
+        let bytes = w.into_bytes();
+        let mut c = BitCursor::new(&bytes);
+        let p = decode_3d(&mut c, Version::R2000).unwrap();
+        assert_eq!(p.flags, [0x08, 0x00]);
+        assert_eq!(p.num_owned_objects, None);
+        assert_eq!(c.position_bits(), 16);
     }
 
     #[test]

--- a/src/entities/seqend.rs
+++ b/src/entities/seqend.rs
@@ -1,0 +1,44 @@
+//! SEQEND entity (§19.4.6) — closes the sub-entity list an INSERT or a
+//! POLYLINE opens, exactly as [`super::endblk::EndBlk`] closes a
+//! BLOCK's.
+//!
+//! # Stream shape — measured
+//!
+//! The record has no type-specific field list at all. All four SEQEND
+//! records of `sample_AC1032.dwg` (handles `0x42A`, `0x431`, `0x706`,
+//! `0x79E`) have a data-field budget of **zero** bits between the end
+//! of the common entity preamble and the record's data-stream boundary
+//! — `examples/probe_entity_budgets.rs` prints `budget=0` for every one
+//! of them. Two of the four sit immediately after a vertex run
+//! (`0x42A` closes the POLYLINE_PFACE at `0x422`, `0x431` closes the
+//! POLYLINE_3D at `0x42B`), which is where the spec puts a SEQEND.
+//!
+//! Before this module the type came back `Unhandled`; it is decoded
+//! now because the boundary check can prove the empty field list right
+//! rather than merely assume it.
+
+use crate::bitcursor::BitCursor;
+use crate::error::Result;
+
+/// SEQEND carries no fields of its own — its owner and its place in the
+/// sub-entity chain are handle-stream data, not data-stream data.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SeqEnd;
+
+/// Decodes a `SeqEnd`; the entity has no payload past the common header.
+pub fn decode(_c: &mut BitCursor<'_>) -> Result<SeqEnd> {
+    Ok(SeqEnd)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seqend_consumes_nothing() {
+        let buf = [0xFFu8; 4];
+        let mut c = BitCursor::new(&buf);
+        let _ = decode(&mut c).unwrap();
+        assert_eq!(c.position_bits(), 0);
+    }
+}

--- a/src/entities/vertex.rs
+++ b/src/entities/vertex.rs
@@ -70,10 +70,120 @@ pub fn decode(c: &mut BitCursor<'_>, version: Version) -> Result<Vertex> {
     })
 }
 
+/// VERTEX_3D (0x0B), VERTEX_MESH (0x0C) and VERTEX_PFACE (0x0D) — the
+/// three variants whose whole field list is a flag byte and a point.
+///
+/// The 2D variant ([`Vertex`]) adds the width / bulge / tangent fields;
+/// these three do not carry them, and none of them carries the R2010+
+/// `BL vertex_id` either.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct VertexPoint {
+    /// Flag byte, same bit meanings as [`Vertex::flag`].
+    pub flag: u8,
+    /// Vertex location in the owning polyline's coordinate system.
+    pub location: Point3D,
+}
+
+/// Decode a VERTEX_3D / VERTEX_MESH / VERTEX_PFACE record.
+///
+/// # Stream shape — measured
+///
+/// ```text
+/// RC   flag
+/// 3BD  location
+/// ```
+///
+/// Every one of the ten records in `sample_AC1032.dwg` closes on its
+/// data-stream boundary with this list and no other: the five
+/// VERTEX_3D (handles `0x42C`..`0x430`) have 142- and 206-bit budgets —
+/// `8 + 3BD` with one and with no defaulted coordinate — and the five
+/// VERTEX_PFACE (`0x423`..`0x427`) have 142 bits each. `delta 0` on all
+/// ten, via `examples/probe_entity_field_list.rs`.
+///
+/// The flag values corroborate the reading rather than merely fitting
+/// it: the VERTEX_3D records read `0x20`, the "3D polyline vertex" bit
+/// of the flag table above, and the VERTEX_PFACE records read `0xC0`,
+/// its "polyface mesh vertex" and "3D polygon mesh vertex" bits
+/// together. A misaligned byte would have no reason to land on either.
+pub fn decode_point(c: &mut BitCursor<'_>) -> Result<VertexPoint> {
+    let flag = c.read_rc()?;
+    let location = read_bd3(c)?;
+    Ok(VertexPoint { flag, location })
+}
+
+/// VERTEX_PFACE_FACE (0x0E) — one face of a POLYLINE_PFACE, given as
+/// four 1-based indices into the mesh's VERTEX_PFACE list.
+///
+/// A negative index marks the edge starting at that vertex as
+/// invisible; a zero index means the face has fewer than four corners.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VertexPfaceFace {
+    /// The four corner indices, in face order.
+    pub vertex_indices: [i16; 4],
+}
+
+/// Decode a VERTEX_PFACE_FACE record.
+///
+/// # Stream shape — measured
+///
+/// ```text
+/// BS   vertex_index_1 .. vertex_index_4
+/// ```
+///
+/// The two records of `sample_AC1032.dwg` close on their boundary with
+/// exactly four `BS` and nothing else — 48 bits for `0x428` and 40 for
+/// `0x429`, `delta 0` on both. Their values are `[1, 2, 3, -4]` and
+/// `[-1, 4, 5, 0]`: every magnitude falls inside the 1..=5 range the
+/// owning POLYLINE_PFACE declares (`vertex_count = 5`), the signs are
+/// the invisible-edge convention, and the trailing `0` is the
+/// three-corner face. A wrong field list has no reason to produce five
+/// in-range indices and one terminator.
+pub fn decode_pface_face(c: &mut BitCursor<'_>) -> Result<VertexPfaceFace> {
+    let mut vertex_indices = [0i16; 4];
+    for index in &mut vertex_indices {
+        *index = c.read_bs()?;
+    }
+    Ok(VertexPfaceFace { vertex_indices })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::bitwriter::BitWriter;
+
+    /// The measured VERTEX_3D shape: flag `0x20` then a point whose z
+    /// defaults, in exactly 142 bits.
+    #[test]
+    fn roundtrip_measured_vertex_3d() {
+        let mut w = BitWriter::new();
+        w.write_rc(0x20);
+        w.write_bd(232.60172074430375);
+        w.write_bd(0.8926935903469939);
+        w.write_bd(0.0);
+        assert_eq!(w.position_bits(), 142);
+        let bytes = w.into_bytes();
+        let mut c = BitCursor::new(&bytes);
+        let v = decode_point(&mut c).unwrap();
+        assert_eq!(v.flag, 0x20);
+        assert_eq!(v.location.z, 0.0);
+        assert_eq!(c.position_bits(), 142);
+    }
+
+    /// The measured VERTEX_PFACE_FACE shape: four `BS`, one negative
+    /// (invisible edge), in exactly 48 bits.
+    #[test]
+    fn roundtrip_measured_pface_face() {
+        let mut w = BitWriter::new();
+        for value in [1i16, 2, 3, -4] {
+            w.write_bs(value);
+        }
+        assert_eq!(w.position_bits(), 48);
+        let bytes = w.into_bytes();
+        let mut c = BitCursor::new(&bytes);
+        let f = decode_pface_face(&mut c).unwrap();
+        assert_eq!(f.vertex_indices, [1, 2, 3, -4]);
+        assert_eq!(c.position_bits(), 48);
+    }
 
     #[test]
     fn roundtrip_simple_vertex_r2000() {

--- a/src/entities/viewport.rs
+++ b/src/entities/viewport.rs
@@ -22,6 +22,23 @@
 //! BD   width
 //! BD   height
 //! ```
+//!
+//! # Measured: this prefix is a quarter of the record
+//!
+//! Since #63 every entity decoder is held to the record's own
+//! data-stream boundary, and VIEWPORT is the type that most visibly
+//! fails it. All six VIEWPORT records of `sample_AC1032.dwg` (handles
+//! `0x240`, `0x245`, `0x252`, `0x256`, `0x267`, `0x26B`) have an
+//! identical 1125-bit data-field budget; the five fields above consume
+//! 266 of them and stop, so each record reports `delta -819`.
+//!
+//! That is deliberate. The alternative — leaving VIEWPORT outside the
+//! check — is what made its zero error count structural rather than
+//! evidential, which is the whole point of #63. Six records that all
+//! spend exactly 1125 bits give the next pass a fixed budget to fill,
+//! but they are six copies of one shape: with no variation between
+//! them there is nothing to separate one candidate token sequence from
+//! another, so no field list is guessed here.
 
 use crate::bitcursor::BitCursor;
 use crate::entities::{Point3D, read_bd3};


### PR DESCRIPTION
## What this does

Until now only the entity types that *had* to know about the R2007+ split streams asserted anything about where their fields end. Everything else decoded with **no boundary check at all** — the POLYLINE family, MESH, IMAGE, WIPEOUT, VIEWPORT, LEADER, MLINE, the swept/lofted/extruded/revolved surfaces, RAY, XLINE, POINT, CIRCLE, ARC, LINE, ELLIPSE, SOLID, TRACE, ENDBLK, BLOCK — and on the R2000/R2004 band, *every* entity type. Their zero error count was a property of `dispatch.rs`, not of the bytes.

Every fixed-code and custom-class entity decoder now runs through `entities::dispatch::checked_inline`, which requires the field list to end **exactly** on the record's own data-stream boundary:

| Band | Boundary | Source |
|---|---|---|
| R2010 / R2013 / R2018 | string-stream start bit, or handle-stream start − 1 when the record carries no strings | `string_stream::data_field_end` |
| R2000 / R2004 | `RL` object-data-size-in-bits from the object prologue | `RawObject::obj_size_bits` |
| R2007 | none — the `RL` spans data **and** strings and this crate cannot locate an AC1021 string stream yet (#110) | — |
| R13 / R14 | none — the prologue has no size field | — |

**On R2010+ the number of entity types that decode unchecked is zero.** Neither unchecked band has a record that reaches a decoder at all.

`checked_inline` also hands the decoder the record's string reader now, which is what let BLOCK stop reading its name inline; the six R2010+-only special cases in `dispatch_split_stream_entity` (INSERT, 3DFACE, LWPOLYLINE, 3DSOLID, REGION, BODY) collapsed into the general path, which is identical.

## Per-type table

Corpus is the local 19-file `samples/` set. "before" is `7b2afe2` (main with #64).

| Type | Corpus records | Checked before | Checked after | Result |
|---|---|---|---|---|
| LINE | 101 (98 R2018 + 3) | no | **yes** | delta 0, 101/101 |
| POINT | 40 | no | **yes** | delta 0, 40/40 |
| BLOCK | 54 (27 R2018, 9 R2010, 9 R2013, 9 R2004) | no | **yes** | 45 R2010+ records were reading the `TV` inline — **fixed**, delta 0 on all 54 |
| ENDBLK | 54 | no | **yes** | delta 0 — budget is 0 bits on every record |
| SOLID | 14 | no | **yes** | delta 0, 14/14 |
| CIRCLE | 16 (13 R2018 + 3) | no | **yes** | delta 0, 16/16 |
| ARC | 6 (3 R2018 + 3) | no | **yes** | delta 0, 6/6 |
| ELLIPSE / RAY / XLINE | 1 each | no | **yes** | delta 0 |
| IMAGE (custom class) | 1 | no | **yes** | delta 0 |
| POLYLINE_PFACE | 1 | no | **yes** | field list was wrong (+52) — **fixed**, delta 0 |
| VIEWPORT | 6 | no | **yes** | **new honest error**, delta −819 ×6 |
| MESH (custom class) | 2 | no | **yes** | **new honest error**, delta −2 ×2 |
| LEADER | 1 | no | **yes** | **new honest error**, delta −12 |
| SEQEND | 4 | not dispatched | **yes** | **new**, delta 0, 4/4 |
| POLYLINE_3D | 1 | not dispatched | **yes** | **new**, delta 0 |
| VERTEX_3D | 5 | not dispatched | **yes** | **new**, delta 0, 5/5 |
| VERTEX_PFACE | 5 | not dispatched | **yes** | **new**, delta 0, 5/5 |
| VERTEX_PFACE_FACE | 2 | not dispatched | **yes** | **new**, delta 0, 2/2 |
| MLINE | 3 | not dispatched | **yes** | **new**, `BS`→`RC` one-token fix, delta 0, 3/3 |
| TEXT / MTEXT / ATTRIB / ATTDEF / TOLERANCE / HATCH / MULTILEADER / DIMENSION ×7 / SPLINE / INSERT / LWPOLYLINE / 3DFACE / 3DSOLID / REGION / UNDERLAY | 174 | yes | yes | unchanged, still delta 0 |
| SHAPE | 1 | n/a | n/a | still `Unhandled` — 160-bit budget, no field list |
| POLYLINE_2D, POLYLINE_MESH, VERTEX_2D, VERTEX_MESH, TRACE, OLE2FRAME, CAMERA, SUN, LIGHT, GEODATA, BODY, WIPEOUT, HELIX, the 4 SURFACE variants | 0 | no | **yes** | check wired, **unexercised** — no corpus record |

**TOLERANCE is confirmed exact** (per #28): all 3 R2018 records go through `tolerance::decode_modern_split_stream`, delta 0. **TEXT's reading is untouched** (#62's `BD`-vs-`RD` caveat): all 29 records close at delta 0 with a 202-bit budget, which means every one of them sets the DataFlags bits that suppress `oblique_angle` / `rotation_angle` / `width_factor` — so no record arbitrates #62 and it stays open.

## New-error census, with evidence

`cargo run --release --example probe_decode_errors -- samples/sample_AC1032.dwg`:

| Type | Handles | Budget | Consumed | Delta | Why it is not fixed here |
|---|---|---|---|---|---|
| VIEWPORT | `0x240`, `0x245`, `0x252`, `0x256`, `0x267`, `0x26B` | 1125 bits (identical on all six) | 266 | −819 | `entities/viewport.rs` is an admitted prefix decoder (`BD3 center, BD width, BD height`). Six records of one identical shape give no variation to separate candidate token sequences with, so no field list is guessed. |
| MESH | `0x343`, `0x380` | 93942 / 92554 | 93940 / 92552 | −2 | The two trailing bits read `10` on both records — the zero/default code of `BS`, `BL` **and** `BD` alike. A zero corroborates nothing, so under the #58 rule this is "documented offsets and stop". The module's older note said "3 bits" — that counted the `strings present` trailer flag, which is not an entity field; corrected. |
| LEADER | `0x512` | 581 | 569 | −12 | Twelve bits that several continuations of §19.4.19's list would fit (any mix of defaulted `BD`s and trailing `B`s summing to 12), on a single record. |

Net effect on the corpus: **9 errored**, up from 0. That is the point of #63 — the same nine records "decoded" before, with nothing checking that they had.

## Fixes made (each `delta 0` + independent value corroboration)

**BLOCK — the `TV` is in the string stream on R2010+.** Budget measured with the new `examples/probe_entity_budgets.rs`: **0 bits** on 27/27 R2018 records and 3/3 on each of `arc_2010.dwg` / `arc_2013.dwg`. Reading the name inline overran on all 33 (deltas +58 … +266). Corroboration: the names now decode as `*Model_Space`, `*Paper_Space0`, `_ArchTick`, `*D3`, `MyBlock` — matching the BLOCK_RECORD entries they pair with, which come from a different stream. The 9 R2004 records spend 114-122 bits there (inline `BS` length + NUL-terminated name) and close on their `RL` with the unchanged inline reading.

**POLYLINE_PFACE — `BS`, `BS`, `BL` in 30 bits, not 5×`BS` + 2 inline `H`.** Handle `0x422`, budget 30 bits, `probe_entity_field_list … BS,BS,BL` → `5`, `2`, `7`, delta 0. Corroboration: the file carries exactly **5** VERTEX_PFACE (`0x423`..`0x427`) and **2** VERTEX_PFACE_FACE (`0x428`, `0x429`) records, summing to the `BL 7` owned-object count. The two inline `H` reads were the bulk of the +52 overrun — an object reference never occupies data-stream bits from R2000 on.

**MLINE — `num_lines` is an `RC`.** With `BS` all three records (`0x38B`, `0x3A5`, `0x3A6`) decode `lines = 521`, `verts = -11716` and die. One token changed; all three land at delta 0 with `num_lines = 2`, `num_verts` 8/2/2, justification Zero/Top/Zero and scale 1.5 / 2.13 / 1.598 — plausible values where the old reading produced a negative count.

## Newly decoded types (previously `Unhandled`)

Handles `0x422`..`0x431` of `sample_AC1032.dwg` are contiguous and read back as one self-consistent chain, which is the corroboration for all five at once:

```
0x422  POLYLINE_PFACE     BS 5, BS 2, BL 7            30 bits,  delta 0
0x423  VERTEX_PFACE       RC 0xC0, 3BD               142 bits   ┐ 5 vertices
 ...                                                             ┘
0x428  VERTEX_PFACE_FACE  BS [ 1, 2, 3, -4]           48 bits   ┐ 2 faces
0x429  VERTEX_PFACE_FACE  BS [-1, 4, 5,  0]           40 bits   ┘
0x42A  SEQEND             (no fields)                  0 bits
0x42B  POLYLINE_3D        RC 0, RC 0, BL 5            26 bits,  delta 0
0x42C  VERTEX_3D          RC 0x20, 3BD          142/206 bits    ┐ 5 vertices
 ...                                                             ┘
0x431  SEQEND             (no fields)                  0 bits
```

Every declared count matches the records that follow it. The face indices are all inside the mesh's declared 1..=5 range, with the negative-index invisible-edge convention and a `0` terminating the three-corner face. The flag bytes name themselves against the flag table already in `entities/vertex.rs`: `0x20` is "3D polyline vertex", `0xC0` is "polyface mesh vertex" + "3D polygon mesh vertex". None of that comes from the bit budget.

`BS` and `BL` are indistinguishable for a value below 256 (both spend `01` plus one byte), so the owned-object counts are read as the `BL` `tables::block_record` already uses for the same purpose; only the width and the value are claimed.

## The three deliberately-undetermined readings (recorded, unchanged)

Gathered into one table in ARCHITECTURE §7i, plus MESH's new one:

| Reading | Undetermined | What would settle it |
|---|---|---|
| MULTILEADER's 17 bits | `MC` + `B` vs `B` + `RS` vs `B` + two `RC`s; the `MC` holds only `274`/`530`/`786` across 15 records and the `B` is `true` on all | a record whose value exceeds `RS` range, or whose `B` is false |
| UNDERLAY clip-vertex encoding | `2BD` vs `2RD` — the one corpus record has a zero clip-vertex count so no vertex is ever read | any UNDERLAY with a clip boundary |
| LWPOLYLINE `0x200` | not one of §20.4.85's presence bits; every record carrying it also carries no optional field, so it survives either reading | a record with `0x200` set *and* an optional field present |
| MESH's trailing `10` (new) | `BS` 0, `BL` 0, `BD` 0.0 and "two spare bits" encode identically | a MESH whose trailing value is non-zero |

## Also in this change

- `POLYGON_MESH` stops reading two `H` handles from the data stream. No corpus record exercises this type, so its list stays otherwise unverified and the module now says so; the removal is justified by the crate-wide invariant, not by a measurement of this type.
- `examples/probe_entity_budgets.rs` (new) — prints, for every entity record, the bit budget its field list has to fill. This is the tool the whole PR was derived from; `probe_decode_errors.rs` only shows records that already error, which is no help for a type with no decoder at all.
- `examples/dump_decoded_entities.rs` prints the six new variants.

## Measured coverage

| Version | Files | Decoded | Skipped | Errored | Ratio |
|---|---|---|---|---|---|
| R2004 (AC1018) | 3 | 582 → 582 | 15 → 15 | 0 → 0 | 97.5 % → **97.5 %** |
| R2010 (AC1024) | 3 | 531 → 531 | 12 → 12 | 0 → 0 | 97.8 % → **97.8 %** |
| R2013 (AC1027) | 3 | 384 → 384 | 12 → 12 | 0 → 0 | 97.0 % → **97.0 %** |
| R2018 (AC1032) | 1 | 765 → 776 | 77 → 57 | 0 → 9 | 90.9 % → **92.2 %** |
| **Aggregate** | **19** | **2262 → 2273** | **116 → 96** | **0 → 9** | 95.1 % → **95.6 %** |

The three unchanged slices are the interesting ones: their counts did not move, but every entity record in them is now checked where none was before, and every one passes. The CI `coverage-smoke` corpus (`tests/fixtures/canonical`) stays at 20/0/0/100 %.

## Gate

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --release` (751 lib + all integration suites green — the canonical-corpus pins are unchanged, the synthetic fixtures already satisfied the new boundary check), `cargo +1.85.0 test --no-run`, `cargo deny check all`, `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --all-features` — all pass.

## Follow-ups

- **VIEWPORT's §20.4.35 field list** — 1125 bits per record, six identical records. Needs a second file with viewports of differing shape.
- **LEADER's last 12 bits** and **MESH's last 2** — both need one more sample.
- `BLOCK_RECORD` decodes `*D` / `*T` / `*Paper_Space` where the BLOCK beside it decodes `*D3` / `*T9` / `*Paper_Space0`. Both come from string streams; one of the two is reading a different slot. Noticed while corroborating the BLOCK fix, not investigated here.
- #62 (TEXT `BD` vs `RD`) remains unarbitrated: every corpus TEXT record suppresses the three fields.
- If you would rather VIEWPORT sat in the *skipped* column than the *errored* one — the precedent being MATERIAL / PROPERTYSET_DATA, which are `Unhandled` because they decode "only a documented prefix" — that is a one-line change to `fixed_entity_label`. I left it as an error because #63 asks for the honest error, and because MESH and LEADER (delta −2, −12) are genuinely near-complete lists rather than prefixes.

---

**Clean-room declaration.** I certify that:

1. All code and tests in this PR were written from scratch by me.
2. I consulted only sources listed as allowed in `CLEANROOM.md`. In particular, I did not consult Autodesk SDK source, ODA SDK (Drawings SDK / Teigha) source, LibreDWG source, decompilations of Autodesk or ODA binaries, or any copyleft-licensed DWG implementation code. Every field list added or corrected here was derived from the corpus bytes: the record's own data-stream boundary, the values that land on it, and the object stream's own counts. No outside vocabulary was needed — `flags`, `vertex_count`, `face_count`, `num_owned_objects`, `location` and `vertex_indices` are the names already used by the sibling modules in this crate.
3. Where this PR cites a reference (ODA spec section, measured offsets), the citation is in the diff as a doc comment.
4. I have never had access to any of the forbidden sources.

Closes #63

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change refactors the central entity dispatch path for every type and alters reported decode success (nine new errors), so regressions in geometry or coverage are possible despite added tests.
> 
> **Overview**
> This PR routes **all** fixed-code and custom-class entity decoders through `entities::dispatch::checked_inline`, so field lists must end exactly on each record’s data-stream boundary (R2010+ string-stream start or handle trailer; R2000/R2004 `RL` object-data-size). R2010+ no longer has any entity type that decodes without that check.
> 
> **Fixes with `delta 0`:** BLOCK reads its name from the string stream on R2010+ (was inline `TV`); POLYLINE_PFACE is `BS`/`BS`/`BL` counts without inline handles; MLINE uses `RC` for `num_lines` instead of `BS`. **New decoders:** SEQEND, POLYLINE_3D, VERTEX_3D/MESH/PFACE, VERTEX_PFACE_FACE. **POLYGON_MESH** drops two inline `H` reads from the data stream (same rule as polyface).
> 
> **Intentional errors (9 records):** VIEWPORT (−819 bits, prefix decoder), MESH (−2 trailing bits), LEADER (−12 bits)—documented, not guessed. Corpus coverage moves from **2262 / 116 / 0** to **2273 / 96 / 9** (95.1% → 95.6%); R2004–R2013 counts unchanged but every entity there is now boundary-checked.
> 
> Adds `examples/probe_entity_budgets.rs` and extends `dump_decoded_entities` for the new variants; docs (ARCHITECTURE §7i, README, STATUS, CHANGELOG) reflect the new honesty model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 376905d631f06031c162fad0f26ba6cd5006481a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->